### PR TITLE
download: Check for null file size

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -944,7 +944,14 @@ class BaseClient(object):
             ofile = self.__sf.getQueryService().get(
                 "OriginalFile", ofile.id.val, ctx)
 
-            if ofile.size is not None and block_size > ofile.size.val:
+            if ofile.size is None:
+                name = omero.rtypes.unwrap(ofile.name)
+                mimetype = omero.rtypes.unwrap(ofile.mimetype)
+                raise omero.ClientError(
+                    ("invalid size for OriginalFile '%s' "
+                     "(mimetype:%s)") % (name, mimetype))
+
+            if block_size > ofile.size.val:
                 block_size = ofile.size.val
 
             prx.setFileId(ofile.id.val, ctx)

--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -944,7 +944,7 @@ class BaseClient(object):
             ofile = self.__sf.getQueryService().get(
                 "OriginalFile", ofile.id.val, ctx)
 
-            if block_size > ofile.size.val:
+            if ofile.size is not None and block_size > ofile.size.val:
                 block_size = ofile.size.val
 
             prx.setFileId(ofile.id.val, ctx)

--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -81,6 +81,8 @@ class DownloadControl(BaseControl):
                 sys.stdout.flush()
             else:
                 client.download(orig_file, target_file)
+        except omero.ClientError as ce:
+            self.ctx.die(67, "ClientError: %s" % ce)
         except omero.ValidationException as ve:
             # Possible, though unlikely after previous check
             self.ctx.die(67, "Unknown ValidationException: %s"


### PR DESCRIPTION
If an unexpected download ID is given, the client can fail with:

```
$ omero download 123456 my.ome.tif
...
Traceback (most recent call last):
  File "OMERO/bin/omero", line 130, in <module>
    rv = omero.cli.argv()
  File "OMERO/lib/python/omero/cli.py", line 1620, in argv
    cli.invoke(args[1:])
  File "OMERO/lib/python/omero/cli.py", line 1095, in invoke
    stop = self.onecmd(line, previous_args)
  File "OMERO/lib/python/omero/cli.py", line 1172, in onecmd
    self.execute(line, previous_args)
  File "OMERO/lib/python/omero/cli.py", line 1254, in execute
    args.func(args)
  File "OMERO/lib/python/omero/plugins/download.py", line 66, in __call__
    client.download(orig_file, target_file)
  File "OMERO/lib/python/omero/clients.py", line 863, in download
    if block_size > ofile.size.val:
```

(line numbers are from 5.4.10)

cc: @chris-allan 