### PR TITLE
fix doc

### DIFF
--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -125,8 +125,8 @@ Other sessions commands:
 
     # List or change the timeToLive for the session
     $ omero sessions timeout
-    $ omero sessions timeout 300.0 # Seconds
-    $ omero sessions timeout 300.0 --session=$UUID
+    $ omero sessions timeout 300 # Seconds
+    $ omero sessions timeout 300 --session=$UUID
 
 Custom sessions directory:
 


### PR DESCRIPTION
running ```omero sessions timeout 300.0 --session=key``` returns ```invalid int value: '300.0'```

This PR fixes the help