### PR TITLE
tables: map metadata bytes to strings

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -457,6 +457,8 @@ class HdfStorage(object):
             elif isinstance(val, TABLES_METADATA_INT_TYPES):
                 val = rlong(val)
             elif isinstance(val, basestring):
+                if isbytes(val):
+                    val = bytes_to_native_str(val)
                 val = rstring(val)
             else:
                 raise omero.ValidationException("BAD TYPE: %s" % type(val))


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/52/testReport/junit/OmeroPy.test.integration.tablestest.test_backwards_compatibility/TestBackwardsCompatibility_5_3_4/testAllColumnsAndMetadata_5_3_4/