### PR TITLE
StringColumn: Handle all encoding inside class

### DIFF
--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -241,6 +241,32 @@ class LongColumnI(AbstractColumn, omero.grid.LongColumn):
 
 
 class StringColumnI(AbstractColumn, omero.grid.StringColumn):
+    """
+    StringColumns are actually numpy dtype 'S':
+      "zero-terminated bytes (not recommended)"
+    https://github.com/ome/omero-py/blob/v5.6.dev8/src/omero/columns.py#L269
+    https://docs.scipy.org/doc/numpy-1.15.1/reference/arrays.dtypes.html#specifying-and-constructing-data-types
+
+    In any case HDF5 doesn't seem to properly support unicode,
+    and numexpr doesn't even pretend to support it:
+      https://github.com/PyTables/PyTables/issues/499
+      https://github.com/pydata/numexpr/issues/142
+      https://github.com/pydata/numexpr/issues/150
+      https://github.com/pydata/numexpr/issues/263
+      https://github.com/pydata/numexpr/blob/v2.7.0/numexpr/necompiler.py#L340-L341
+
+    > import numexpr
+    > a = "£"
+    > numexpr.evaluate('a=="£"')
+    ValueError: unknown type str32
+    > b = "£".encode()
+    > numexpr.evaluate('b=="£"')
+    UnicodeEncodeError: 'ascii' codec can't encode character '\xa3'
+        in position 0: ordinal not in range(128)
+
+    You should be able to store/load unicode data but you can't use
+    unicode in a where condition
+    """
 
     def __init__(self, name="Unknown", *args):
         omero.grid.StringColumn.__init__(self, name, *args)
@@ -253,19 +279,19 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
     def arrays(self):
         """
         Check for strings longer than the initialised column width
+        This will always return bytes
         """
-        for v in self.values:
-            if sys.version_info >= (3, 0, 0):
-                vsize = len(v.encode())
-            else:
-                vsize = len(v)
-
-            if vsize > self.size:
+        if sys.version_info >= (3, 0, 0):
+            bytevalues = [v.encode() for v in self.values]
+        else:
+            bytevalues = self.values
+        for bv in bytevalues:
+            if len(bv) > self.size:
                 raise omero.ValidationException(
                     None, None,
                     "Maximum string (byte) length in column %s is %d" %
                     (self.name, self.size))
-        return [self.values]
+        return [bytevalues]
 
     def dtypes(self):
         """

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -25,7 +25,7 @@ import omero
 import Ice
 import IceImport
 IceImport.load("omero_Tables_ice")
-sys = __import__("sys")  # Python sys
+python_sys = __import__("sys")  # Python sys
 
 try:
     import numpy
@@ -281,7 +281,7 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
         Check for strings longer than the initialised column width
         This will always return bytes
         """
-        if sys.version_info >= (3, 0, 0):
+        if python_sys.version_info >= (3, 0, 0):
             bytevalues = [v.encode() for v in self.values]
         else:
             bytevalues = self.values

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -504,11 +504,6 @@ class HdfStorage(object):
     @locked
     @modifies
     def append(self, cols):
-        def _encode_string_array(sarray):
-            if sys.version_info >= (3, 0, 0):
-                return [s.encode() for s in sarray]
-            return sarray
-
         self.__initcheck()
         # Optimize!
         arrays = []
@@ -521,37 +516,8 @@ class HdfStorage(object):
                 if sz != col.getsize():
                     raise omero.ValidationException(
                         "Columns are of differing length")
-            # StringColumns are actually numpy dtype 'S':
-            #   "zero-terminated bytes (not recommended)"
-            # https://github.com/ome/omero-py/blob/v5.6.dev8/src/omero/columns.py#L269
-            # https://docs.scipy.org/doc/numpy-1.15.1/reference/arrays.dtypes.html#specifying-and-constructing-data-types
-            #
-            # In any case HDF5 doesn't seem to properly support unicode,
-            # and numexpr doesn't even pretend to support it:
-            #   https://github.com/PyTables/PyTables/issues/499
-            #   https://github.com/pydata/numexpr/issues/142
-            #   https://github.com/pydata/numexpr/issues/150
-            #   https://github.com/pydata/numexpr/issues/263
-            #   https://github.com/pydata/numexpr/blob/v2.7.0/numexpr/necompiler.py#L340-L341
-            #
-            # > import numexpr
-            # > a = "£"
-            # > numexpr.evaluate('a=="£"')
-            #   ValueError: unknown type str32
-            # > b = "£".encode()
-            # > numexpr.evaluate('b=="£"')
-            #   UnicodeEncodeError: 'ascii' codec can't encode character '\xa3'
-            #     in position 0: ordinal not in range(128)
-            #
-            # You should be able to store/load unicode data but you can't use
-            # unicode in a where condition
-            dtype = col.dtypes()
-            if dtype[0][1] == 'S':
-                arrays.extend(_encode_string_array(array)
-                              for array in col.arrays())
-            else:
-                arrays.extend(col.arrays())
-            dtypes.extend(dtype)
+            arrays.extend(col.arrays())
+            dtypes.extend(col.dtypes())
             col.append(self.__mea)  # Potential corruption !!!
 
         # Convert column-wise data to row-wise records

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -284,7 +284,7 @@ class TestHdfStorage(TestCase):
 
     @pytest.mark.xfail(reason=(
         "Unicode conditions broken on Python 3. "
-        "See explanation in hdfstorageV2.HdfStorage.append"))
+        "See explanation in omero.columns.StringColumnI"))
     @pytest.mark.broken(reason="Unicode conditions broken on Python 3")
     def testStringColWhereUnicode(self):
         # Tables size is in bytes, len("მიკროსკოპის პონი".encode()) == 46


### PR DESCRIPTION
Clean-up https://github.com/ome/omero-py/pull/143 by moving all changes into `StringColumnI`