### PR TITLE
fix test api wells listChildren

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -6434,7 +6434,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             q = self._conn.getQueryService()
             params = omero.sys.Parameters()
             params.map = {}
-            params.map["oid"] = omero_type(self.getId())
+            params.map["oid"] = rlong(self.getId())
             query = ("select well from Well as well "
                      "join fetch well.details.creationEvent "
                      "join fetch well.details.owner "


### PR DESCRIPTION
Fixes tests in 
 - https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/35/testReport/(root)/(empty)/OmeroWeb_test_integration_test_api_wells/

NB: tests weren't run on that build because of sort() errors in setup.