### PR TITLE
setup.py: devtarget command to symlink src into target

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ def _relative_symlink_file(src, dst):
     try:
         os.symlink(relsrc, dst)
         print(src, dst)
-    except FileExistsError:
+    except OSError as e:
+        if e.errno != 17:
+            raise
         os.remove(dst)
         os.symlink(relsrc, dst)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,11 @@ import glob
 import sys
 import os
 
-from setuptools import setup, find_packages
+from setuptools import (
+    Command,
+    setup,
+    find_packages,
+)
 
 try:
     from StringIO import StringIO
@@ -22,7 +26,11 @@ except ImportError:
     from io import StringIO
     from io import BytesIO
 
-from shutil import copy
+from shutil import (
+    copy,
+    rmtree,
+)
+
 try:
     from urllib.request import urlopen
 except ImportError:
@@ -78,7 +86,7 @@ def get_blitz_location():
     return config_blitz_url
 
 
-if not os.path.exists("target"):
+def download_blitz_target():
     loc = get_blitz_location()
     print("Downloading %s ..." % loc, file=sys.stderr)
     resp = urlopen(loc)
@@ -87,6 +95,18 @@ if not os.path.exists("target"):
     zipfile = ZipFile(content)
     zipfile.extractall("target")
 
+
+def _relative_symlink_file(src, dst):
+    relsrc = os.path.relpath(src, os.path.dirname(dst))
+    try:
+        os.symlink(relsrc, dst)
+        print(src, dst)
+    except FileExistsError:
+        os.remove(dst)
+        os.symlink(relsrc, dst)
+
+
+def copy_src_to_target(symlink=False):
     for dirpath, dirs, files in os.walk("src"):
         for filename in files:
             topath = dirpath.replace("src", "target", 1)
@@ -94,7 +114,48 @@ if not os.path.exists("target"):
                 os.makedirs(topath)
             fromfile = os.path.sep.join([dirpath, filename])
             tofile = os.path.sep.join([topath, filename])
-            copy(fromfile, tofile)
+            if symlink:
+                _relative_symlink_file(fromfile, tofile)
+            else:
+                copy(fromfile, tofile)
+
+
+# https://coderwall.com/p/3q_czg/custom-subcommand-at-setup-py
+class DevTargetCommand(Command):
+    """
+    Recreate "target" with symlinks to files in "src" to ease development.
+
+    For example, `pip install -e .` will work.
+    Changes in files under "src" will be automatically seen in the installed
+    module.
+
+    If you add or remove files in src you must re-run both of these commands:
+
+        python setup.py devtarget
+        pip install -e .
+    """
+
+    description = (
+        'Recreate target with symlinks to files in src to ease development')
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        rmtree('target')
+        download_blitz_target()
+        copy_src_to_target(symlink=True)
+        print("If this is installed as an editable module re-run "
+              "`pip install -e .`")
+
+
+if not os.path.exists('target'):
+    download_blitz_target()
+    copy_src_to_target()
 
 
 packageless = glob.glob("target/*.py")
@@ -147,4 +208,8 @@ setup(
         'zeroc-ice>=3.6.4,<3.7',
         'future',
     ],
-    tests_require=['pytest<3'])
+    tests_require=['pytest<3'],
+    cmdclass={
+        'devtarget': DevTargetCommand,
+    },
+)


### PR DESCRIPTION
Recreate "target" with symlinks to files in "src" to ease development
For example, `pip install -e .` will work

Currently if you edit a file under `src` you must reinstall the python module. If isntead you fisrt run `python setup.py devtarget` this will symlink files from `src` into `target` instead of the default copy, which means you can use `pip install -e .` to install the module as an editable module as long as you only edit existing files. If you add/remove files under `src` you will need to rerun these commands. Default beahaviour should be unchanged.