### PR TITLE
CmdError: implement __str__

### DIFF
--- a/src/omero/__init__.py
+++ b/src/omero/__init__.py
@@ -85,6 +85,12 @@ class CmdError(ClientError):
         ClientError.__init__(self, *args, **kwargs)
         self.err = err
 
+    def __str__(self):
+        sb = ClientError.__str__(self)
+        sb += "\n"
+        sb += str(self.err)
+        return sb
+
 
 class UnloadedEntityException(ClientError):
     pass


### PR DESCRIPTION
Provide a better representation of the CmdError instance
even without unwrapping the `err` instance.

transfered from: https://github.com/ome/openmicroscopy/pull/6091
----

# Testing this PR

```
$ bin/omero shell --login
import omero
import omero.all
fp = omero.cmd.FindChildren()
h = client.submit(fp)
# Manually check h.getResponse()
print(str(omero.CmdError(h.getResponse())))
```