### PR TITLE
Handle getObjects(attributes={id:ID} as long

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3407,7 +3407,12 @@ class _BlitzGateway (object):
                     rv = rlong(v)
                 else:
                     # lookup type of attribute from class
-                    klass = wrapper.OMERO_TYPE
+                    if wrapper.OMERO_CLASS is not None:
+                        klass = getattr(omero.model,
+                                        "%sI" % wrapper.OMERO_CLASS)
+                    else:
+                        # AnnotationWrappers don't have OMERO_CLASS
+                        klass = wrapper.OMERO_TYPE
                     rtype = getattr(klass._field_info, k).wrapper(1)
                     rv = rtype.__class__(v)
                 baseParams.map[k] = rv

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3405,8 +3405,8 @@ class _BlitzGateway (object):
                 clauses.append('obj.%s=:%s' % (k, k))
                 if k == 'id':
                     rv = rlong(v)
-                else:
-                    # lookup type of attribute from class
+                elif isinstance(v, IntType):
+                    # lookup rint vv rlong from class
                     if wrapper.OMERO_CLASS is not None:
                         klass = getattr(omero.model,
                                         "%sI" % wrapper.OMERO_CLASS)
@@ -3415,6 +3415,8 @@ class _BlitzGateway (object):
                         klass = wrapper.OMERO_TYPE
                     rtype = getattr(klass._field_info, k).wrapper(1)
                     rv = rtype.__class__(v)
+                else:
+                    rv = omero_type(v)
                 baseParams.map[k] = rv
         if clauses:
             query += " where " + (" and ".join(clauses))

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3413,7 +3413,7 @@ class _BlitzGateway (object):
                     else:
                         # AnnotationWrappers don't have OMERO_CLASS
                         klass = wrapper.OMERO_TYPE
-                    rtype = getattr(klass._field_info, k).wrapper(1)
+                    rv = getattr(klass._field_info, k).wrapper(v)
                     rv = rtype.__class__(v)
                 else:
                     rv = omero_type(v)

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3414,7 +3414,6 @@ class _BlitzGateway (object):
                         # AnnotationWrappers don't have OMERO_CLASS
                         klass = wrapper.OMERO_TYPE
                     rv = getattr(klass._field_info, k).wrapper(v)
-                    rv = rtype.__class__(v)
                 else:
                     rv = omero_type(v)
                 baseParams.map[k] = rv

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3406,7 +3406,10 @@ class _BlitzGateway (object):
                 if k == 'id':
                     rv = rlong(v)
                 else:
-                    rv = omero_type(v)
+                    # lookup type of attribute from class
+                    klass = wrapper.OMERO_TYPE
+                    rtype = getattr(klass._field_info, k).wrapper(1)
+                    rv = rtype.__class__(v)
                 baseParams.map[k] = rv
         if clauses:
             query += " where " + (" and ".join(clauses))

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3403,7 +3403,11 @@ class _BlitzGateway (object):
         if attributes is not None:
             for k, v in list(attributes.items()):
                 clauses.append('obj.%s=:%s' % (k, k))
-                baseParams.map[k] = omero_type(v)
+                if k == 'id':
+                    rv = rlong(v)
+                else:
+                    rv = omero_type(v)
+                baseParams.map[k] = rv
         if clauses:
             query += " where " + (" and ".join(clauses))
 


### PR DESCRIPTION
Fixes many 'show' tests, which use
```getObjects('Image', attributes={'id':1})```
We handle ```id``` to wrap in ```rlong```.
E.g: - https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/37/testReport/OmeroWeb.test.integration.test_show/TestShow/test_project_legacy_path/