### PR TITLE
blitz gateway unit tests

### DIFF
--- a/src/omero/scripts.py
+++ b/src/omero/scripts.py
@@ -31,6 +31,8 @@ from omero.rtypes import rint, rfloat, rstring, rinternal, rbool, rmap
 from omero.rtypes import robject, rlist, rset, rtype, rlong, rdouble
 from omero.rtypes import wrap, unwrap
 
+from collections import defaultdict
+
 
 TYPE_LOG = logging.getLogger("omero.scripts.Type")
 PROC_LOG = logging.getLogger("omero.scripts.ProcessCallback")
@@ -550,7 +552,7 @@ def group_params(params):
 
     this function returns:
 
-        {"A" {"": "1" : "B" : "2", "C" : "3"} }
+        {"A" : {"": "1", "B" : "2", "C" : "3"} }
 
     while:
 
@@ -561,40 +563,40 @@ def group_params(params):
         {"A" : "1"}
 
     """
-    groupings = dict()
-    for k, v in params.inputs.items():
+    nested_dict = lambda: defaultdict(nested_dict)
+    groupings = nested_dict()
+    ordered_params = sorted(list(params.inputs.items()))
+    for param_name, v in ordered_params:
 
         val = v.grouping
-        if not val.endswith("."):
-            val = val + "."
+        if val.endswith("."):
+            val = val[:-1]
 
         parts = val.split(".")
 
-        g = groupings
-        while parts:
-            p = parts.pop(0)
-            try:
-                g = g[p]
-            except KeyError:
-                if parts:
-                    g[p] = dict()
-                    g = g[p]
-                else:
-                    g[p] = k
-
-        # Now find all subtrees of the form {"": "key"} and
-        # replace them by themselves
-        tuples = [(groupings, k, v) for k, v in groupings.items()]
-        while tuples:
-            new_tuples = []
-            for g, k, v in tuples:
-                if isinstance(v, dict):
-                    if len(v) == 1 and "" in v:
-                        g[k] = v[""]
+        previous = None
+        current = groupings
+        for idx, key in enumerate(parts):
+            if (idx+1) < len(parts):
+                # We need to descend further
+                previous = current
+                current = current[key]
+            else:
+                # No further keys remaining, assign
+                if isinstance(current, dict):
+                    if key in current:
+                        current[key][""] = param_name
                     else:
-                        new_tuples.extend([(v, k2, v2)
-                                           for k2, v2 in v.items()])
-            tuples = new_tuples
+                        current[key] = param_name
+                elif isinstance(current, str):
+                    # Here we assume the value is a node key
+                    replacement = dict()
+                    replacement[""] = current
+                    replacement[key] = param_name
+                    assert previous[parts[idx-1]] == current
+                    previous[parts[idx-1]] = replacement
+                else:
+                    raise Exception(current, type(current))
 
     return groupings
 

--- a/test/unit/scriptstest/test_parse.py
+++ b/test/unit/scriptstest/test_parse.py
@@ -162,8 +162,9 @@ if True:
             assert "these" == groupings["A"]["1"], str(groupings)
             assert "belong" == groupings["A"]["2"], str(groupings)
             assert "together" == groupings["A"]["3"], str(groupings)
-        except KeyError:
-            assert False, str(groupings)
+        except:
+            print("INVALID: %s" % groupings)
+            raise
 
     def testGroupingWithMainExtraDot(self):
         SCRIPT = """if True:
@@ -176,10 +177,14 @@ if True:
         params = parse_text(SCRIPT)
 
         groupings = group_params(params)
