### PR TITLE
Remove PYTHONPATH from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps =
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
 setenv =
-    PYTHONPATH = {toxinidir}/target
     ICE_CONFIG = {toxinidir}/ice.config
 passenv =
     PIP_CACHE_DIR


### PR DESCRIPTION
There's no need to add `target` to `PYTHONPATH`, `python setup.py install` should do everything