### PR TITLE
Use http for downloads url for gateway_tests

### DIFF
--- a/src/omero/gateway/scripts/dbhelpers.py
+++ b/src/omero/gateway/scripts/dbhelpers.py
@@ -22,7 +22,7 @@ except ImportError:
 from omero_ext.path import path
 
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
-TESTIMG_URL = 'https://downloads.openmicroscopy.org/images/gateway_tests/'
+TESTIMG_URL = 'http://downloads.openmicroscopy.org/images/gateway_tests/'
 DEFAULT_GROUP_PERMS = 'rwr---'
 
 if not omero.gateway.BlitzGateway.ICE_CONFIG:

--- a/src/omero/gateway/scripts/dbhelpers.py
+++ b/src/omero/gateway/scripts/dbhelpers.py
@@ -22,7 +22,7 @@ except ImportError:
 from omero_ext.path import path
 
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
-TESTIMG_URL = 'http://downloads.openmicroscopy.org/images/gateway_tests/'
+TEST_IMG_URL = 'http://downloads.openmicroscopy.org/images/gateway_tests/'
 DEFAULT_GROUP_PERMS = 'rwr---'
 
 if not omero.gateway.BlitzGateway.ICE_CONFIG:
@@ -421,10 +421,10 @@ class ImageEntry (ObjectEntry):
             else:
                 # First try to download the image
                 try:
-                    # print "Trying to get test image from " + TESTIMG_URL +
+                    # print "Trying to get test image from " + TEST_IMG_URL +
                     # self.filename
                     sys.stderr.write('<')
-                    fin = urllib.request.urlopen(TESTIMG_URL + self.filename)
+                    fin = urllib.request.urlopen(TEST_IMG_URL + self.filename)
                     with open(fpath, 'wb') as fout:
                         fout.write(fin.read())
                 except urllib.error.HTTPError:


### PR DESCRIPTION
Currently, over 60 tests are failing with:
```
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:877)
``` 
See https://latest-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/247/testReport/

This workaround doesn't fix the underlying issue but should allow us to reduce the noise and get the integration tests green (or identify other failures).