### PR TITLE
gateway: tiles

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7362,7 +7362,7 @@ class _PixelsWrapper (BlitzObjectWrapper):
                 # +str(sizeX*sizeY)+pythonTypes[pixelType]
                 convertType = '>%d%s' % (
                     (planeY*planeX), pixelTypes[pixelType][0])
-                convertedPlane = unpack(convertType, rawPlane)
+                convertedPlane = unpack(convertType, rawPlane.encode("utf-8"))
                 remappedPlane = numpy.array(convertedPlane, numpyType)
                 remappedPlane.resize(planeY, planeX)
                 yield remappedPlane

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7362,7 +7362,11 @@ class _PixelsWrapper (BlitzObjectWrapper):
                 # +str(sizeX*sizeY)+pythonTypes[pixelType]
                 convertType = '>%d%s' % (
                     (planeY*planeX), pixelTypes[pixelType][0])
-                convertedPlane = unpack(convertType, rawPlane.encode("utf-8"))
+                if isinstance(rawPlane, bytes):
+                    convertedPlane = unpack(convertType, rawPlane)
+                else:
+                    encoded = rawPlane.encode("utf-8")
+                    convertedPlane = unpack(convertType, encoded)
                 remappedPlane = numpy.array(convertedPlane, numpyType)
                 remappedPlane.resize(planeY, planeX)
                 yield remappedPlane


### PR DESCRIPTION
Fix the type

This should fix 
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest.test_pixels/TestPixels/testGetPlanesExceptionOnGetPlane/ and similar

This should be green for Py2 and 3