### PR TITLE
py3: processor.py

### DIFF
--- a/src/omero/processor.py
+++ b/src/omero/processor.py
@@ -994,7 +994,7 @@ class ProcessorI(omero.grid.Processor, omero.util.Servant):
 
             # client.download(file, str(process.script_path))
             scriptText = sf.getScriptService().getScriptText(file.id.val)
-            process.script_path.write_bytes(scriptText)
+            process.script_path.write_bytes(scriptText.encode('utf-8'))
 
             self.logger.info("Downloaded file: %s" % file.id.val)
             s = client.sha1(str(process.script_path))


### PR DESCRIPTION
Encode the text of the script
This should fix 
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.scriptstest.test_rand/TestRand/testRand/
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.scriptstest.test_inputs/TestInputs/testInputs/