### PR TITLE
scripts: fix script launching (string issues)

### DIFF
--- a/src/omero/processor.py
+++ b/src/omero/processor.py
@@ -9,6 +9,7 @@
 from __future__ import division
 from builtins import str
 from builtins import range
+from future.utils import native_str
 from past.utils import old_div
 from builtins import object
 import os
@@ -56,7 +57,7 @@ class WithGroup(object):
 
     def __init__(self, service, group_id):
         self._service = service
-        self._group_id = str(group_id)
+        self._group_id = native_str(group_id)
 
     def _get_ctx(self, group=None):
         ctx = self._service.ice_getCommunicator()\

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -286,7 +286,7 @@ def load_dotted_class(dotted_class):
     try:
         parts = dotted_class.split(".")
         pkg = ".".join(parts[0:-2])
-        mod = str(parts[-2])
+        mod = native_str(parts[-2])
         kls = parts[-1]
         got = __import__(pkg, fromlist=[mod])
         got = getattr(got, mod)


### PR DESCRIPTION
Fixes Ice context issues as well as the __import__
method, which is another function which solely
takes native strings.