### PR TITLE
Fix file_ann.getFileInChunks() - start with b''

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5303,7 +5303,7 @@ class _OriginalFileAsFileObj(object):
         return self.pos
 
     def read(self, n=-1):
-        buf = ''
+        buf = b''
         if n < 0:
             endpos = self.rfs.size()
         else:

--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -322,8 +322,8 @@ class ITest(object):
             raise Exception("import failed: [%r] %s\n%s\n%s" % (
                 args, rc, out, err))
         pix_ids = []
-        for x in out.split("\n"):
-            if x and x.find("Created") < 0 and x.find("#") < 0:
+        for x in out.split(b"\n"):
+            if x and x.find(b"Created") < 0 and x.find(b"#") < 0:
                 try:    # if the line has an image ID...
                     image_id = str(int(x.strip()))
                     # Occasionally during tests an id is duplicated on stdout

--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1010,7 +1010,7 @@ class ITest(object):
         if mimetype is None:
             mimetype = "application/octet-stream"
         if binary is None:
-            binary = "12345678910"
+            binary = b"12345678910"
         if name is None:
             name = str(self.uuid())
 


### PR DESCRIPTION
Needed for e.g. opening Figure files.
See https://github.com/ome/omero-figure/pull/344/files#diff-0a76704154b08eff719dbe89fa944468R355
