### PR TITLE
import --fetch-jars

### DIFF
--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -106,7 +106,7 @@ SKIP_CHOICES = ['all', 'checksum', 'minmax', 'thumbnails', 'upgrade']
 NO_ARG = object()
 
 OMERO_JAVA_ZIP = (
-    'https://downloads.openmicroscopy.org/omero/latest/OMERO.java.zip'
+    'https://downloads.openmicroscopy.org/omero/{version}/OMERO.java.zip'
 )
 
 
@@ -326,8 +326,8 @@ class ImportControl(BaseControl):
             help="Path to a logback xml file. "
             " Default: etc/logback-cli.xml")
         add_python_argument(
-            "--fetch-jars", action="store_true",
-            help="Download OMERO.java jars")
+            "--fetch-jars", type=str,
+            help="Download this version of OMERO.java jars")
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
@@ -502,7 +502,7 @@ class ImportControl(BaseControl):
         if args.fetch_jars:
             if args.path:
                 self.ctx.err('WARNING: Ignoring extra arguments')
-            self.download_omero_java()
+            self.download_omero_java(args.fetch_jars)
             return
 
         if args.clientdir:
@@ -555,12 +555,13 @@ class ImportControl(BaseControl):
         else:
             return None, omero_java_txt
 
-    def download_omero_java(self):
-        self.ctx.err("Downloading %s" % OMERO_JAVA_ZIP)
+    def download_omero_java(self, version):
+        omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
+        self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         if not jars_dir.exists():
             jars_dir.mkdir()
-        resp = urlopen(OMERO_JAVA_ZIP)
+        resp = urlopen(omero_java_zip)
         zipfile = ZipFile(BytesIO(resp.read()))
         topdirs = set(f.filename.split(
             os.path.sep)[0] for f in zipfile.filelist if f.is_dir())

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -41,7 +41,7 @@ from zipfile import ZipFile
 
 from omero.cli import BaseControl, CLI
 import omero.java
-from omero.util import get_omero_userdir
+from omero.util import get_omero_user_cache_dir
 from omero_ext.argparse import SUPPRESS
 from omero_ext.path import path
 
@@ -545,7 +545,7 @@ class ImportControl(BaseControl):
             self.do_import(command_args, xargs)
 
     def _userdir_jars(self, parentonly=False):
-        user_jars = get_omero_userdir() / 'jars'
+        user_jars = get_omero_user_cache_dir() / 'jars'
         # Use this file instead of a symlink so it works on all platform
         omero_java_txt = user_jars / 'OMERO.java.txt'
         if parentonly:

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -515,7 +515,6 @@ class ImportControl(BaseControl):
             xml_file = path(args.logback)
         else:
             xml_file = old_div(etc_dir, "logback-cli.xml")
-        logback = "-Dlogback.configurationFile=%s" % xml_file
 
         classpath = []
         if client_dir and client_dir.exists():
@@ -523,10 +522,14 @@ class ImportControl(BaseControl):
         if auto_download:
             if classpath:
                 self.ctx.err('Using {}'.format(omero_java_txt.text()))
+                if not args.logback:
+                    xml_file = client_dir / "logback-cli.xml"
         else:
             if not classpath:
                 self.ctx.die(
                     103, "No JAR files found under '%s'" % client_dir)
+
+        logback = "-Dlogback.configurationFile=%s" % xml_file
         return classpath, logback
 
     def importer(self, args):

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -327,7 +327,7 @@ class ImportControl(BaseControl):
             " Default: etc/logback-cli.xml")
         add_python_argument(
             "--fetch-jars", type=str,
-            help="Download this version of OMERO.java jars")
+            help="Download this version of OMERO.java jars and exit")
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -561,23 +561,23 @@ class ImportControl(BaseControl):
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         if not jars_dir.exists():
             jars_dir.mkdir()
