### PR TITLE
Remove package WARNING

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ if not os.path.exists("target"):
             copy(fromfile, tofile)
 
 
-packages = find_packages(where="target")+[""]
+packageless = glob.glob("target/*.py")
+packageless = [x[7:-3] for x in packageless]
+packages = find_packages(where="target")
+
 url = 'https://docs.openmicroscopy.org/latest/omero/developers'
 
 sys.path.append("target")
@@ -81,6 +84,7 @@ setup(
     package_data={
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
+    py_modules=packageless,
     scripts=glob.glob(os.path.sep.join(["bin", "*"])),
     install_requires=[
         'zeroc-ice>=3.6.4,<3.7',


### PR DESCRIPTION
```
WARNING: '' not a valid package name
```

was printed on every call to `setup.py` meaning that
`python setup.py --version` could not be used for
build-infra integration.