### PR TITLE
First attempt at adding optional packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,28 @@ setup(
         'zeroc-ice>=3.6.4,<3.7',
         'future',
     ],
+    extras_require={
+        'extra': [
+            # 'ipython',
+            'Jinja2',
+            'numexpr',
+            'numpy',
+            'Pillow',
+            'PyYAML',
+            'tables',
+        ],
+        'linux': [
+            # These match the currently available binary wheels and should
+            # ensure omero-py can be installed without a compiler
+            # 'ipython==7.9.0',
+            'Jinja2==2.10.3',
+            'numexpr==2.7.0',
+            'numpy==1.17.3',
+            'Pillow==6.2.1',
+            'PyYAML==5.1.2',
+            'tables==3.6.1',
+        ],
+    },
     tests_require=[
         'pytest<3',
         'mox3',

--- a/setup.py
+++ b/setup.py
@@ -231,6 +231,9 @@ setup(
             'PyYAML==5.1.2',
             'tables==3.6.1',
         ],
+        'testlib': [
+            'mox3',
+        ],
     },
     tests_require=[
         'pytest<3',


### PR DESCRIPTION
Can be tested locally:
- `pip install -e '.[extra]'`
- `pip install -e '.[linux]'`
- New: `pip install -e '.[testlib]'`

The general idea is to manage the packages installed by the Ansible role here to reduce the number of time dependencies are defined or pinned.