### PR TITLE
Fix update warning in omero shell

### DIFF
--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -139,7 +139,7 @@ class UpgradeCheck(object):
                 request.add_header('User-Agent', self.agent)
                 self.log.debug("Attempting to connect to %s" % full_url)
                 response = urllib.request.urlopen(request)
-                result = response.read()
+                result = response.read().decode("utf-8")
             finally:
                 socket.setdefaulttimeout(old_timeout)
 


### PR DESCRIPTION
Fixes this on python 3

```
$ omero shell
Traceback (most recent call last):
  File "/Users/willadmin/Desktop/py3/venv/bin/omero", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/willadmin/Desktop/PYTHON/omero-py/bin/omero", line 131, in <module>
    rv = omero.cli.argv()
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/cli.py", line 1732, in argv
    cli.invoke(args[1:])
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/cli.py", line 1185, in invoke
    stop = self.onecmd(line, previous_args)
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/cli.py", line 1262, in onecmd
    self.execute(line, previous_args)
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/cli.py", line 1344, in execute
    args.func(args)
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/plugins/basics.py", line 110, in __call__
    check.run()
  File "/Users/willadmin/Desktop/PYTHON/omero-py/target/omero/util/upgrade_check.py", line 155, in run
    self.log.warn("UPGRADE AVAILABLE:" + result)
TypeError: can only concatenate str (not "bytes") to str
```