### PR TITLE
ServiceOpts setitem() ensures value is a string

### DIFF
--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -25,6 +25,7 @@
 
 import logging
 import json
+from future.utils import native_str
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class ServiceOptsDict(dict):
     def __setitem__(self, key, item):
         """Set key to value as string."""
         if self._testItem(item):
-            super(ServiceOptsDict, self).__setitem__(key, str(item))
+            super(ServiceOptsDict, self).__setitem__(key, native_str(item))
             logger.debug("Setting %r to %r" % (key, item))
         else:
             raise AttributeError(


### PR DESCRIPTION
This fixes
```File "/Users/willadmin/Desktop/py2/omeroweb/lib/python2.7/site-packages/omero_api_IQuery_ice.py", line 651, in findByQuery
    return _M_omero.api.IQuery._op_findByQuery.invoke(self, ((query, params), _ctx))
ValueError: context value must be a string``` in the current merge build with python 2, where we have ```from builtins import str```.

NB: this will likely conflict with the branch that adds that.