### PR TITLE
Use ImportError instead of ModuleNotFoundError.

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -301,7 +301,7 @@ class BaseClient(object):
             # Register Object Factory
             try:
                 import ObjectFactoryRegistrar as ofr
-            except ModuleNotFoundError:
+            except ImportError:
                 from . import ObjectFactoryRegistrar as ofr
             ofr.registerObjectFactory(self.__ic, self)
 


### PR DESCRIPTION
Ubuntu xenial ships with Python 3.5 so this PR helps with getting that working.

We may instead choose to require Python 3.6.