### PR TITLE
Get file size for download from the RawFileStore instead of the DB

### DIFF
--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -81,6 +81,8 @@ class DownloadControl(BaseControl):
                 sys.stdout.flush()
             else:
                 client.download(orig_file, target_file)
+        except omero.ClientError as ce:
+            self.ctx.die(67, "ClientError: %s" % ce)
         except omero.ValidationException as ve:
             # Possible, though unlikely after previous check
             self.ctx.die(67, "Unknown ValidationException: %s"


### PR DESCRIPTION
Similar to https://github.com/ome/omero-py/pull/180
This PR is to fix the issue where attempting to download a file with a null size in `originalfile` table results in the following:
```Traceback (most recent call last):
  File "OMERO/bin/omero", line 130, in <module>
    rv = omero.cli.argv()
  File "OMERO/lib/python/omero/cli.py", line 1620, in argv
    cli.invoke(args[1:])
  File "OMERO/lib/python/omero/cli.py", line 1095, in invoke
    stop = self.onecmd(line, previous_args)
  File "OMERO/lib/python/omero/cli.py", line 1172, in onecmd
    self.execute(line, previous_args)
  File "OMERO/lib/python/omero/cli.py", line 1254, in execute
    args.func(args)
  File "OMERO/lib/python/omero/plugins/download.py", line 66, in __call__
    client.download(orig_file, target_file)
  File "OMERO/lib/python/omero/clients.py", line 863, in download
    if block_size > ofile.size.val:
```
If, however, we retrieve the size from the RawFileStore instead of the DB record, we can get a size for the file even if the DB field is null. 