### PR TITLE
admin.py: handle errors in getdirsize

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1472,7 +1472,7 @@ present, the user will enter a console""")
             dir_path_exists = os.path.exists(dir_path)
             is_writable = os.access(dir_path, os.R_OK | os.W_OK)
             if dir_size and dir_path_exists:
-                dir_size = self.getdirsize(omero_temp_dir)
+                dir_size = self.getdirsize(omero_temp_dir, False)
                 dir_size = "   (Size: %s)" % dir_size
             self._item("OMERO %s dir" % dir_name, "'%s'" % dir_path)
             self.ctx.out("Exists? %s\tIs writable? %s%s" %
@@ -1548,10 +1548,11 @@ present, the user will enter a console""")
         finally:
             cb.close(True)
 
-    def getdirsize(self, directory):
+    def getdirsize(self, directory, strict=True):
         """
         Uses os.walk to calculate the deep size of the given
-        directory. If a directory disappears during calculation,
+        directory. If strict is set, an exception will be thrown
+        if a directory disappears during calculation. Otherwise,
         an error will be printed to stderr, but the calculation
         will continue.
         """
@@ -1562,7 +1563,9 @@ present, the user will enter a console""")
                 try:
                     total += os.path.getsize(fullpath)
                 except Exception:
-                    self.ctx.error("Failed to get size of: %s" % fullpath)
+                    self.ctx.err("Failed to get size of: %s" % fullpath)
+                    if strict:
+                        raise
         return total
 
     def session_manager(self, communicator):

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1549,10 +1549,20 @@ present, the user will enter a console""")
             cb.close(True)
 
     def getdirsize(self, directory):
+        """
+        Uses os.walk to calculate the deep size of the given
+        directory. If a directory disappears during calculation,
+        an error will be printed to stderr, but the calculation
+        will continue.
+        """
         total = 0
         for values in os.walk(directory):
             for filename in values[2]:
-                total += os.path.getsize(os.path.join(values[0], filename))
+                fullpath = os.path.join(values[0], filename)
+                try:
+                    total += os.path.getsize(fullpath)
+                except Exception:
+                    self.ctx.error("Failed to get size of: %s" % fullpath)
         return total
 
     def session_manager(self, communicator):


### PR DESCRIPTION
see: 
 - https://latest-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/197/console
 - https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/80/console

Both failed with:

```
01:24:20 OMERO data dir:'/home/omero/workspace/OMERO-test-integration/data' Exists? True	Is writable? True
01:24:21 Traceback (most recent call last):
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/bin/omero", line 131, in <module>
01:24:21     rv = omero.cli.argv()
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/cli.py", line 1756, in argv
01:24:21     cli.invoke(args[1:])
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/cli.py", line 1187, in invoke
01:24:21     stop = self.onecmd(line, previous_args)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/cli.py", line 1264, in onecmd
01:24:21     self.execute(line, previous_args)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/cli.py", line 1346, in execute
01:24:21     args.func(args)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/install/windows_warning.py", line 26, in wrapper
01:24:21     return func(self, *args, **kwargs)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/plugins/prefs.py", line 78, in open_and_close_config
01:24:21     return func(*args, **kwargs)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/plugins/admin.py", line 1475, in diagnostics
01:24:21     dir_size = self.getdirsize(omero_temp_dir)
01:24:21   File "/home/omero/workspace/OMERO-test-integration/src/dist/lib/python/omero/plugins/admin.py", line 1555, in getdirsize
01:24:21     total += os.path.getsize(os.path.join(values[0], filename))
01:24:21   File "/home/omero/workspace/OMERO-test-integration/omero-virtualenv/lib64/python2.7/genericpath.py", line 49, in getsize
01:24:21     return os.stat(filename).st_size
01:24:21 OSError: [Errno 2] No such file or directory: '/home/omero/omero/tmp/omero_omero/6014'
```

Another process created a temp directory at the beginning of the run, but finished and was removed before `getdirsize` had completed. 