### PR TITLE
omero db password should be a string

### DIFF
--- a/src/omero/plugins/db.py
+++ b/src/omero/plugins/db.py
@@ -147,7 +147,7 @@ class DatabaseControl(BaseControl):
         value = p.communicate()[0]
         if not value or len(value) == 0:
             self.ctx.die(100, "Encoded password is empty")
-        return value.strip()
+        return value.strip().decode()
 
     def _copy(self, input_path, output, func, cfg=None):
             try:

--- a/src/omero/plugins/db.py
+++ b/src/omero/plugins/db.py
@@ -143,7 +143,8 @@ class DatabaseControl(BaseControl):
         rc = p.wait()
         if rc != 0:
             out, err = p.communicate()
-            self.ctx.die(rc, "PasswordUtil failed: %s" % err)
+            self.ctx.die(rc, "PasswordUtil failed: %s" % err.decode(
+                errors='replace'))
         value = p.communicate()[0]
         if not value or len(value) == 0:
             self.ctx.die(100, "Encoded password is empty")


### PR DESCRIPTION
Closes https://github.com/ome/omero-py/issues/112

Testing: `omero db password` should output a valid psql string