### PR TITLE
Use version.properties for choosing omero-blitz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_install:
   - sudo apt-get install -y openssl
-  - pip install "zeroc-ice>3.6.4,<3.7"
+  - pip install "zeroc-ice>3.6.4,<3.7" future
   - python -c "import Ice; print Ice.stringVersion()"
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y python-setuptools python-virtualenv git python-yaml
 RUN virtualenv /v && /v/bin/pip install twine tox pytest pytest-xdist restructuredtext-lint
-RUN /v/bin/pip install --upgrade pip setuptools
+RUN /v/bin/pip install --upgrade pip setuptools future
 RUN /v/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
 
 # Optimize for fixing tests

--- a/setup.py
+++ b/setup.py
@@ -8,22 +8,24 @@
 """
 
 
+from future import standard_library
+standard_library.install_aliases()
 import glob
 import sys
 import os
 
 from setuptools import setup, find_packages
 
-from StringIO import StringIO
+from io import StringIO
 from shutil import copy
-from urllib import urlopen
+from urllib.request import urlopen
 from zipfile import ZipFile
 
-import ConfigParser
+import configparser
 
 
 def get_blitz_location():
-    defaultsect = ConfigParser.DEFAULTSECT
+    defaultsect = configparser.DEFAULTSECT
     version_key = "versions.omero-blitz"
     url_key = "versions.omero-blitz-url"
 
@@ -33,7 +35,7 @@ def get_blitz_location():
     config_blitz_version = "5.5.3"
     config_path = os.environ.get("VERSION_PROPERTIES", "version.properties")
     if os.path.exists(config_path):
-        config_obj = ConfigParser.RawConfigParser({
+        config_obj = configparser.RawConfigParser({
             url_key: config_blitz_url,
             version_key: config_blitz_version,
         })

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@
    Use is subject to license terms supplied in LICENSE.txt
 """
 
+
 import glob
 import sys
 import os
@@ -14,19 +15,39 @@ import os
 from setuptools import setup, find_packages
 
 from StringIO import StringIO
-from hashlib import md5
 from shutil import copy
 from urllib import urlopen
 from zipfile import ZipFile
 
-blitz_zip = "https://artifacts.openmicroscopy.org/artifactory/ome.releases/org/openmicroscopy/omero-blitz/5.5.3/omero-blitz-5.5.3-python.zip"  # noqa
-blitz_md5 = "cf9c0cd4b2e499fc3b4b8be8c58ab6cb"
+import ConfigParser
+
+
+def get_blitz_location():
+    defaultsect = ConfigParser.DEFAULTSECT
+    version_key = "versions.omero-blitz"
+    url_key = "versions.omero-blitz-url"
+
+    config_blitz_url = ("https://artifacts.openmicroscopy.org/artifactory/"
+                        "ome.releases/org/openmicroscopy/omero-blitz/VERSION/"
+                        "omero-blitz-VERSION-python.zip")
+    config_blitz_version = "5.5.3"
+    config_path = os.environ.get("VERSION_PROPERTIES", "version.properties")
+    if os.path.exists(config_path):
+        config_obj = ConfigParser.RawConfigParser({
+            url_key: config_blitz_url,
+            version_key: config_blitz_version,
+        })
+        with open(config_path) as f:
+            config_str = StringIO('[%s]\n%s' % (defaultsect, f.read()))
+        config_obj.readfp(config_str)
+        config_blitz_url = config_obj.get(defaultsect, url_key)
+        config_blitz_version = config_obj.get(defaultsect, version_key)
+    config_blitz_url = config_blitz_url.replace("VERSION", config_blitz_version)
+    return config_blitz_url
 
 if not os.path.exists("target"):
-    resp = urlopen(blitz_zip)
+    resp = urlopen(get_blitz_location())
     content = resp.read()
-    md5 = md5(content).hexdigest()
-    assert md5 == blitz_md5
     zipfile = ZipFile(StringIO(content))
     zipfile.extractall("target")
 


### PR DESCRIPTION
version.properties is generated by upstream builds already.
By using it as (an approximation of) an ini file, setup.py
can load the version and optionally a URL to pick a different
omero-blitz download.