### PR TITLE
Fix test_repository/TestRecursiveDelete/test_dir

### DIFF
--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1423,12 +1423,12 @@ class AbstractRepoTest(ITest):
     def assert_write(self, mrepo2, filename, ofile):
         def _write(rfs):
             try:
-                rfs.write("bye", 0, 3)
-                assert "bye" == rfs.read(0, 3)
+                rfs.write(b"bye", 0, 3)
+                assert b"bye" == rfs.read(0, 3)
                 # Resetting for other expectations
                 rfs.truncate(2)
                 rfs.write(b"hi", 0, 2)
-                assert "hi" == rfs.read(0, 2)
+                assert b"hi" == rfs.read(0, 2)
             finally:
                 rfs.close()
 
@@ -1444,7 +1444,7 @@ class AbstractRepoTest(ITest):
             try:
                 pytest.raises(omero.SecurityViolation,
                               rfs.write, "bye", 0, 3)
-                assert "hi" == rfs.read(0, 2)
+                assert b"hi" == rfs.read(0, 2)
             finally:
                 rfs.close()
 
@@ -1476,7 +1476,7 @@ class AbstractRepoTest(ITest):
     def assert_read(self, mrepo2, filename, ofile, ctx=None):
         def _read(rfs):
             try:
-                assert "hi" == rfs.read(0, 2)
+                assert b"hi" == rfs.read(0, 2)
             finally:
                 rfs.close()
 

--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1307,7 +1307,7 @@ class AbstractRepoTest(ITest):
     def create_file(self, mrepo1, filename):
         rfs = mrepo1.file(filename, "rw")
         try:
-            rfs.write("hi", 0, 2)
+            rfs.write(b"hi", 0, 2)
             ofile = rfs.save()
             return ofile
         finally:
@@ -1427,7 +1427,7 @@ class AbstractRepoTest(ITest):
                 assert "bye" == rfs.read(0, 3)
                 # Resetting for other expectations
                 rfs.truncate(2)
-                rfs.write("hi", 0, 2)
+                rfs.write(b"hi", 0, 2)
                 assert "hi" == rfs.read(0, 2)
             finally:
                 rfs.close()

--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1443,7 +1443,7 @@ class AbstractRepoTest(ITest):
         def _nowrite(rfs):
             try:
                 pytest.raises(omero.SecurityViolation,
-                              rfs.write, "bye", 0, 3)
+                              rfs.write, b"bye", 0, 3)
                 assert b"hi" == rfs.read(0, 2)
             finally:
                 rfs.close()


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.test_repository/TestRecursiveDelete/test_dir/

and https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.test_repository/TestManagedRepositoryMultiUser/testTopPrivateGroup/