### PR TITLE
py3: fs plugin + testlib

### DIFF
--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -614,12 +614,16 @@ Examples:
         """
 
         from omero.grid import ManagedRepositoryPrx as MRepo
+        from functools import cmp_to_key
+
+        def my_cmp(a, b):
+            return cmp(a[0].id.val, b[0].id.val)
 
         client = self.ctx.conn(args)
         shared = client.sf.sharedResources()
         repos = shared.repositories()
         repos = list(zip(repos.descriptions, repos.proxies))
-        repos.sort(lambda a, b: cmp(a[0].id.val, b[0].id.val))
+        repos.sort(key = cmp_to_key(my_cmp))
 
         tb = self._table(args)
         tb.cols(["Id", "UUID", "Type", "Path"])

--- a/src/omero/testlib/cli.py
+++ b/src/omero/testlib/cli.py
@@ -176,6 +176,7 @@ def get_group_ids(out, sort_key=None):
                 new_value = ids[-1]
             else:
                 new_value = elements[1].strip()
-            assert new_value >= last_value
+            if last_value is not None:
+                assert new_value >= last_value
             last_value = new_value
     return ids


### PR DESCRIPTION
tests py3 failures
This should fix 
 * https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/26/testReport/junit/OmeroPy.test.integration.clitest.test_fs/TestFS/testRepos/
 * https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/26/testReport/junit/OmeroPy.test.integration.clitest.test_group/TestGroup/testList_None_id_/

Test should now pass in Python 2 and 3