-        assert "checkbox" == groupings["A"][""], str(groupings)
-        assert "these" == groupings["A"]["1"], str(groupings)
-        assert "belong" == groupings["A"]["2"], str(groupings)
-        assert "together" == groupings["A"]["3"], str(groupings)
+        try:
+            assert "checkbox" == groupings["A"][""], str(groupings)
+            assert "these" == groupings["A"]["1"], str(groupings)
+            assert "belong" == groupings["A"]["2"], str(groupings)
+            assert "together" == groupings["A"]["3"], str(groupings)
+        except:
+            print("INVALID: %s" % groupings)
+            raise
 
     def testValidateRoiMovieCall(self):
         SCRIPT = """if True:

--- a/test/unit/test_gateway.py
+++ b/test/unit/test_gateway.py
@@ -27,8 +27,12 @@ Test of various things under omero.gateway
 import Ice
 import pytest
 
-from omero.gateway import BlitzGateway, ImageWrapper
-from omero.model import ImageI, PixelsI, ExperimenterI, EventI
+from omero.gateway import BlitzGateway, ImageWrapper, \
+    ExperimenterWrapper, ProjectWrapper, AnnotationWrapper, \
+    PlateWrapper, WellWrapper
+from omero.model import ImageI, PixelsI, ExperimenterI, EventI, \
+    ProjectI, TagAnnotationI, FileAnnotationI, OriginalFileI, \
+    MapAnnotationI, NamedValue, PlateI, WellI
 from omero.rtypes import rstring, rtime, rlong, rint
 
 
@@ -64,6 +68,99 @@ def wrapped_image():
     creation_event.time = rtime(2000)  # In milliseconds
     image.details.creationEvent = creation_event
     return ImageWrapper(conn=MockConnection(), obj=image)
+
+
+class TestObjectsUnicode(object):
+    """
+    Tests that ExperimenterWrapper methods return correct unicode
+    """
+
+    def test_experimenter(self):
+        """
+        Tests methods handled by BlitzObjectWrapper.__getattr__
+
+        These will return unicode strings
+        """
+        first_name = u'fîrst_nąmę'
+        last_name = u'làst_NÅMÉ'
+        experimenter = ExperimenterI()
+        experimenter.firstName = rstring(first_name)
+        experimenter.lastName = rstring(last_name)
+
+        exp = ExperimenterWrapper(None, experimenter)
+        assert exp.getFirstName() == first_name
+        assert exp.getLastName() == last_name
+        assert exp.getFullName() == "%s %s" % (first_name, last_name)
+
+    def test_project(self):
+        """Tests BlitzObjectWrapper.getName() returns string"""
+        name = u'Pròjëct ©ψ'
+        desc = u"Desc Φωλ"
+        project = ProjectI()
+        project.name = rstring(name)
+        project.description = rstring(desc)
+
+        proj = ProjectWrapper(None, project)
+        assert proj.getName() == name.encode('utf8')
+        assert proj.getDescription() == desc.encode('utf8')
+
+    def test_tag_annotation(self):
+        """Tests AnnotationWrapper methods return strings"""
+        ns = u'πλζ.test.ζ'
+        text_value = u'Tαg - ℗'
+        obj = TagAnnotationI()
+        obj.textValue = rstring(text_value)
+        obj.ns = rstring(ns)
+
+        tag = AnnotationWrapper._wrap(None, obj)
+        assert tag.getValue() == text_value.encode('utf8')
+        assert tag.getNs() == ns.encode('utf8')
+
+    def test_file_annotation(self):
+        """Tests AnnotationWrapper methods return strings"""
+        file_name = u'₩€_file_$$'
+        f = OriginalFileI()
+        f.name = rstring(file_name)
+        obj = FileAnnotationI()
+        obj.file = f
+
+        file_ann = AnnotationWrapper._wrap(None, obj)
+        assert file_ann.getFileName() == file_name.encode('utf8')
+
+    def test_map_annotation(self):
+        """Tests MapAnnotationWrapper.getValue() returns unicode"""
+        values = [(u'one', u'₹₹'), (u'two', u'¥¥')]
+        obj = MapAnnotationI()
+        data = [NamedValue(d[0], d[1]) for d in values]
+        obj.setMapValue(data)
+
+        map_ann = AnnotationWrapper._wrap(None, obj)
+        assert map_ann.getValue() == values
+
+    def test_plate(self):
+        """Tests label methods for Plate and Well."""
+        name = u'plate_∞'
+        cols = 4
+        rows = 3
+        obj = PlateI()
+        obj.name = rstring(name)
+
+        plate = PlateWrapper(None, obj)
+        assert plate.getName() == name.encode('utf8')
+        plate._gridSize = {'rows': rows, 'columns': cols}
+        assert plate.getColumnLabels() == [c for c in range(1, cols + 1)]
+        assert plate.getRowLabels() == ['A', 'B', 'C']
+
+        well_obj = WellI()
+        well_obj.column = rint(1)
+        well_obj.row = rint(2)
+
+        class MockWell(WellWrapper):
+            def getParent(self):
+                return plate
+
+        well = MockWell(None, well_obj)
+        assert well.getWellPos() == "C2"
 
 
 class TestBlitzGatewayUnicode(object):


### PR DESCRIPTION
Tests that some BlitzGateway Object methods return unicode and some return string. 
See https://docs.openmicroscopy.org/omero/5.5.1/developers/PythonBlitzGateway.html#unicode

For a deeper discussion of Unicode handling in BlitzGateway, see https://github.com/ome/openmicroscopy/pull/5400

Tests ```BlitzObjectWrapper.__getattr__``` returning unicode strings, enums, values/units and wrapper objects.
NB: Tests pass with the current behaviour of the BlitzGateway, with some methods returning strings and some returning unicode. With Python3, that should all go away ;).