-        resp = urlopen(omero_java_zip)
-        zipfile = ZipFile(BytesIO(resp.read()))
-        topdirs = set(f.filename.split(
-            os.path.sep)[0] for f in zipfile.filelist if f.is_dir())
-        if len(topdirs) != 1:
-            self.ctx.die(
-                108, 'Expected one top directory in OMERO.java.zip: {}'.format(
-                    topdirs))
-        topdir = topdirs.pop()
-        if os.path.isabs(topdir):
-            self.ctx.die(
-                108, 'Unexpected absolute paths in OMERO.java.zip: {}'.format(
-                    topdir))
-        zipfile.extractall(jars_dir)
-        zipfile.close()
-        omero_java_txt.write_text(topdir)
-        resp.close()
+        with urlopen(omero_java_zip) as resp:
+            with ZipFile(BytesIO(resp.read())) as zipfile:
+                topdirs = set(f.filename.split(
+                    os.path.sep)[0] for f in zipfile.filelist if f.is_dir())
+                if len(topdirs) != 1:
+                    self.ctx.die(
+                        108,
+                        'Expected one top directory in OMERO.java.zip: {}'
+                        .format(topdirs))
+                topdir = topdirs.pop()
+                if os.path.isabs(topdir):
+                    self.ctx.die(
+                        108,
+                        'Unexpected absolute paths in OMERO.java.zip: {}'
+                        .format(topdir))
+                zipfile.extractall(jars_dir)
+                omero_java_txt.write_text(topdir)
 
     def do_import(self, command_args, xargs, mode="w"):
         out = err = None

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -112,8 +112,8 @@ SKIP_CHOICES = ['all', 'checksum', 'minmax', 'thumbnails', 'upgrade']
 NO_ARG = object()
 
 OMERO_JAVA_ZIP = (
-    'https://downloads.openmicroscopy.org/omero/5.6.0-m5/artifacts/'
-    'OMERO.java-5.6.0-m5-ice36-b129.zip'
+    'https://downloads.openmicroscopy.org/omero/5.6.1/artifacts/'
+    'OMERO.java-5.6.1-ice36-b225.zip'
 )
 
 

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -841,6 +841,11 @@ def get_omero_userdir():
         return old_div(path.path(get_user_dir()), "omero")
 
 
+def get_omero_user_cache_dir():
+    """Returns the OMERO user cache directory"""
+    return get_omero_userdir()
+
+
 def get_user_dir():
     exceptions_to_handle = (ImportError)
     try:

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -73,11 +73,12 @@ class TestImport(object):
         self.args = ["import"]
 
     def add_client_dir(self):
-        dist_dir = path(OMERODIR)
-        client_dir = dist_dir / "lib" / "client"
-        logback = dist_dir / "etc" / "logback-cli.xml"
-        self.args += ["--clientdir", client_dir]
-        self.args += ["--logback", logback]
+        if OMERODIR is not False:
+            dist_dir = path(OMERODIR)
+            client_dir = dist_dir / "lib" / "client"
+            logback = dist_dir / "etc" / "logback-cli.xml"
+            self.args += ["--clientdir", client_dir]
+            self.args += ["--logback", logback]
 
     def mkdir(self, parent, name, with_ds_store=False):
         child = old_div(parent, name)
@@ -166,7 +167,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize("data", (("1", False), ("3", True)))
     def testImportDepth(self, tmpdir, capfd, data):
         """Test import using depth argument"""
@@ -195,7 +195,6 @@ class TestImport(object):
             with pytest.raises(NonZeroReturnCode):
                 f()
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testImportFakeImage(self, tmpdir, capfd):
         """Test fake image import"""
 
