### PR TITLE
Allow OMERO.py to connect to OMERO websockets with chained SSL certs

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -223,7 +223,7 @@ class BaseClient(object):
             # OPENSSL_VERSION_INFO not available for 2.6, fall back to default
             self._optSetProp(id, prop, "HIGH:ADH")
 
-        self._optSetProp(id, "IceSSL.VerifyDepthMax", "0")
+        self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 

--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -223,6 +223,7 @@ class BaseClient(object):
             # OPENSSL_VERSION_INFO not available for 2.6, fall back to default
             self._optSetProp(id, prop, "HIGH:ADH")
 
+        self._optSetProp(id, "IceSSL.VerifyDepthMax", "0")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 


### PR DESCRIPTION
`curl -sSL https://github.com/ome/openmicroscopy/pull/6098.patch | sed 's%/components/tools/OmeroPy/%/%g' | git am`

Ported from https://github.com/openmicroscopy/openmicroscopy/pull/6098