### PR TITLE
BaseClient.upload: accept str as well

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -858,7 +858,7 @@ class BaseClient(object):
 
         import os
         import types
-        if not filename or not isinstance(filename, bytes):
+        if not filename or not isinstance(filename, basestring):
             raise omero.ClientError("Non-null filename must be provided")
 
         if not os.path.exists(filename):


### PR DESCRIPTION
Under Python 2, the file name received is a `str` object rather than a `bytes`. Both should be accepted.