### PR TITLE
Add option to create new ThumbnailStore connection

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -8262,7 +8262,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return self._obj.getPrimaryPixels().getId().val
 
     # @setsessiongroup
-    def _prepareTB(self, _r=False, rdefId=None):
+    def _prepareTB(self, _r=False, rdefId=None, use_cached_ts=True):
         """
         Prepares Thumbnail Store for the image.
 
@@ -8271,6 +8271,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :type _r:           Boolean
         :param rdefId:      Rendering def ID to use for rendering thumbnail
         :type rdefId:       Long
+        :param use_cached_ts: If true (default) use the cached ThumbnailStore,
+                              else create a new one.
         :return:            Thumbnail Store or None
         :rtype:             :class:`ProxyObjectWrapper`
         """
@@ -8278,7 +8280,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         pid = self.getPrimaryPixels().id
         if rdefId is None:
             rdefId = self._getRDef()
-        tb = self._conn.createThumbnailStore()
+
+        if use_cached_ts:
+            tb = self._conn.createThumbnailStore()
+        else:
+            tb = ProxyObjectWrapper(self._conn, 'createThumbnailStore')
 
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
@@ -8395,7 +8401,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     # @setsessiongroup
     def getThumbnail(self, size=(64, 64), z=None, t=None, direct=True,
-                     rdefId=None):
+                     rdefId=None, use_cached_ts=True):
         """
         Returns a string holding a rendered JPEG of the thumbnail.
 
@@ -8416,12 +8422,14 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param direct:      If true, force creation of new thumbnail
                             (don't use cached)
         :param rdefId:      The rendering def to apply to the thumbnail.
+        :param use_cached_ts: If true (default) use the cached ThumbnailStore,
+                              else create a new one.
         :rtype:             string or None
         :return:            the rendered JPEG, or None if there was an error.
         """
         tb = None
         try:
-            tb = self._prepareTB(rdefId=rdefId)
+            tb = self._prepareTB(rdefId=rdefId, use_cached_ts=use_cached_ts)
             if tb is None:
                 return None
             if isinstance(size, IntType):

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -1524,7 +1524,7 @@ class _BlitzGateway (object):
     def __init__(self, username=None, passwd=None, client_obj=None, group=None,
                  clone=False, try_super=False, host=None, port=None,
                  extra_config=None, secure=False, anonymous=True,
-                 useragent=None, userip=None):
+                 useragent=None, userip=None, cache_services=True):
         """
         Create the connection wrapper.
         Does not attempt to connect at this stage
@@ -1555,6 +1555,9 @@ class _BlitzGateway (object):
         :param useragent:   Log which python clients use this connection.
                             E.g. 'OMERO.webadmin'
         :param userip:      Log client ip.
+        :param cache_services: False to create a new service connection for
+                               each request. Note: Make sure to close the
+                               service in that case.
         :type useragent:    String
         """
 
@@ -1606,6 +1609,7 @@ class _BlitzGateway (object):
 
         # The properties we are setting through the interface
         self.setIdentity(username, passwd, not clone)
+        self._cache_services = cache_services
 
     def __enter__(self):
         """
@@ -1671,6 +1675,12 @@ class _BlitzGateway (object):
                 logger.error("%s - %s\n%s" % (
                     prefix, service_string, stack_msg))
         return count
+
+    def cacheServices(self, cache_services):
+        """Use cached services (default). Set to False in order to
+        create a new service connection for each request. Note: In that
+        case make sure that the connection is closed again."""
+        self._cache_services = cache_services
 
     def createServiceOptsDict(self):
         serviceOpts = ServiceOptsDict(self.c.getImplicitContext().getContext())
@@ -2553,7 +2563,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['admin']
+        if self._cache_services:
+            return self._proxies['admin']
+        return ProxyObjectWrapper(self, 'getAdminService')
 
     def getQueryService(self):
         """
@@ -2561,7 +2573,9 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['query']
+        if self._cache_services:
+            return self._proxies['query']
+        return ProxyObjectWrapper(self, 'getQueryService')
 
     def getContainerService(self):
         """
@@ -2570,7 +2584,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['container']
+        if self._cache_services:
+            return self._proxies['container']
+        return ProxyObjectWrapper(self, 'getContainerService')
 
     def getPixelsService(self):
         """
@@ -2579,7 +2595,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['pixel']
+        if self._cache_services:
+            return self._proxies['pixel']
+        return ProxyObjectWrapper(self, 'getPixelsService')
 
     def getMetadataService(self):
         """
@@ -2588,7 +2606,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['metadata']
+        if self._cache_services:
+            return self._proxies['metadata']
+        return ProxyObjectWrapper(self, 'getMetadataService')
 
     def getRoiService(self):
         """
@@ -2597,7 +2617,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['roi']
+        if self._cache_services:
+            return self._proxies['roi']
+        return ProxyObjectWrapper(self, 'getRoiService')
 
     def getScriptService(self):
         """
@@ -2606,7 +2628,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['script']
+        if self._cache_services:
+            return self._proxies['script']
+        return ProxyObjectWrapper(self, 'getScriptService')
 
     def createRawFileStore(self):
         """
