### PR TITLE
Disable new testLoadGlob when OMERODIR not set

### DIFF
--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -23,12 +23,14 @@
 from __future__ import unicode_literals
 from builtins import object
 import pytest
+import os
 from omero.cli import CLI
 
 cli = CLI()
 cli.loadplugins()
 commands = list(cli.controls.keys())
 topics = list(cli.topics.keys())
+OMERODIR = os.environ.get('OMERODIR', False)
 
 
 class TestBasics(object):
@@ -67,6 +69,7 @@ class TestBasics(object):
     def testVersion(object):
         cli.invoke(["version"], strict=True)
 
+    @pytest.mark.skipif(OMERODIR is False, reason="We need $OMERODIR")
     def testLoadGlob(object, tmp_path, capsys):
         for i in 'abc':
             (tmp_path / (i + 'a.omero')).write_text(

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     jinja2
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config
+    OMERODIR = /tmp
 passenv =
     PIP_CACHE_DIR
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
     jinja2
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config
-    OMERODIR = /tmp
 passenv =
     PIP_CACHE_DIR
 commands =


### PR DESCRIPTION
https://github.com/ome/omero-py/pull/14 and https://github.com/ome/omero-py/pull/137 overlapped so were not tested together.