### PR TITLE
strictness fixes (tables)

### DIFF
--- a/src/omero/tables.py
+++ b/src/omero/tables.py
@@ -431,7 +431,7 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
             "omero.repo.wait", "1"))
         per_loop = old_div(wait, retries)
 
-        e = None
+        exc = None
         for x in range(retries):
             try:
                 self._get_dir()
@@ -439,6 +439,7 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
                 self._get_repo()
             except Exception as e:
                 self.logger.warn("Failed to find repo_svc: %s" % e)
+                exc = e
 
             if self.repo_svc:
                 break
@@ -447,8 +448,8 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
                 self.logger.debug(msg)
                 self.stop_event.wait(per_loop)
 
-        if e:
-            raise e
+        if exc:
+            raise exc
 
     def _get_dir(self):
         """

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -736,10 +736,12 @@ class Resources(object):
 
     @locked
     def cleanup(self):
-        self.stop_event.set()
-        for m in self.stuff:
-            self.safeClean(m)
+        stuff = self.stuff
         self.stuff = None
+        self.stop_event.set()
+        if stuff:
+            for m in stuff:
+                self.safeClean(m)
         self.logger.debug("Cleanup done")
 
     def safeClean(self, m):


### PR DESCRIPTION
The scoping for variable captpuring as well as locking
semantics seem to have also changed. These fixes work
towards having tables unit tests passing but are more
generally useful.

closes #41 