### PR TITLE
rtypes: use past.builtins.long

### DIFF
--- a/src/omero/rtypes.py
+++ b/src/omero/rtypes.py
@@ -22,7 +22,7 @@ omero.rtypes as well as the omero/rtypes.{h,cpp} files.
 """
 
 from builtins import str
-from past.builtins import basestring
+from past.builtins import basestring, long
 import omero
 import Ice
 import IceImport
@@ -54,7 +54,7 @@ def rtype(val):
         return rbool(val)
     elif isinstance(val, int):
         return rint(val)
-    elif isinstance(val, int):
+    elif isinstance(val, long):  # Maintains Py2 compatibility
         return rlong(val)
     elif isinstance(val, float):
         return rfloat(val)
@@ -562,7 +562,7 @@ class RIntI(omero.RInt):
 class RLongI(omero.RLong):
 
     def __init__(self, value):
-        omero.RLong.__init__(self, int(value))
+        omero.RLong.__init__(self, long(value))
 
     def getValue(self, current=None):
         return self._val
@@ -618,7 +618,7 @@ class RLongI(omero.RLong):
 class RTimeI(omero.RTime):
 
     def __init__(self, value):
-        omero.RTime.__init__(self, int(value))
+        omero.RTime.__init__(self, long(value))
 
     def getValue(self, current=None):
         return self._val

--- a/test/unit/test_rtypes.py
+++ b/test/unit/test_rtypes.py
@@ -10,6 +10,8 @@
 """
 from builtins import str
 from builtins import object
+from past.builtins import long
+import sys
 import pytest
 import omero
 import omero.model  # For Image
@@ -30,7 +32,10 @@ class TestModel(object):
         # Unsupported
         # assert rdouble(0) == rtype(Double.valueOf(0))
         assert rfloat(0) == rtype(float(0))
-        assert rlong(0) == rtype(int(0))
+        if sys.version_info < (3, 0, 0):
+            assert rlong(0) == rtype(long(0))
+        else:
+            assert rint(0) == rtype(long(0))
         assert rint(0) == rtype(int(0))
         assert rstring("string") == rtype("string")
         # Unsupported


### PR DESCRIPTION
Fixes:
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/221/testReport/junit/OmeroWeb.test.integration.test_scripts/TestScripts/test_script_inputs_outputs_inputs0_/
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/221/testReport/junit/OmeroWeb.test.integration.test_scripts/TestScripts/test_script_inputs_outputs_inputs1_/
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/221/testReport/junit/OmeroWeb.test.integration.test_scripts/TestScripts/test_script_inputs_outputs_inputs2_/