### PR TITLE
tables: fix table creation (string issues)

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -10,6 +10,8 @@ from builtins import str
 from builtins import zip
 from builtins import range
 from builtins import object
+from future.utils import native
+from past.utils import basestring
 import time
 import numpy
 import logging
@@ -224,7 +226,7 @@ class HdfStorage(object):
                             self.__hdf_path, mode))
                     mode = "r"
 
-            return tables.open_file(str(self.__hdf_path), mode=mode,
+            return tables.open_file(native(str(self.__hdf_path)), mode=mode,
                                     title="OMERO HDF Measurement Storage",
                                     rootUEP="/")
         except (tables.HDF5ExtError, IOError) as e:
@@ -297,7 +299,7 @@ class HdfStorage(object):
         k = '__version'
         try:
             v = self.__mea.attrs[k]
-            if isinstance(v, str):
+            if isinstance(v, basestring):
                 return v
         except KeyError:
             k = 'version'
@@ -441,7 +443,7 @@ class HdfStorage(object):
                 val = rint(val)
             elif isinstance(val, int):
                 val = rlong(val)
-            elif isinstance(val, str):
+            elif isinstance(val, basestring):
                 val = rstring(val)
             else:
                 raise omero.ValidationException("BAD TYPE: %s" % type(val))

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -11,7 +11,7 @@ from builtins import zip
 from builtins import range
 from builtins import object
 from future.utils import native
-from past.utils import basestring
+from past.builtins import basestring
 import time
 import numpy
 import logging

--- a/src/omero/tables.py
+++ b/src/omero/tables.py
@@ -9,6 +9,7 @@
 from __future__ import division
 from builtins import str
 from builtins import range
+from future.utils import native_str
 from past.utils import old_div
 import Ice
 import time
@@ -162,7 +163,7 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
             gid = unwrap(self.file_obj.details.group.id)
             client_uuid = self.factory.ice_getIdentity().category[8:]
             ctx = {
-                "omero.group": str(gid),
+                "omero.group": native_str(gid),
                 omero.constants.CLIENTUUID: client_uuid}
             try:
                 # Size to reset the server object to (must be checked after

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ deps =
     Pillow
     pytest
     PyYAML
-    tables
+    py27: tables < 3.6.0
+    py36: tables
     pytest-sugar
     pytest-xdist
     restructuredtext-lint


### PR DESCRIPTION
The native HDF5 libraries are like the Ice libraries
and expect traditional objects (bytes not newbytes).
With this PR, it's possible run the integration tests.
It does *not* fix the issues with ints and longs.