### PR TITLE
populate-roi

### DIFF
--- a/src/omero/util/populate_roi.py
+++ b/src/omero/util/populate_roi.py
@@ -165,8 +165,7 @@ class DownloadingOriginalFileProvider(object):
         """
         log.info("Downloading original file: %d" % original_file.id.val)
         self.raw_file_store.setFileId(original_file.id.val)
-        temporary_file = tempfile.TemporaryFile(mode='rt+', dir=str(self.dir),
-                                                encoding="utf-8")
+        temporary_file = tempfile.TemporaryFile(mode='rt+', dir=str(self.dir))
         size = original_file.size.val
         for i in range((old_div(size, self.BUFFER_SIZE)) + 1):
             index = i * self.BUFFER_SIZE

--- a/src/omero/util/populate_roi.py
+++ b/src/omero/util/populate_roi.py
@@ -165,12 +165,13 @@ class DownloadingOriginalFileProvider(object):
         """
         log.info("Downloading original file: %d" % original_file.id.val)
         self.raw_file_store.setFileId(original_file.id.val)
-        temporary_file = tempfile.TemporaryFile(mode='rU+', dir=str(self.dir))
+        temporary_file = tempfile.TemporaryFile(mode='rt+', dir=str(self.dir),
+                                                encoding="utf-8")
         size = original_file.size.val
         for i in range((old_div(size, self.BUFFER_SIZE)) + 1):
             index = i * self.BUFFER_SIZE
             data = self.raw_file_store.read(index, self.BUFFER_SIZE)
-            temporary_file.write(data)
+            temporary_file.write(data.decode("utf-8"))
         temporary_file.seek(0)
         temporary_file.truncate(size)
         return temporary_file


### PR DESCRIPTION
fix reading of original file
This does fix the test https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/30/testReport/junit/OmeroPy.test.integration.metadata.test_populate/TestPopulateRois/testPopulateRoisPlate/
but it now shows the same error as the other tests
i.e.
```
 ValueError: findObjectFactory expects a string for argument 'id'
E       
E           message = BAD COLUMN TYPE: b'::omero::grid::ImageColumn' for Image
```

