### PR TITLE
omero-py requires Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ setup(
     install_requires=[
         'zeroc-ice>=3.6.4,<3.7',
         'future',
+        'Pillow',
     ],
     tests_require=[
         'pytest<3',


### PR DESCRIPTION
Add ```Pillow``` to the requirements.
This is required by ```BlitzGateway``` in several places and we get an error logged if it's not installed. With this change...

```
$ pip install .
Processing /Users/willadmin/Desktop/PYTHON/omero-py
Collecting zeroc-ice<3.7,>=3.6.4 (from omero-py==5.6.dev6)
Collecting future (from omero-py==5.6.dev6)
  Using cached https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz
Collecting Pillow (from omero-py==5.6.dev6)
  Using cached https://files.pythonhosted.org/packages/85/28/2c72ba965b52884a0bd71e419761fc162763dc2e5d9bec2f3b1949f7272a/Pillow-6.2.1-cp37-cp37m-macosx_10_6_intel.whl
Installing collected packages: zeroc-ice, future, Pillow, omero-py
  Running setup.py install for future ... done
  Running setup.py install for omero-py ... done
Successfully installed Pillow-6.2.1 future-0.18.2 omero-py-5.6.dev6 zeroc-ice-3.6.5
```