### PR TITLE
wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
         'future',
         'numpy',
         'Pillow',
+        'wheel',
         'zeroc-ice>=3.6.4,<3.7',
     ],
     tests_require=[


### PR DESCRIPTION
add wheel to requirement
Following comment https://forum.image.sc/t/omero-python-3-5-6-milestone-for-upgrade-testing/32120/2
I had a closer look at the log of omero-install. I could see error like ```invalid command 'bdist_wheel'``` when installing omero-py (same for omero-web) on all OS


Check that you cannot see the error in the travis log with this PR

 