### PR TITLE
Fix ome.conditions.ResourceError in create_test_image

### DIFF
--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -434,7 +434,7 @@ class ITest(object):
             return y
 
         def f2(x, y):
-            return old_div((x + y), 2)
+            return (x + y) // 2
 
         def f3(x, y):
             return x


### PR DESCRIPTION
This caused at message = BufferOverflowException: null at
raw_pixels_store.setPlane(converted_plane, z, c, t)

Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.scriptstest.test_script_utils/TestScriptUtils/test_split_image/
and https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/junit/OmeroPy.test.integration.test_librarytest/TestLibrary/test9188/

Seems that ```old_div``` doesn't play well with ```numpy```. We want only integers values but...

```
>>> from past.utils import old_div
>>> def f1(x, y):
...     return old_div((x + y), 2)
...
>>> def f2(x, y):
...     return (x + y) // 2
... 
>>> from numpy import fromfunction, int16

>>> fromfunction(f1, (2, 2), dtype=int16)
array([[0. , 0.5],
       [0.5, 1. ]])

>>> fromfunction(f2, (2, 2), dtype=int16)
array([[0, 0],
       [0, 1]], dtype=int16)
```