### PR TITLE
hostmatch url regex: don't double escape

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -336,9 +336,9 @@ class BaseClient(object):
             return {}
 
         hostmatch = re.match(
-            r'(?P<protocol>\\w+)://'
+            r'(?P<protocol>\w+)://'
             r'(?P<server>[^:/]+)'
-            r'(:(?P<port>\\d+))?'
+            r'(:(?P<port>\d+))?'
             r'(?P<path>/.*)?$',
             host)
 


### PR DESCRIPTION
Closes https://github.com/ome/omero-py/issues/30

Testing: `omero login ws://idr.openmicroscopy.org/omero-ws` should create a session (note that output from `omero login` is broken in the current branch as can be seen from a non-websocket login without this PR