### PR TITLE
Ignore OMERO_HOME in bin/omero with warning

### DIFF
--- a/bin/omero
+++ b/bin/omero
@@ -95,6 +95,7 @@ try:
     try:
         import omero.cli
     except ImportError as ie:
+        OMERODIR = os.environ.get('OMERODIR', None)
         print("*"*80)
         print("""
         ERROR: Could not import omero.cli! (%s)
@@ -115,9 +116,11 @@ try:
         --------------
         CWD=%s
         VERSION=%s
-        dist=%s
+        OMERO_EXE=%s
+        OMERODIR=%s
         PYTHONPATH=%s
-        """ % (os.getcwd(), sys.version.replace("\n"," "), top, sys.path))
+        """ % (os.getcwd(), sys.version.replace("\n", " "), top,
+               OMERODIR, sys.path))
         sys.exit(2)
 
     logging.basicConfig(level=logging.WARN)

--- a/bin/omero
+++ b/bin/omero
@@ -59,18 +59,11 @@ def readlink(file=sys.argv[0]):
     file = os.path.abspath(file)
     return file
 
-omero_home = None
 if "OMERO_HOME" in os.environ:
-    omero_home = os.environ["OMERO_HOME"]
-    if not os.path.exists(omero_home):
-        print("OMERO_HOME=%s cannot be found" % omero_home)
-        sys.exit(3)
+    print("WARN: OMERO_HOME usage is deprecated in omero-py")
 
-if omero_home:
-    top = omero_home
-else:
-    exe = readlink()
-    top = os.path.join(exe, os.pardir, os.pardir)
+exe = readlink()
+top = os.path.join(exe, os.pardir, os.pardir)
 
 #
 # This list needs to be kept in line with omero.cli.CLI._env

--- a/bin/omero
+++ b/bin/omero
@@ -60,7 +60,7 @@ def readlink(file=sys.argv[0]):
     return file
 
 if "OMERO_HOME" in os.environ:
-    print("WARN: OMERO_HOME usage is deprecated in omero-py")
+    print("WARN: OMERO_HOME usage is ignored in omero-py")
 
 exe = readlink()
 top = os.path.join(exe, os.pardir, os.pardir)

--- a/bin/omero
+++ b/bin/omero
@@ -115,9 +115,9 @@ try:
         --------------
         CWD=%s
         VERSION=%s
-        OMERO_HOME=%s
+        dist=%s
         PYTHONPATH=%s
-        """ % (os.getcwd(), sys.version.replace("\n"," "), omero_home, sys.path))
+        """ % (os.getcwd(), sys.version.replace("\n"," "), top, sys.path))
         sys.exit(2)
 
     logging.basicConfig(level=logging.WARN)


### PR DESCRIPTION
See https://forum.image.sc/t/omero-python-3-5-6-milestone-for-upgrade-testing/32120/3

OMERO_HOME shouldn't be used any more, but we still try to read it.
This now ignores OMERO_HOME (but prints a warning that it is being ignored).

To test:
 ```
$ export OMERO_HOME=/path/to/somewhere
# any omero command
$ omero -h
WARN: OMERO_HOME usage is deprecated in omero-py
```
