### PR TITLE
omero load --glob

### DIFF
--- a/src/omero/plugins/basics.py
+++ b/src/omero/plugins/basics.py
@@ -20,11 +20,10 @@
 from __future__ import print_function
 
 from past.builtins import cmp
+from glob import glob
 import sys
 
 from collections import defaultdict
-
-from omero_ext.argparse import FileType
 
 from omero.cli import BaseControl
 from omero.cli import CLI
@@ -72,22 +71,43 @@ Examples:
 class LoadControl(BaseControl):
 
     def _configure(self, parser):
-        parser.add_argument("infile", nargs="*", type=FileType("r"),
-                            default=[sys.stdin])
+        parser.add_argument("infile", nargs="*")
+        parser.add_argument(
+            "-g", "--glob", action="store_true", default=False,
+            help=("Input paths are shell globs that should be expanded and "
+                  "sorted."))
         parser.add_argument(
             "-k", "--keep-going", action="store_true", default=False,
             help="Continue processing after an error.")
         parser.set_defaults(func=self.__call__)
 
-    def __call__(self, args):
-        for file in args.infile:
-            self.ctx.dbg("Loading file %s" % file)
-            for line in file:
-                self.ctx.invoke(line, strict=(not args.keep_going))
+    def _load_filehandle(self, fh, keep_going):
+        for line in fh:
+            self.ctx.invoke(line, strict=(not keep_going))
 
-                if self.ctx.rv != 0:
-                    self.ctx.err("Ignoring error: %s" % line)
-                    self.ctx.rv = 0
+            if self.ctx.rv != 0:
+                self.ctx.err("Ignoring error: %s" % line)
+                self.ctx.rv = 0
+
+    def __call__(self, args):
+        stdout = False
+        if args.glob:
+            infiles = []
+            for fileglob in args.infile:
+                infiles.extend(glob(fileglob))
+            infiles.sort()
+        elif not args.infile:
+            stdout = True
+        else:
+            infiles = args.infile
+
+        if stdout:
+            self._load_filehandle(sys.stdin, args.keep_going)
+        else:
+            for filename in infiles:
+                self.ctx.dbg("Loading file %s" % filename)
+                with open(filename, 'r') as fh:
+                    self._load_filehandle(fh, args.keep_going)
 
 
 class ShellControl(BaseControl):

--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -66,10 +66,7 @@ class TestBasics(object):
     def testVersion(object):
         cli.invoke(["version"], strict=True)
 
-    def testLoadGlob(object, monkeypatch, tmp_path, capsys):
-        (tmp_path / 'etc').mkdir()
-        (tmp_path / 'etc' / 'grid').mkdir()
-        monkeypatch.setenv('OMERODIR', str(tmp_path))
+    def testLoadGlob(object, tmp_path, capsys):
         for i in 'abc':
             (tmp_path / (i + 'a.omero')).write_text(
                 'config set {i} {i}'.format(i=i))

--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from __future__ import unicode_literals
 from builtins import object
 import pytest
 from omero.cli import CLI

--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -65,3 +65,17 @@ class TestBasics(object):
 
     def testVersion(object):
         cli.invoke(["version"], strict=True)
+
+    def testLoadGlob(object, monkeypatch, tmp_path, capsys):
+        (tmp_path / 'etc').mkdir()
+        (tmp_path / 'etc' / 'grid').mkdir()
+        monkeypatch.setenv('OMERODIR', str(tmp_path))
+        for i in 'abc':
+            (tmp_path / (i + 'a.omero')).write_text(
+                'config set {i} {i}'.format(i=i))
+        cli.invoke(["load", "--glob", str(tmp_path / '*.omero')], strict=True)
+        cli.invoke(["config", "get"], strict=True)
+        captured = capsys.readouterr()
+        lines = captured.out.splitlines()
+        for i in 'abc':
+            assert '{i}={i}'.format(i=i) in lines


### PR DESCRIPTION
Closes https://github.com/ome/omero-py/issues/120

For example, `omero load --glob /opt/omero/server/config/*.omero` will sort files `/opt/omero/server/config/*.omero` before loading them