### PR TITLE
changelog: list breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - Fixes primarily focused on byte return types
 
+## API Changes
+
+- getFileInChunks now returns a bytes-generator
+
 # 5.6.dev2 (October 2019)
 
 - Even more Python 3 fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## API Changes
 
-- getFileInChunks now returns a bytes-generator
+- omero.gateway.FileAnnotationWrapper.getFileInChunks returns bytes
+- omero.gateway.ImageWrapper.exportOmeTiff returns bytes
 
 # 5.6.dev2 (October 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   - image.renderBirdsEyeView()
   - image.renderJpegRegion()
   - image.renderJpeg()
+- `rlong` instances now require explicit mapping:
+  - `omero_type(longValue)` defaults to `rint`
+  - `omero.rtypes.wrap(longValue)` defaults to `rint`
 
 # 5.6.dev2 (October 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 - omero.gateway.FileAnnotationWrapper.getFileInChunks returns bytes
 - omero.gateway.ImageWrapper.exportOmeTiff returns bytes
+- omero.gateway.BlitzGateawy.createOriginalFileFromFileObj takes BytesIO
+- several return values should now be _wrapped_ by BytesIO:
+  - image.renderSplitChannel()
+  - image.renderBirdsEyeView()
+  - image.renderJpegRegion()
+  - image.renderJpeg()
 
 # 5.6.dev2 (October 2019)
 


### PR DESCRIPTION
 - [x] getFileInChunks
 - [x] exportOmeTiff
 - [x] BytesIO etc.
 - [x] rlongs

cc: @ome/python 