### PR TITLE
Fix tables StringColumn unicode

### DIFF
--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -21,11 +21,11 @@ from builtins import zip
 from builtins import range
 from builtins import object
 from future.utils import native, bytes_to_native_str, isbytes
-import sys
 import omero
 import Ice
 import IceImport
 IceImport.load("omero_Tables_ice")
+sys = __import__("sys")  # Python sys
 
 try:
     import numpy

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -21,6 +21,7 @@ from builtins import zip
 from builtins import range
 from builtins import object
 from future.utils import native, bytes_to_native_str, isbytes
+import sys
 import omero
 import Ice
 import IceImport
@@ -254,9 +255,15 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
         Check for strings longer than the initialised column width
         """
         for v in self.values:
-            if len(v) > self.size:
+            if sys.version_info >= (3, 0, 0):
+                vsize = len(v.encode())
+            else:
+                vsize = len(v)
+
+            if vsize > self.size:
                 raise omero.ValidationException(
-                    None, None, "Maximum string length in column %s is %d" %
+                    None, None,
+                    "Maximum string (byte) length in column %s is %d" %
                     (self.name, self.size))
         return [self.values]
 

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -504,6 +504,9 @@ class HdfStorage(object):
     @locked
     @modifies
     def append(self, cols):
+        def _encode_string_array(sarray):
+            return [s.encode() for s in sarray]
+
         self.__initcheck()
         # Optimize!
         arrays = []
@@ -516,8 +519,37 @@ class HdfStorage(object):
                 if sz != col.getsize():
                     raise omero.ValidationException(
                         "Columns are of differing length")
-            arrays.extend(col.arrays())
-            dtypes.extend(col.dtypes())
+            # StringColumns are actually numpy dtype 'S':
+            #   "zero-terminated bytes (not recommended)"
+            # https://github.com/ome/omero-py/blob/v5.6.dev8/src/omero/columns.py#L269
+            # https://docs.scipy.org/doc/numpy-1.15.1/reference/arrays.dtypes.html#specifying-and-constructing-data-types
+            #
+            # In any case HDF5 doesn't seem to properly support unicode,
+            # and numexpr doesn't even pretend to support it:
+            #   https://github.com/PyTables/PyTables/issues/499
+            #   https://github.com/pydata/numexpr/issues/142
+            #   https://github.com/pydata/numexpr/issues/150
+            #   https://github.com/pydata/numexpr/issues/263
+            #   https://github.com/pydata/numexpr/blob/v2.7.0/numexpr/necompiler.py#L340-L341
+            #
+            # > import numexpr
+            # > a = "£"
+            # > numexpr.evaluate('a=="£"')
+            #   ValueError: unknown type str32
+            # > b = "£".encode()
+            # > numexpr.evaluate('b=="£"')
+            #   UnicodeEncodeError: 'ascii' codec can't encode character '\xa3'
+            #     in position 0: ordinal not in range(128)
+            #
+            # You should be able to store/load unicode data but you can't use
+            # unicode in a where condition
+            dtype = col.dtypes()
+            if dtype[0][1] == 'S':
+                arrays.extend(_encode_string_array(array)
+                              for array in col.arrays())
+            else:
+                arrays.extend(col.arrays())
+            dtypes.extend(dtype)
             col.append(self.__mea)  # Potential corruption !!!
 
         # Convert column-wise data to row-wise records

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -505,7 +505,9 @@ class HdfStorage(object):
     @modifies
     def append(self, cols):
         def _encode_string_array(sarray):
-            return [s.encode() for s in sarray]
+            if sys.version_info >= (3, 0, 0):
+                return [s.encode() for s in sarray]
+            return sarray
 
         self.__initcheck()
         # Optimize!

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -240,22 +240,48 @@ class TestHdfStorage(TestCase):
         hdf.cleanup()
 
     def testStringCol(self):
+        # Tables size is in bytes, len("მიკროსკოპის პონი".encode()) == 46
+        bytesize = 46
         hdf = HdfStorage(self.hdfpath(), self.lock)
-        cols = [omero.columns.StringColumnI("name", "description", 16, None)]
+        cols = [omero.columns.StringColumnI(
+            "name", "description", bytesize, None)]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
         cols[0].values = ["foo", "მიკროსკოპის პონი"]
         hdf.append(cols)
         rows = hdf.getWhereList(time.time(), '(name=="foo")', None, 'b', None,
                                 None, None)
-        assert 1 == len(rows)
-        assert 16 == hdf.readCoordinates(time.time(), [0],
-                                         self.current).columns[0].size
-        rows = hdf.getWhereList(time.time(), '(name=="მიკროსკოპის პონი")', None, 'b', None,
-                                None, None)
-        assert 1 == len(rows)
-        assert 16 == hdf.readCoordinates(time.time(), [0],
-                                         self.current).columns[0].size
+        assert rows == [0]
+        assert bytesize == hdf.readCoordinates(
+            time.time(), [0], self.current).columns[0].size
+        # Unicode conditions don't work on Python 3
+        # Fetching should still work though
+        r1 = hdf.readCoordinates(time.time(), [1], self.current)
+        assert r1.columns[0].size == bytesize
+        assert r1.columns[0].values[0] == "მიკროსკოპის პონი"
+
+        # Doesn't work yet.
+        hdf.cleanup()
+
+    @pytest.mark.xfail(reason=(
+        "Unicode conditions broken on Python 3. "
+        "See explanation in hdfstorageV2.HdfStorage.append"))
+    @pytest.mark.broken(reason="Unicode conditions broken on Python 3")
+    def testStringColWhereUnicode(self):
+        # Tables size is in bytes, len("მიკროსკოპის პონი".encode()) == 46
+        bytesize = 46
+        hdf = HdfStorage(self.hdfpath(), self.lock)
+        cols = [omero.columns.StringColumnI(
+            "name", "description", bytesize, None)]
+        hdf.initialize(cols)
+        cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
+        cols[0].values = ["foo", "მიკროსკოპის პონი"]
+        hdf.append(cols)
+        rows = hdf.getWhereList(time.time(), '(name=="მიკროსკოპის პონი")',
+                                None, 'b', None, None, None)
+        assert rows == [1]
+        assert bytesize == hdf.readCoordinates(
+            time.time(), [0], self.current).columns[0].size
         # Doesn't work yet.
         hdf.cleanup()
 

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -244,9 +244,14 @@ class TestHdfStorage(TestCase):
         cols = [omero.columns.StringColumnI("name", "description", 16, None)]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
-        cols[0].values = ["foo"]
+        cols[0].values = ["foo", "αbc"]
         hdf.append(cols)
         rows = hdf.getWhereList(time.time(), '(name=="foo")', None, 'b', None,
+                                None, None)
+        assert 1 == len(rows)
+        assert 16 == hdf.readCoordinates(time.time(), [0],
+                                         self.current).columns[0].size
+        rows = hdf.getWhereList(time.time(), '(name=="αbc")', None, 'b', None,
                                 None, None)
         assert 1 == len(rows)
         assert 16 == hdf.readCoordinates(time.time(), [0],

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -244,14 +244,14 @@ class TestHdfStorage(TestCase):
         cols = [omero.columns.StringColumnI("name", "description", 16, None)]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
-        cols[0].values = ["foo", "αbc"]
+        cols[0].values = ["foo", "მიკროსკოპის პონი"]
         hdf.append(cols)
         rows = hdf.getWhereList(time.time(), '(name=="foo")', None, 'b', None,
                                 None, None)
         assert 1 == len(rows)
         assert 16 == hdf.readCoordinates(time.time(), [0],
                                          self.current).columns[0].size
-        rows = hdf.getWhereList(time.time(), '(name=="αbc")', None, 'b', None,
+        rows = hdf.getWhereList(time.time(), '(name=="მიკროსკოპის პონი")', None, 'b', None,
                                 None, None)
         assert 1 == len(rows)
         assert 16 == hdf.readCoordinates(time.time(), [0],


### PR DESCRIPTION
Replacement for https://github.com/ome/omero-py/pull/133

See comment in hdfstorageV2.HdfStorage.append (https://github.com/ome/omero-py/commit/9e1d8e00873f76a2a2972a0c96de1494639c9c48) for the full explanation

Probably needs a doc update to say string column sizes must be given as the number of bytes not the number of unicode characters.