### PR TITLE
Add numpy to requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,10 +207,10 @@ setup(
     py_modules=packageless,
     scripts=glob.glob(os.path.sep.join(["bin", "*"])),
     install_requires=[
-        'zeroc-ice>=3.6.4,<3.7',
         'future',
-        'Pillow',
         'numpy',
+        'Pillow',
+        'zeroc-ice>=3.6.4,<3.7',
     ],
     tests_require=[
         'pytest<3',

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
         'zeroc-ice>=3.6.4,<3.7',
         'future',
         'Pillow',
+        'numpy',
     ],
     tests_require=[
         'pytest<3',


### PR DESCRIPTION
Required for:
 - BlitzGateway getTile(), createImageFromNumpySeq() etc
 - webgateway: render_shape_mask() ```logger.error('No numpy installed')```

Also required for parade and tests in omero-figure etc (see Travis failure at https://github.com/ome/omero-figure/pull/354).