### PR TITLE
test: testdb_create

### DIFF
--- a/src/omero/gateway/scripts/testdb_create.py
+++ b/src/omero/gateway/scripts/testdb_create.py
@@ -290,7 +290,7 @@ class TestDBHelper(object):
         @param content:     String containing the content of the file
         @return:            OriginalFileWrapper
         """
-        sio = BytesIO(content)
+        sio = BytesIO(content.encode("utf-8"))
         f = self.gateway.createOriginalFileFromFileObj(
             sio, parentpath, filename, len(content))
         return f


### PR DESCRIPTION
convert string
Change required to fix
https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest.test_wrapper/TestWrapper/testOriginalFileWrapperAsFileObj/
