### PR TITLE
Tables: fix arguments to Ice

### DIFF
--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -20,6 +20,7 @@ to PyTables types.
 from builtins import zip
 from builtins import range
 from builtins import object
+from future.utils import native, bytes_to_native_str, isbytes
 import omero
 import Ice
 import IceImport
@@ -277,6 +278,12 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
                 None, None, "String size must be > 0 (Column: %s)"
                 % self.name)
         return tables.StringCol(pos=pos, itemsize=self.size)
+
+    def fromrows(self, rows):
+        AbstractColumn.fromrows(self, rows)
+        for i, val in enumerate(self.values):
+            if isbytes(val):
+                self.values[i] = bytes_to_native_str(val)
 
 
 class AbstractArrayColumn(AbstractColumn):

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -10,7 +10,7 @@ from builtins import str
 from builtins import zip
 from builtins import range
 from builtins import object
-from future.utils import native, bytes_to_native_str
+from future.utils import native, bytes_to_native_str, isbytes
 from past.builtins import basestring
 import time
 import numpy
@@ -413,9 +413,13 @@ class HdfStorage(object):
         descs = self.__descriptions
         cols = []
         for i in range(len(types)):
-            t = bytes_to_native_str(types[i])
+            t = types[i]
+            if isbytes(t):
+                t = bytes_to_native_str(t)
             n = names[i]
-            d = bytes_to_native_str(descs[i])
+            d = descs[i]
+            if isbytes(d):
+                d = bytes_to_native_str(d)
             try:
                 col = ic.findObjectFactory(t).create(t)
                 col.name = n

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -10,7 +10,7 @@ from builtins import str
 from builtins import zip
 from builtins import range
 from builtins import object
-from future.utils import native
+from future.utils import native, bytes_to_native_str
 from past.builtins import basestring
 import time
 import numpy
@@ -413,9 +413,9 @@ class HdfStorage(object):
         descs = self.__descriptions
         cols = []
         for i in range(len(types)):
-            t = types[i]
+            t = bytes_to_native_str(types[i])
             n = names[i]
-            d = descs[i]
+            d = bytes_to_native_str(descs[i])
             try:
                 col = ic.findObjectFactory(t).create(t)
                 col.name = n

--- a/src/omero/util/populate_metadata.py
+++ b/src/omero/util/populate_metadata.py
@@ -852,9 +852,9 @@ class ParsingContext(object):
 
     def parse(self):
         if self.file.endswith(".gz"):
-            data = gzip.open(self.file, "rb")
+            data = gzip.open(self.file, "rt")
         else:
-            data = open(self.file, 'U')
+            data = open(self.file, "rt")
 
         try:
             return self.parse_from_handle(data)


### PR DESCRIPTION
 * [x] hdfstorage: map b'' to native_str
 * [x] invalid value for element 0 of sequence<string> ([failure](https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/38/testReport/OmeroPy.test.integration.tablestest.test_service/TestTables/testAllColumnsSameTable/), [zeroc thread](https://forums.zeroc.com/discussion/46708/icepy-sequence-issues-migrating-to-python-3/p1?new=1))