@@ -2616,7 +2640,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['rawfile']
+        if self._cache_services:
+            return self._proxies['rawfile']
+        return ProxyObjectWrapper(self, 'createRawFileStore')
 
     def getRepositoryInfoService(self):
         """
@@ -2625,7 +2651,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['repository']
+        if self._cache_services:
+            return self._proxies['repository']
+        return ProxyObjectWrapper(self, 'getRepositoryInfoService')
 
     def getShareService(self):
         """
@@ -2634,7 +2662,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['share']
+        if self._cache_services:
+            return self._proxies['share']
+        return ProxyObjectWrapper(self, 'getShareService')
 
     def getSharedResources(self):
         """
@@ -2643,7 +2673,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['sharedres']
+        if self._cache_services:
+            return self._proxies['sharedres']
+        return ProxyObjectWrapper(self, 'getSharedResources')
 
     def getTimelineService(self):
         """
@@ -2652,7 +2684,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['timeline']
+        if self._cache_services:
+            return self._proxies['timeline']
+        return ProxyObjectWrapper(self, 'getTimelineService')
 
     def getTypesService(self):
         """
@@ -2661,7 +2695,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['types']
+        if self._cache_services:
+            return self._proxies['types']
+        return ProxyObjectWrapper(self, 'getTypesService')
 
     def getConfigService(self):
         """
@@ -2670,7 +2706,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['config']
+        if self._cache_services:
+            return self._proxies['config']
+        return ProxyObjectWrapper(self, 'getConfigService')
 
     def createRenderingEngine(self):
         """
@@ -2682,7 +2720,10 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        rv = self._proxies['rendering']
+        if self._cache_services:
+            rv = self._proxies['rendering']
+        else:
+            rv = ProxyObjectWrapper(self, 'createRenderingEngine')
         if rv._tainted:
             rv = self._proxies['rendering'] = rv.clone()
         rv.taint()
@@ -2696,7 +2737,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['rendsettings']
+        if self._cache_services:
+            return self._proxies['rendsettings']
+        return ProxyObjectWrapper(self, 'getRenderingSettingsService')
 
     def createRawPixelsStore(self):
         """
@@ -2705,8 +2748,9 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-
-        return self._proxies['rawpixels']
+        if self._cache_services:
+            return self._proxies['rawpixels']
+        return ProxyObjectWrapper(self, 'createRawPixelsStore')
 
     def createThumbnailStore(self):
         """
@@ -2716,8 +2760,9 @@ class _BlitzGateway (object):
         :rtype: omero.gateway.ProxyObjectWrapper
         :return: The proxy wrapper of the thumbnail store
         """
-
-        return self._proxies['thumbs']
+        if self._cache_services:
+            return self._proxies['thumbs']
+        return ProxyObjectWrapper(self, 'createThumbnailStore')
 
     def createSearchService(self):
         """
@@ -2726,7 +2771,9 @@ class _BlitzGateway (object):
 
         :return: omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['search']
+        if self._cache_services:
+            return self._proxies['search']
+        return ProxyObjectWrapper(self, 'createSearchService')
 
     def getUpdateService(self):
         """
@@ -2734,7 +2781,9 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['update']
+        if self._cache_services:
+            return self._proxies['update']
+        return ProxyObjectWrapper(self, 'getUpdateService')
 
     def getSessionService(self):
         """
@@ -2742,7 +2791,9 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['session']
+        if self._cache_services:
+            return self._proxies['session']
+        return ProxyObjectWrapper(self, 'getSessionService')
 
     def createExporter(self):
         """
@@ -8262,7 +8313,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return self._obj.getPrimaryPixels().getId().val
 
     # @setsessiongroup
-    def _prepareTB(self, _r=False, rdefId=None, use_cached_ts=True):
+    def _prepareTB(self, _r=False, rdefId=None):
         """
         Prepares Thumbnail Store for the image.
 
@@ -8281,10 +8332,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if rdefId is None:
             rdefId = self._getRDef()
 
-        if use_cached_ts:
-            tb = self._conn.createThumbnailStore()
-        else:
-            tb = ProxyObjectWrapper(self._conn, 'createThumbnailStore')
+        tb = self._conn.createThumbnailStore()
 
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
@@ -8401,7 +8449,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     # @setsessiongroup
     def getThumbnail(self, size=(64, 64), z=None, t=None, direct=True,
-                     rdefId=None, use_cached_ts=True):
+                     rdefId=None):
         """
         Returns a string holding a rendered JPEG of the thumbnail.
 
@@ -8422,14 +8470,12 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param direct:      If true, force creation of new thumbnail
                             (don't use cached)
         :param rdefId:      The rendering def to apply to the thumbnail.
-        :param use_cached_ts: If true (default) use the cached ThumbnailStore,
-                              else create a new one.
         :rtype:             string or None
         :return:            the rendered JPEG, or None if there was an error.
         """
         tb = None
         try:
-            tb = self._prepareTB(rdefId=rdefId, use_cached_ts=use_cached_ts)
+            tb = self._prepareTB(rdefId=rdefId)
             if tb is None:
                 return None
             if isinstance(size, IntType):


### PR DESCRIPTION
Just adds an option to `_prepareTB` to use a new ThumbnailStore connection. If the cached one of the BlitzGateway is used then you can't call `getThumbnail` for multiple images in parallel.

Required by https://github.com/ome/omero-cli-render/pull/33 
