### PR TITLE
Bump to blitz 5.5.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ except ImportError:
 
 def get_blitz_location():
 
-    config_blitz_version = "5.5.4"
+    config_blitz_version = "5.5.5"
 
     # simplified strings
     defaultsect = configparser.DEFAULTSECT


### PR DESCRIPTION
see https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-python-superbuild-push/216/console

The version updating in devspace _should_ have corrected for this.