### PR TITLE
Retry flakey tests up to 5 times

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     py27: tables < 3.6.0
     py36: tables
     py37: tables
+    pytest-rerunfailures
     pytest-sugar
     pytest-xdist
     restructuredtext-lint
@@ -30,4 +31,4 @@ passenv =
 commands =
     rst-lint README.rst
     python setup.py install
-    pytest {posargs:-n4 -m "not broken" -rf test}
+    pytest {posargs:-n4 -m "not broken" --reruns 5 -rf test}


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-rerunfailures
Since this doesn't use test markers it's an optional dependency (omit `--reruns 5`)

Example output after adding this to `testStringCol`:
```python
        import random
        if random.random() < 0.8:
            assert False
```

```
$ pytest -vs --reruns 5 test/unit/tablestest/test_hdfstorage.py
...
test/unit/tablestest/test_hdfstorage.py::TestHdfStorage::testStringCol RERUN
test/unit/tablestest/test_hdfstorage.py::TestHdfStorage::testStringCol RERUN
test/unit/tablestest/test_hdfstorage.py::TestHdfStorage::testStringCol RERUN
test/unit/tablestest/test_hdfstorage.py::TestHdfStorage::testStringCol RERUN
test/unit/tablestest/test_hdfstorage.py::TestHdfStorage::testStringCol PASSED
...
================ 14 passed, 2 xfailed, 4 rerun in 1.82 seconds =================
```