### PR TITLE
Tables metadata: treat int and long as long

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -27,7 +27,7 @@ import omero.callbacks
 
 # For ease of use
 from omero.columns import columns2definition
-from omero.rtypes import rfloat, rint, rlong, rstring, unwrap
+from omero.rtypes import rfloat, rlong, rstring, unwrap
 from omero.util.decorators import locked
 from omero_ext import portalocker
 from functools import wraps
@@ -35,6 +35,15 @@ from functools import wraps
 
 sys = __import__("sys")  # Python sys
 tables = __import__("tables")  # Pytables
+
+
+try:
+    # long only exists on Python 2
+    # Recent versions of PyTables may have treated Python 2 int and long
+    # identically anyway so treat the same
+    TABLES_METADATA_INT_TYPES = (int, numpy.int64, long)
+except NameError:
+    TABLES_METADATA_INT_TYPES = (int, numpy.int64)
 
 VERSION = '2'
 
@@ -439,9 +448,7 @@ class HdfStorage(object):
             val = attr[key]
             if isinstance(val, float):
                 val = rfloat(val)
-            elif isinstance(val, int):
-                val = rint(val)
-            elif isinstance(val, int):
+            elif isinstance(val, TABLES_METADATA_INT_TYPES):
                 val = rlong(val)
             elif isinstance(val, basestring):
                 val = rstring(val)

--- a/src/omero_ext/portalocker.py
+++ b/src/omero_ext/portalocker.py
@@ -94,8 +94,9 @@ if os.name == 'nt':
             win32file.LockFileEx(hfile, flags, 0, -0x10000, __overlapped)
         except pywintypes.error as exc_value:
             # error: (33, 'LockFileEx', 'The process cannot access the file because another process has locked a portion of the file.')
-            if exc_value[0] == 33:
-                raise LockException(LockException.LOCK_FAILED, exc_value[2])
+            if exc_value.args[0] == 33:
+                raise LockException(
+                    LockException.LOCK_FAILED, exc_value.args[2])
             else:
                 # Q:  Are there exceptions/codes we should be dealing with here?
                 raise
@@ -121,8 +122,9 @@ elif os.name == 'posix':
             #  IOError: [Errno 11] Resource temporarily unavailable
             #  Following added by Glencoe Software, Inc. using LOCK_NB|LOCK_EX on Mac 10.4
             #  IOError: [Errno 35] Resource temporarily unavailable
-            if exc_value[0] == 11 or exc_value[0] == 35:
-                raise LockException(LockException.LOCK_FAILED, exc_value[1])
+            if exc_value.args[0] == 11 or exc_value.args[0] == 35:
+                raise LockException(
+                    LockException.LOCK_FAILED, exc_value.args[1])
             else:
                 raise
 


### PR DESCRIPTION
Python 3 code fixes from https://github.com/ome/omero-py/pull/59 excluding test changes