### PR TITLE
prefs.py: config throw if OMERODIR not set

### DIFF
--- a/src/omero/plugins/prefs.py
+++ b/src/omero/plugins/prefs.py
@@ -66,6 +66,9 @@ def getprefs(args, dir):
 
 def _make_open_and_close_config(func, allow_readonly):
     def open_and_close_config(*args, **kwargs):
+        if not os.environ.get('OMERODIR'):
+            raise Exception('OMERODIR not set')
+
         args = list(args)
         self = args[0]
         argp = args[1]


### PR DESCRIPTION
Partial fix for https://github.com/ome/omero-py/issues/159
This throws an exception. Ideally it'll be caught and wrapped into a nice error message in the CLI plugins but I this is at least better than nothing.