@@ -214,7 +213,6 @@ class TestImport(object):
         assert outputlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('params', (
         ("-l", "only_fakes.txt", True),
         ("-l", "no_fakes.txt", False),
@@ -247,7 +245,6 @@ class TestImport(object):
             o, e = capfd.readouterr()
             assert "parsed into 0 group" in e
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('with_ds_store', (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
         """Test fake screen import"""
@@ -270,7 +267,6 @@ class TestImport(object):
         for i in range(len(fieldfiles)):
             assert outputlines[-1-len(fieldfiles)+i] == str(fieldfiles[i])
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testImportPattern(self, tmpdir, capfd):
         """Test pattern import"""
 
@@ -318,7 +314,6 @@ class TestImport(object):
         expected_args += ['test.fake']
         assert command_args.java_args() == expected_args
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testLogPrefix(self, tmpdir, capfd):
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')
@@ -340,7 +335,6 @@ class TestImport(object):
         assert outlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testYamlOutput(self, tmpdir, capfd):
 
         import yaml
@@ -368,7 +362,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkSimple(self):
         t = path(__file__).parent / "bulk_import" / "test_simple"
         b = old_div(t, "bulk.yml")
@@ -377,7 +370,6 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkInclude(self):
         t = path(__file__).parent / "bulk_import" / "test_include" / "inner"
         b = old_div(t, "bulk.yml")
@@ -386,7 +378,6 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkName(self):
         # Metadata provided in the yml file will be applied
         # to the args
@@ -402,7 +393,6 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkCols(self):
         # Metadata provided about the individual columns in
         # the tsv will be used.
@@ -430,7 +420,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkDry(self, capfd):
         t = path(__file__).parent / "bulk_import" / "test_dryrun"
         b = old_div(t, "bulk.yml")
@@ -441,7 +430,6 @@ class TestImport(object):
         o, e = capfd.readouterr()
         assert o == '"--name=no-op" "1.fake"\n'
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkJavaArgs(self):
         """Test Java arguments"""
         t = path(__file__).parent / "bulk_import" / "test_javaargs"
@@ -461,7 +449,6 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('skip', plugin.SKIP_CHOICES)
     def testBulkSkip(self, skip):
         """Test skip arguments"""

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -19,6 +19,7 @@ from builtins import object
 from past.utils import old_div
 import os
 import pytest
+import sys
 from omero_ext.path import path
 import omero.clients
 import uuid
@@ -167,6 +168,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize("data", (("1", False), ("3", True)))
     def testImportDepth(self, tmpdir, capfd, data):
         """Test import using depth argument"""
@@ -195,6 +197,7 @@ class TestImport(object):
             with pytest.raises(NonZeroReturnCode):
                 f()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testImportFakeImage(self, tmpdir, capfd):
         """Test fake image import"""
 
@@ -213,6 +216,7 @@ class TestImport(object):
         assert outputlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('params', (
         ("-l", "only_fakes.txt", True),
         ("-l", "no_fakes.txt", False),
@@ -245,6 +249,7 @@ class TestImport(object):
             o, e = capfd.readouterr()
             assert "parsed into 0 group" in o
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('with_ds_store', (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
         """Test fake screen import"""
@@ -267,6 +272,7 @@ class TestImport(object):
         for i in range(len(fieldfiles)):
             assert outputlines[-1-len(fieldfiles)+i] == str(fieldfiles[i])
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testImportPattern(self, tmpdir, capfd):
         """Test pattern import"""
 
@@ -314,6 +320,7 @@ class TestImport(object):
         expected_args += ['test.fake']
         assert command_args.java_args() == expected_args
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testLogPrefix(self, tmpdir, capfd):
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')
@@ -335,6 +342,7 @@ class TestImport(object):
         assert outlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testYamlOutput(self, tmpdir, capfd):
 
         import yaml
@@ -364,6 +372,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkSimple(self):
         t = path(__file__).parent / "bulk_import" / "test_simple"
         b = old_div(t, "bulk.yml")
@@ -372,6 +381,7 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkInclude(self):
         t = path(__file__).parent / "bulk_import" / "test_include" / "inner"
         b = old_div(t, "bulk.yml")
@@ -380,6 +390,7 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkName(self):
         # Metadata provided in the yml file will be applied
         # to the args
@@ -395,6 +406,7 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkCols(self):
         # Metadata provided about the individual columns in
         # the tsv will be used.
@@ -422,6 +434,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkDry(self, capfd):
         t = path(__file__).parent / "bulk_import" / "test_dryrun"
         b = old_div(t, "bulk.yml")
@@ -432,6 +445,7 @@ class TestImport(object):
         o, e = capfd.readouterr()
         assert o == '"--name=no-op" "1.fake"\n'
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkJavaArgs(self):
         """Test Java arguments"""
         t = path(__file__).parent / "bulk_import" / "test_javaargs"
@@ -451,6 +465,7 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('skip', plugin.SKIP_CHOICES)
     def testBulkSkip(self, skip):
         """Test skip arguments"""

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -41,6 +41,21 @@ OMERODIR = False
 if 'OMERODIR' in os.environ:
     OMERODIR = os.environ.get('OMERODIR')
 
+
+@pytest.fixture(scope="session")
+def omero_userdir_tmpdir(tmpdir_factory):
+    # If OMERO_USERDIR is set assume user wants to use it for tests
+    # Otherwise avoid modifying the default userdir
+    if os.getenv("OMERO_USERDIR"):
+        return os.getenv("OMERO_USERDIR")
+    return str(tmpdir_factory.mktemp('omero_userdir'))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def omero_userdir(monkeypatch, omero_userdir_tmpdir):
+    monkeypatch.setenv("OMERO_USERDIR", omero_userdir_tmpdir)
+
+
 class MockClient(omero.clients.BaseClient):
 
     def setSessionId(self, uuid):

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -334,7 +334,7 @@ class TestImport(object):
 
         o, e = capfd.readouterr()
         assert o == ""
-        assert e == ""
+        assert (e == "" or e.startswith('Using OMERO.java-'))
 
         outlines = prefix.join("out").read().split("\n")
         reader = 'loci.formats.in.FakeReader'

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -243,7 +243,7 @@ class TestImport(object):
             with pytest.raises(NonZeroReturnCode):
                 self.cli.invoke(self.args, strict=True)
             o, e = capfd.readouterr()
-            assert "parsed into 0 group" in e
+            assert "parsed into 0 group" in o
 
     @pytest.mark.parametrize('with_ds_store', (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
@@ -347,7 +347,9 @@ class TestImport(object):
         self.cli.invoke(self.args, strict=True)
 
         o, e = capfd.readouterr()
-        result = yaml.safe_load(StringIO(o))
+        # o also contains loads of preceding log output, strip this off
+        yamlout = o[o.find('---'):]
+        result = yaml.safe_load(StringIO(yamlout))
         result = result[0]
         assert "fake" in result["group"]
         assert 1 == len(result["files"])
@@ -385,7 +387,7 @@ class TestImport(object):
         b = old_div(t, "bulk.yml")
 
         class MockImportControl(ImportControl):
-            def do_import(self, command_args, xargs):
+            def do_import(self, command_args, xargs, mode):
                 assert "--name=testname" in command_args.java_args()
         self.cli.register("mock-import", MockImportControl, "HELP")
 
@@ -400,7 +402,7 @@ class TestImport(object):
         b = old_div(t, "bulk.yml")
 
         class MockImportControl(ImportControl):
-            def do_import(self, command_args, xargs):
+            def do_import(self, command_args, xargs, mode):
                 cmd = command_args.java_args()
                 assert "--name=meta_one" in cmd or \
                        "--name=meta_two" in cmd
@@ -436,7 +438,7 @@ class TestImport(object):
         b = old_div(t, "bulk.yml")
 
         class MockImportControl(ImportControl):
-            def do_import(self, command_args, xargs):
+            def do_import(self, command_args, xargs, mode):
                 assert ("--checksum-algorithm=File-Size-64" in
                         command_args.java_args())
                 assert "--parallel-upload=10" in command_args.java_args()
@@ -456,7 +458,7 @@ class TestImport(object):
         b = t / "%s.yml" % skip
 
         class MockImportControl(ImportControl):
-            def do_import(self, command_args, xargs):
+            def do_import(self, command_args, xargs, mode):
                 if skip in ["all", "checksum"]:
                     assert ("--checksum-algorithm=File-Size-64" in
                             command_args.java_args())

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pytest-rerunfailures
     pytest-xdist
     restructuredtext-lint
-    py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    py36: https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
     py37: zeroc-ice
     py37-win: pywin32
     mox3

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,7 @@ deps =
     pytest-rerunfailures
     pytest-xdist
     restructuredtext-lint
-    py36: https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
-    py37: zeroc-ice
+    zeroc-ice
     py37-win: pywin32
     mox3
     jinja2


### PR DESCRIPTION
Thought I'd see how difficult it is to automatically fetch the jars....

```
$ rm -rf ~/omero/jars/

$ omero import test.fake
Downloading https://downloads.openmicroscopy.org/omero/latest/OMERO.java.zip

... import as normal...
```

Closes https://github.com/ome/omero-py/pull/161