### PR TITLE
Convert tables v1 version to string

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -304,6 +304,8 @@ class HdfStorage(object):
         except KeyError:
             k = 'version'
             v = self.__mea.attrs[k]
+            if isbytes(v):
+                v = bytes_to_native_str(v)
             if v == 'v1':
                 return '1'
 


### PR DESCRIPTION
This may or may not fix ome/openmicroscopy#6114 (comment)

Moved from https://github.com/joshmoore/omero-py/pull/14