### PR TITLE
Test test/unit/test_metadata_utils.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
         test/unit/test_conversions.py \
         test/unit/test_jvmcfg.py \
         test/unit/test_metadata_mapannotations.py \
+        test/unit/test_metadata_utils.py \
         test/unit/test_model.py \
         test/unit/test_parameters.py \
         test/unit/test_path.py \
@@ -48,5 +49,3 @@ commands =
     # Currently broken:
     # test/unit/test_gateway.py
     # test/unit/tablestest/
-    # py36 passes, py27 broken when run with other tests (works on its own):
-    # test/unit/test_metadata_utils.py


### PR DESCRIPTION
This test fails on Travis Python 2.7 when run as part of the whole test suite but passes locally:
