### PR TITLE
Test py 3.7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOX=py27
     - python: "3.6"
       env: TOX=py36
+    - python: "3.7"
+      env: TOX=py37
     - python: "3.6"
       env: TOX=no
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py36, py37
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
 requires = pip >= 19.0.0
@@ -14,11 +14,13 @@ deps =
     PyYAML
     py27: tables < 3.6.0
     py36: tables
+    py37: tables
     pytest-sugar
     pytest-xdist
     restructuredtext-lint
     py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    py37: zeroc-ice
     mox3
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,9 @@ deps =
     pytest-sugar
     pytest-xdist
     restructuredtext-lint
-    py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
-    py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
-    py37: zeroc-ice
+    py27: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp27-cp27mu-manylinux2010_x86_64.whl
+    py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    py37: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp37-cp37m-manylinux2010_x86_64.whl
     mox3
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config


### PR DESCRIPTION
We officially support Python 3.6 but since we'll probably support 3.7 at some point in the future we might as well ensure the unit tests pass.

See https://github.com/ome/zeroc-ice-py-manylinux/pull/2 to speed this up