### PR TITLE
Declare mox3 as an extra dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,9 @@ setup(
         'zeroc-ice>=3.6.4,<3.7',
         'future',
     ],
+    extras_require={
+        'testlib': ["mox3"],
+    },
     tests_require=[
         'pytest<3',
         'mox3',


### PR DESCRIPTION
See discussion at https://github.com/ome/omero-upload/pull/6#pullrequestreview-318288383

In order to consume `omero.testlib`, this should allow dependent projects to declare `omero-py[testlib]` to install the `mox3` dependency