### PR TITLE
Test natively in travis instead of docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,34 @@ sudo: required
 
 language: python
 
-python:
-  - "2.7"
+matrix:
+  include:
+    - python: "2.7"
+      env: TOX=py27
+    - python: "3.6"
+      env: TOX=py36
+    - python: "3.6"
+      env: TOX=no
 
-services:
-  - docker
-
-before_install:
-  - pip install -U pip future
-  - pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.0.10/zeroc_ice-3.6.4-cp27-cp27mu-manylinux2010_x86_64.whl
-  - python -c "import Ice; print Ice.stringVersion()"
+install:
+  - |
+    if [ "$TOX" = "no" ]; then
+      pip install https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+      pip install restructuredtext-lint
+    else
+      pip install tox
+    fi
 
 script:
-  - python setup.py sdist
-  - pip install dist/omero-py*gz
-  - python -c "import omero_version; print omero_version.omero_version"
-  - omero version
-  - docker build -t test .
-  - docker run --rm -ti test
+  - |
+    if [ "$TOX" = "no" ]; then
+      rst-lint README.rst
+      python setup.py sdist
+      pip install dist/omero-py*gz
+      omero version
+    else
+      tox -e $TOX
+    fi
 
 deploy:
   provider: pypi
@@ -27,3 +37,4 @@ deploy:
   password: $PYPI_PASSWORD
   on:
     tags: true
+    condition: "$TOX = no"

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
     tables
     pytest-sugar
     pytest-xdist
-    restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 setenv =
@@ -24,8 +23,7 @@ setenv =
 passenv =
     PIP_CACHE_DIR
 commands =
-    rst-lint README.rst
-    python setup.py install
+    python setup.py -q install
     pytest {posargs:-n4 -m "not broken" -rf \
         test/unit/clitest/ \
         test/unit/fstest/ \
@@ -49,6 +47,3 @@ commands =
     # test/unit/test_model.py \
     # test/unit/tablestest/
 
-[testenv:py36]
-basepython =
-    /opt/rh/rh-python36/root/usr/bin/python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     tables
     pytest-sugar
     pytest-xdist
+    restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 setenv =
@@ -23,7 +24,8 @@ setenv =
 passenv =
     PIP_CACHE_DIR
 commands =
-    python setup.py -q install
+    rst-lint README.rst
+    python setup.py install
     pytest {posargs:-n4 -m "not broken" -rf \
         test/unit/clitest/ \
         test/unit/fstest/ \
@@ -46,4 +48,3 @@ commands =
     # test/unit/test_metadata_utils.py \
     # test/unit/test_model.py \
     # test/unit/tablestest/
-


### PR DESCRIPTION
The docker tox travis check has the problem that the output of both environments is in the same log so it's not easy to see what's broken. This switches to using Travis environments instead.
- quietens the `python setup.py install` step inside tox to reduce the log output and make it easier to view the test output
- speeds up the time to run the tests in travis which has recently increased due to previously disabled unit tests being enabled.
