### PR TITLE
Use native_str in script_utils.download_plane()

### DIFF
--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -22,6 +22,7 @@
 Utility methods for dealing with scripts.
 """
 from __future__ import division
+from future.utils import native_str
 
 from builtins import hex
 from builtins import str
@@ -672,7 +673,7 @@ def download_plane(raw_pixels_store, pixels, z, c, t):
     size_x = pixels.getSizeX().getValue()
     size_y = pixels.getSizeY().getValue()
     pixel_type = pixels.getPixelsType().getValue().getValue()
-    convert_type = '>' + str(size_x * size_y) + \
+    convert_type = '>' + native_str(size_x * size_y) + \
         pixelstypetopython.toPython(pixel_type)
     converted_plane = unpack(convert_type, raw_plane)
     numpy_type = pixelstypetopython.toNumpy(pixel_type)


### PR DESCRIPTION
This should fix https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.scriptstest.test_script_utils/TestScriptUtils/test_split_image/ by making the `convert_type` a native string independently of the Python version