### PR TITLE
fix metadata.test_pydict_text

### DIFF
--- a/src/omero/util/pydict_text_io.py
+++ b/src/omero/util/pydict_text_io.py
@@ -123,11 +123,12 @@ def _format_from_name(filename):
 
 
 def get_format_filename(filename, filetype):
+    """Returns bytes from the named json or yaml file."""
     if not filetype:
         filetype = _format_from_name(filename)
     if filetype not in ('json', 'yaml'):
         raise ValueError('Unknown file format: %s' % filename)
-    with open(filename, 'r') as f:
+    with open(filename, 'rb') as f:
         rawdata = f.read()
     return rawdata, filetype
 


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.metadata.test_pydict_text/TestPydictTextIo/test_get_format_originalfileid_yaml_format0_/ along with https://github.com/ome/openmicroscopy/pull/6146