### PR TITLE
Auto-format code with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/ambv/black
+  rev: 19.10b0
+  hooks:
+  - id: black
+    # default black line length is 88
+    args: [--target-version=py35, --line-length=80]
+# pre-commit doesn't support flake8<3.7.0
+# - repo: https://gitlab.com/pycqa/flake8
+#   rev: 3.7.9
+#   hooks:
+#   - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 jobs:
   include:
+    - name: lint
+      script:
+        - pip install pre-commit
+        - pre-commit run --all-files
     - name: Windows
       os: windows
       language: sh

--- a/bin/omero
+++ b/bin/omero
@@ -17,6 +17,7 @@ import stat
 import sys
 
 import warnings
+
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 # Assuming a CLI user never wants to see development details
 # such as code that has been deprecated.
@@ -30,7 +31,10 @@ def not_root():
     try:
         euid = os.geteuid()
         if euid == 0:
-            print("FATAL: Running %s as root can corrupt your directory permissions." % sys.argv[0])
+            print(
+                "FATAL: Running %s as root can corrupt your directory permissions."
+                % sys.argv[0]
+            )
             sys.exit(1)
         else:
             return euid
@@ -39,7 +43,9 @@ def not_root():
         # So nothing to worry about.
         return None
 
+
 euid = not_root()
+
 
 def readlink(file=sys.argv[0]):
     """
@@ -59,6 +65,7 @@ def readlink(file=sys.argv[0]):
     file = os.path.abspath(file)
     return file
 
+
 if "OMERO_HOME" in os.environ:
     print("WARN: OMERO_HOME usage is ignored in omero-py")
 
@@ -71,12 +78,13 @@ top = os.path.join(exe, os.pardir, os.pardir)
 top = os.path.normpath(top)
 var = os.path.join(top, "var")
 vlb = os.path.join(var, "lib")
-sys.path.append(vlb);
+sys.path.append(vlb)
 
 # Testing shortcut. If the first argument is an
 # empty string, exit sucessfully.
 #
-if len(sys.argv) == 2 and sys.argv[1] == "": sys.exit(0)
+if len(sys.argv) == 2 and sys.argv[1] == "":
+    sys.exit(0)
 
 #
 # Primary activity: import omero.cli and launch
@@ -86,9 +94,10 @@ try:
     try:
         import omero.cli
     except ImportError as ie:
-        OMERODIR = os.environ.get('OMERODIR', None)
-        print("*"*80)
-        print("""
+        OMERODIR = os.environ.get("OMERODIR", None)
+        print("*" * 80)
+        print(
+            """
         ERROR: Could not import omero.cli! (%s)
 
         This means that your installation is incomplete. Contact
@@ -100,9 +109,12 @@ try:
         as well as which version you are building from. If you
         downloaded a distribution, please provide which link you
         used.
-        """ % ie)
-        print("*"*80)
-        print("""
+        """
+            % ie
+        )
+        print("*" * 80)
+        print(
+            """
         Debugging Info:
         --------------
         CWD=%s
@@ -110,8 +122,15 @@ try:
         OMERO_EXE=%s
         OMERODIR=%s
         PYTHONPATH=%s
-        """ % (os.getcwd(), sys.version.replace("\n", " "), top,
-               OMERODIR, sys.path))
+        """
+            % (
+                os.getcwd(),
+                sys.version.replace("\n", " "),
+                top,
+                OMERODIR,
+                sys.path,
+            )
+        )
         sys.exit(2)
 
     logging.basicConfig(level=logging.WARN)

--- a/examples/projection_1.py
+++ b/examples/projection_1.py
@@ -64,12 +64,8 @@ def projection():
         zSectionSet = client.getInput("zSectionSet")
 
         # Not sure what a point object would be in the OME::System(?)
-        point1 = point(
-            client.getInput("point1.x"),
-            client.getInput("point1.y"))
-        point2 = point(
-            client.getInput("point2.x"),
-            client.getInput("point2.y"))
+        point1 = point(client.getInput("point1.x"), client.getInput("point1.y"))
+        point2 = point(client.getInput("point2.x"), client.getInput("point2.y"))
 
         width = point2.x - point1.x
         height = point2.y - point1.y
@@ -82,8 +78,9 @@ def projection():
         # and one timepoint and one zsection from the original image.
         # It will use the original image to set the bitdepth, channel info,
         # metadata.
-        newPixelsID = client.copyPixels(pixelsID, [width, height, channelSet,
-                                                   timeSet, 1])
+        newPixelsID = client.copyPixels(
+            pixelsID, [width, height, channelSet, timeSet, 1]
+        )
 
         # Iterate original image, over the channelSet, timeSet, zSectionSet
         # and create the new plane based on the method
@@ -97,8 +94,9 @@ def projection():
                     # method should return an array so it is simple to
                     # manipulate in python, (scripting should not really
                     # involve too much bit twiddling :)
-                    planeData = client.getPixels(pixelsID, zSection, time,
-                                                 channel, time)
+                    planeData = client.getPixels(
+                        pixelsID, zSection, time, channel, time
+                    )
 
                     # loop through the selection of the original image.
                     for x in range(point1.x, point2.x):
@@ -106,31 +104,35 @@ def projection():
 
                             # The new image coords are just offset by point1
                             # values.
-                            newImageX = x-point1.x
-                            newImageY = y-point1.y
+                            newImageX = x - point1.x
+                            newImageY = y - point1.y
 
                             # Apply projection method.
                             if method == self.AVERAGE or method == self.SUM:
-                                newPlaneData[newImageX][newImageY] += \
-                                    planeData[x][y]
+                                newPlaneData[newImageX][newImageY] += planeData[
+                                    x
+                                ][y]
                             if method == self.MAX:
                                 newPlaneData[newImageX][newImageY] = max(
                                     newPlaneData[newImageX][newImageY],
-                                    planeData[x][y])
+                                    planeData[x][y],
+                                )
                 # calculate mean for AVERAGE method.
                 if method == self.AVERAGE:
-                    for x in range(0, width-1):
-                        for y in range(0, height-1):
+                    for x in range(0, width - 1):
+                        for y in range(0, height - 1):
                             newPlaneData[x][y] /= len(zSectionSet)
 
                 # A method to set the plane of the newImage to the
                 # newPlaneData
-                client.setPlane(newPixelsID, newPlaneData, 1, time, channel,
-                                time)
+                client.setPlane(
+                    newPixelsID, newPlaneData, 1, time, channel, time
+                )
 
         # save the image?
         client.setOutput("newPixelsID", newPixelsID)
         sys.exit(0)
+
 
 if __name__ == "__main__":
     projection().__runScript()

--- a/manualtests/populate_roi_test.py
+++ b/manualtests/populate_roi_test.py
@@ -42,6 +42,7 @@ class TestingServiceFactory(object):
     """
     Testing service factory implementation.
     """
+
     def getUpdateService(self):
         return None
 
@@ -54,6 +55,7 @@ class FromFileOriginalFileProvider(object):
     Provides a testing original file provider which provides file data
     directly from disk.
     """
+
     def __init__(self, service_factory):
         pass
 
@@ -68,12 +70,15 @@ class MIASParseRoiTest(unittest.TestCase):
 
     RESULT_FILE = "Well0001_mode1_z000_t000_detail_2008-09-18-10h48m54s.txt"
 
-    ROOT = "/Users/callan/testimages/siRNA_PRIM1_03102008/"\
+    ROOT = (
+        "/Users/callan/testimages/siRNA_PRIM1_03102008/"
         "001-365700055641/results/"
+    )
 
     def setUp(self):
-        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = \
+        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = (
             FromFileOriginalFileProvider
+        )
         original_files = list()
         # Create our container images and an original file image map
         images = list()
@@ -90,7 +95,7 @@ class MIASParseRoiTest(unittest.TestCase):
                 images.append(image)
         original_file_image_map = dict()
         # Our required original file format
-        format = rstring('Companion/MIAS')
+        format = rstring("Companion/MIAS")
         # Create original file representing the log file
         o = OriginalFileI(1, True)
         o.name = rstring(self.LOG_FILE)
@@ -107,7 +112,8 @@ class MIASParseRoiTest(unittest.TestCase):
         original_file_image_map[2] = images[0]
         sf = TestingServiceFactory()
         self.analysis_ctx = MIASPlateAnalysisCtx(
-            images, original_files, original_file_image_map, 1, sf)
+            images, original_files, original_file_image_map, 1, sf
+        )
 
     def test_get_measurement_ctx(self):
         ctx = self.analysis_ctx.get_measurement_ctx(0)
@@ -118,15 +124,15 @@ class MIASParseRoiTest(unittest.TestCase):
         columns = ctx.parse()
         self.assertNotEqual(None, columns)
         self.assertEqual(9, len(columns))
-        self.assertEqual('Image', columns[0].name)
-        self.assertEqual('ROI', columns[1].name)
-        self.assertEqual('Label', columns[2].name)
-        self.assertEqual('Row', columns[3].name)
-        self.assertEqual('Col', columns[4].name)
-        self.assertEqual('Nucleus Area', columns[5].name)
-        self.assertEqual('Cell Diam.', columns[6].name)
-        self.assertEqual('Cell Type', columns[7].name)
-        self.assertEqual('Mean Nucleus Intens.', columns[8].name)
+        self.assertEqual("Image", columns[0].name)
+        self.assertEqual("ROI", columns[1].name)
+        self.assertEqual("Label", columns[2].name)
+        self.assertEqual("Row", columns[3].name)
+        self.assertEqual("Col", columns[4].name)
+        self.assertEqual("Nucleus Area", columns[5].name)
+        self.assertEqual("Cell Diam.", columns[6].name)
+        self.assertEqual("Cell Type", columns[7].name)
+        self.assertEqual("Mean Nucleus Intens.", columns[8].name)
         for column in columns:
             if column.name == "ROI":
                 continue
@@ -140,8 +146,9 @@ class FlexParseRoiTest(unittest.TestCase):
     RESULT_FILE = "An_02_Me01_12132846(2009-06-17_11-56-17).res"
 
     def setUp(self):
-        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = \
+        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = (
             FromFileOriginalFileProvider
+        )
         original_files = list()
         # Create our container images and an original file image map
         images = list()
@@ -158,7 +165,7 @@ class FlexParseRoiTest(unittest.TestCase):
                 images.append(image)
         original_file_image_map = dict()
         # Our required original file format
-        format = rstring('Companion/Flex')
+        format = rstring("Companion/Flex")
         # Create original file representing the result file
         o = OriginalFileI(1, True)
         o.name = rstring(self.RESULT_FILE)
@@ -168,7 +175,8 @@ class FlexParseRoiTest(unittest.TestCase):
         original_file_image_map[1] = images[0]
         sf = TestingServiceFactory()
         self.analysis_ctx = FlexPlateAnalysisCtx(
-            images, original_files, original_file_image_map, 1, sf)
+            images, original_files, original_file_image_map, 1, sf
+        )
 
     def test_get_measurement_ctx(self):
         ctx = self.analysis_ctx.get_measurement_ctx(0)
@@ -190,8 +198,9 @@ class InCellParseRoiTest(unittest.TestCase):
     RESULT_FILE = "Mara_488 and hoechst_P-HisH3.xml"
 
     def setUp(self):
-        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = \
+        AbstractPlateAnalysisCtx.DEFAULT_ORIGINAL_FILE_PROVIDER = (
             FromFileOriginalFileProvider
+        )
         original_files = list()
         # Create our container images and an original file image map
         images = list()
@@ -208,7 +217,7 @@ class InCellParseRoiTest(unittest.TestCase):
                 images.append(image)
         original_file_image_map = dict()
         # Our required original file format
-        format = rstring('Companion/InCell')
+        format = rstring("Companion/InCell")
         # Create original file representing the result file
         o = OriginalFileI(1, True)
         o.name = rstring(self.RESULT_FILE)
@@ -218,7 +227,8 @@ class InCellParseRoiTest(unittest.TestCase):
         original_file_image_map[1] = image
         sf = TestingServiceFactory()
         self.analysis_ctx = InCellPlateAnalysisCtx(
-            images, original_files, original_file_image_map, 1, sf)
+            images, original_files, original_file_image_map, 1, sf
+        )
 
     def test_get_measurement_ctx(self):
         ctx = self.analysis_ctx.get_measurement_ctx(0)
@@ -229,10 +239,11 @@ class InCellParseRoiTest(unittest.TestCase):
         columns = ctx.parse()
         self.assertNotEqual(None, columns)
         for column in columns:
-            print('Column: %s' % column.name)
+            print("Column: %s" % column.name)
         self.assertEqual(33, len(columns))
         for column in columns:
             self.assertEqual(114149, len(column.values))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -64,25 +64,25 @@ def get_blitz_location():
         config_blitz_url = (
             "https://artifacts.openmicroscopy.org/artifactory/ome.releases/"
             "org/openmicroscopy/omero-blitz/VERSION/"
-            "omero-blitz-VERSION-python.zip")
+            "omero-blitz-VERSION-python.zip"
+        )
 
     # load version.properties if available
-    config_path = os.environ.get("VERSION_PROPERTIES",
-                                 "artifact/version.properties")
+    config_path = os.environ.get(
+        "VERSION_PROPERTIES", "artifact/version.properties"
+    )
     if os.path.exists(config_path):
-        config_obj = configparser.RawConfigParser({
-            url_key: config_blitz_url,
-            version_key: config_blitz_version,
-        })
+        config_obj = configparser.RawConfigParser(
+            {url_key: config_blitz_url, version_key: config_blitz_version,}
+        )
         with open(config_path) as f:
-            config_str = StringIO('[%s]\n%s' % (defaultsect, f.read()))
+            config_str = StringIO("[%s]\n%s" % (defaultsect, f.read()))
         config_obj.readfp(config_str)
         config_blitz_url = config_obj.get(defaultsect, url_key)
         config_blitz_version = config_obj.get(defaultsect, version_key)
 
     # replace VERSION in the final url and return
-    config_blitz_url = config_blitz_url.replace(
-        "VERSION", config_blitz_version)
+    config_blitz_url = config_blitz_url.replace("VERSION", config_blitz_version)
     return config_blitz_url
 
 
@@ -138,7 +138,8 @@ class DevTargetCommand(Command):
     """
 
     description = (
-        'Recreate target with symlinks to files in src to ease development')
+        "Recreate target with symlinks to files in src to ease development"
+    )
     user_options = []
 
     def initialize_options(self):
@@ -148,14 +149,16 @@ class DevTargetCommand(Command):
         pass
 
     def run(self):
-        rmtree('target')
+        rmtree("target")
         download_blitz_target()
         copy_src_to_target(symlink=True)
-        print("If this is installed as an editable module re-run "
-              "`pip install -e .`")
+        print(
+            "If this is installed as an editable module re-run "
+            "`pip install -e .`"
+        )
 
 
-if not os.path.exists('target'):
+if not os.path.exists("target"):
     download_blitz_target()
     copy_src_to_target()
 
@@ -164,7 +167,7 @@ packageless = glob.glob("target/*.py")
 packageless = [x[7:-3] for x in packageless]
 packages = find_packages(where="target")
 
-url = 'https://docs.openmicroscopy.org/latest/omero/developers'
+url = "https://docs.openmicroscopy.org/latest/omero/developers"
 
 sys.path.append("target")
 from omero_version import omero_version as ov  # noqa
@@ -184,40 +187,31 @@ setup(
     description="Python bindings to the OMERO.blitz server",
     long_description=read("README.rst"),
     classifiers=[
-      'Development Status :: 5 - Production/Stable',
-      'Intended Audience :: Developers',
-      'Intended Audience :: Science/Research',
-      'Intended Audience :: System Administrators',
-      'License :: OSI Approved :: GNU General Public License v2 '
-      'or later (GPLv2+)',
-      'Natural Language :: English',
-      'Operating System :: OS Independent',
-      'Programming Language :: Python :: 3',
-      'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: GNU General Public License v2 "
+        "or later (GPLv2+)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],  # Get strings from
-        # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    # http://pypi.python.org/pypi?%3Aaction=list_classifiers
     author="The Open Microscopy Team",
     author_email="ome-devel@lists.openmicroscopy.org.uk",
     url=url,
     package_dir={"": "target"},
     packages=packages,
     package_data={
-        'omero.gateway': ['pilfonts/*'],
-        'omero.gateway.scripts': ['imgs/*']},
+        "omero.gateway": ["pilfonts/*"],
+        "omero.gateway.scripts": ["imgs/*"],
+    },
     py_modules=packageless,
     scripts=glob.glob(os.path.sep.join(["bin", "*"])),
-    python_requires='>=3',
-    install_requires=[
-        'future',
-        'numpy',
-        'Pillow',
-        'zeroc-ice>=3.6.4,<3.7',
-    ],
-    tests_require=[
-        'pytest',
-        'mox3',
-    ],
-    cmdclass={
-        'devtarget': DevTargetCommand,
-    },
+    python_requires=">=3",
+    install_requires=["future", "numpy", "Pillow", "zeroc-ice>=3.6.4,<3.7",],
+    tests_require=["pytest", "mox3",],
+    cmdclass={"devtarget": DevTargetCommand,},
 )

--- a/src/IceImport.py
+++ b/src/IceImport.py
@@ -11,6 +11,7 @@ Load modules with automatic updating of Ice modules.
 """
 
 import Ice
+
 update = getattr(Ice, "updateModules", None)
 
 

--- a/src/omero/__init__.py
+++ b/src/omero/__init__.py
@@ -16,6 +16,7 @@ from omero_version import omero_version
 from omero_version import ice_compatibility as compat
 import Ice
 import os
+
 _sys = __import__("sys")
 
 try:
@@ -38,8 +39,12 @@ try:
         --------------
         VERSION=%s
         PYTHONPATH=%s
-        """ % (".".join(compat), ".".join(vers), omero_version,
-               os.path.pathsep.join(_sys.path))
+        """ % (
+            ".".join(compat),
+            ".".join(vers),
+            omero_version,
+            os.path.pathsep.join(_sys.path),
+        )
         raise Exception(msg)
 finally:
     del omero_version
@@ -59,11 +64,13 @@ def client_wrapper(*args, **kwargs):
     @return:    See above
     """
     import omero.gateway
+
     return omero.gateway.BlitzGateway(*args, **kwargs)
 
 
 def client(*args, **kwargs):
     import omero.clients
+
     return omero.clients.BaseClient(*args, **kwargs)
 
 
@@ -71,6 +78,7 @@ class ClientError(Exception):
     """
     Top of client exception hierarchy.
     """
+
     pass
 
 
@@ -109,6 +117,7 @@ def proxy_to_instance(proxy_string, default=None):
     but not required.
     """
     import omero
+
     parts = proxy_string.split(":")
     if len(parts) == 1 and default is not None:
         proxy_string = "%s:%s" % (default, proxy_string)
@@ -119,9 +128,12 @@ def proxy_to_instance(proxy_string, default=None):
         kls += "I"
     kls = getattr(omero.model, kls, None)
     if kls is None:
-        raise ClientError(("Invalid proxy string: %s. "
-                          "Correct format is Class:ID") % proxy_string)
+        raise ClientError(
+            ("Invalid proxy string: %s. " "Correct format is Class:ID")
+            % proxy_string
+        )
     return kls(proxy_string)
+
 
 #
 # Workaround for warning messages produced in
@@ -129,7 +141,9 @@ def proxy_to_instance(proxy_string, default=None):
 #
 if _sys.version_info[:2] == (2, 6):
     import warnings
+
     warnings.filterwarnings(
-        action='ignore',
-        message='BaseException.message has been deprecated as of Python 2.6',
-        category=DeprecationWarning)
+        action="ignore",
+        message="BaseException.message has been deprecated as of Python 2.6",
+        category=DeprecationWarning,
+    )

--- a/src/omero/all.py
+++ b/src/omero/all.py
@@ -16,11 +16,13 @@
 import Ice
 import IceImport
 import omero
+
 if omero.__import_style__ is None:
     omero.__import_style__ = "all"
     import omero.min
     import omero.callbacks
     import omero.ObjectFactoryRegistrar
+
     IceImport.load("omero_FS_ice")
     IceImport.load("omero_System_ice")
     IceImport.load("omero_Collections_ice")

--- a/src/omero/callbacks.py
+++ b/src/omero/callbacks.py
@@ -63,8 +63,9 @@ class ProcessCallbackI(omero.grid.ProcessCallback):
         self.result = None
         self.poll = poll
         self.process = process
-        self.adapter, self.category = \
-            adapter_and_category(adapter_or_client, category)
+        self.adapter, self.category = adapter_and_category(
+            adapter_or_client, category
+        )
 
         self.id = Ice.Identity(native_str(uuid.uuid4()), self.category)
         self.prx = self.adapter.add(self, self.id)  # OK ADAPTER USAGE
@@ -126,8 +127,9 @@ class CmdCallbackI(omero.cmd.CmdCallback):
         response = cb.loop(5, 500)
     """
 
-    def __init__(self, adapter_or_client, handle, category=None,
-                 foreground_poll=True):
+    def __init__(
+        self, adapter_or_client, handle, category=None, foreground_poll=True
+    ):
 
         if adapter_or_client is None:
             raise omero.ClientError("Null client")
@@ -138,8 +140,9 @@ class CmdCallbackI(omero.cmd.CmdCallback):
         self.event = omero.util.concurrency.get_event(name="CmdCallbackI")
         self.state = (None, None)  # (Response, Status)
         self.handle = handle
-        self.adapter, self.category = \
-            adapter_and_category(adapter_or_client, category)
+        self.adapter, self.category = adapter_and_category(
+            adapter_or_client, category
+        )
 
         self.id = Ice.Identity(native_str(uuid.uuid4()), self.category)
         self.prx = self.adapter.add(self, self.id)  # OK ADAPTER USAGE
@@ -167,7 +170,6 @@ class CmdCallbackI(omero.cmd.CmdCallback):
             return self.poll()
 
         class T(threading.Thread):
-
             def run(this):
                 try:
                     self.poll()
@@ -256,8 +258,12 @@ class CmdCallbackI(omero.cmd.CmdCallback):
         else:
             waited = (old_div(ms, 1000.0)) * loops
             raise omero.LockTimeout(
-                None, None, "Command unfinished after %s seconds" % waited,
-                5000, int(waited))
+                None,
+                None,
+                "Command unfinished after %s seconds" % waited,
+                5000,
+                int(waited),
+            )
 
     def block(self, ms):
         """

--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -36,6 +36,7 @@ from builtins import range
 from builtins import bytes
 from past.utils import old_div
 from builtins import object
+
 sys = __import__("sys")
 cmd = __import__("cmd")
 
@@ -59,6 +60,7 @@ from omero_ext.argparse import ArgumentParser
 from omero_ext.argparse import FileType
 from omero_ext.argparse import Namespace
 from omero_ext.argparse import _SubParsersAction
+
 # Help text
 from omero_ext.argparse import RawTextHelpFormatter
 from omero_ext.argparse import SUPPRESS
@@ -75,6 +77,7 @@ import warnings
 
 try:
     from omero_version import omero_version
+
     VERSION = omero_version
 except ImportError:
     VERSION = "Unknown"  # Usually during testing
@@ -96,13 +99,13 @@ OMEROHELP = """Type "help" for more information, "quit" or Ctrl-D to exit"""
 OMEROSUBS = """Use %(prog)s <subcommand> -h for more information."""
 OMEROSUBM = """<subcommand>"""
 OMEROCLI = path(__file__).expand().dirname()
-OMERODIR = os.getenv('OMERODIR', None)
+OMERODIR = os.getenv("OMERODIR", None)
 if OMERODIR is not None:
     OMERODIR = path(OMERODIR)
 else:
     OMERODIR = OMEROCLI.dirname().dirname().dirname()
 
-OMERO_COMPONENTS = ['common', 'model', 'romio', 'renderer', 'server', 'blitz']
+OMERO_COMPONENTS = ["common", "model", "romio", "renderer", "server", "blitz"]
 
 COMMENT = re.compile(r"^\s*#")
 RELFILE = re.compile(r"^\w")
@@ -132,38 +135,43 @@ class NonZeroReturnCode(Exception):
 #####################################################
 #
 
+
 class HelpFormatter(RawTextHelpFormatter):
     """
     argparse.HelpFormatter subclass which cleans up our usage, preventing very
     long lines in subcommands.
     """
 
-    def __init__(self, prog, indent_increment=2, max_help_position=40,
-                 width=None):
+    def __init__(
+        self, prog, indent_increment=2, max_help_position=40, width=None
+    ):
         RawTextHelpFormatter.__init__(
-            self, prog, indent_increment, max_help_position, width)
+            self, prog, indent_increment, max_help_position, width
+        )
         self._action_max_length = 20
 
     def _split_lines(self, text, width):
         return [text.splitlines()[0]]
 
     class _Section(RawTextHelpFormatter._Section):
-
         def __init__(self, formatter, parent, heading=None):
             # if heading:
             #    heading = "\n%s\n%s" % ("=" * 40, heading)
             RawTextHelpFormatter._Section.__init__(
-                self, formatter, parent, heading)
+                self, formatter, parent, heading
+            )
 
 
 class WriteOnceNamespace(Namespace):
     """
     Namespace subclass which prevents overwriting any values by accident.
     """
+
     def __setattr__(self, name, value):
         if hasattr(self, name):
-            raise Exception("%s already has field %s"
-                            % (self.__class__.__name__, name))
+            raise Exception(
+                "%s already has field %s" % (self.__class__.__name__, name)
+            )
         else:
             return Namespace.__setattr__(self, name, value)
 
@@ -184,99 +192,154 @@ class Parser(ArgumentParser):
 
     def sub(self):
         return self.add_subparsers(
-            title="Subcommands", description=OMEROSUBS, metavar=OMEROSUBM)
+            title="Subcommands", description=OMEROSUBS, metavar=OMEROSUBM
+        )
 
     def add(self, sub, func, help=None, **kwargs):
         if help is None:
             help = func.__doc__
         parser = sub.add_parser(
-            func.__func__.__name__, help=help, description=help)
+            func.__func__.__name__, help=help, description=help
+        )
         parser.set_defaults(func=func, **kwargs)
         return parser
 
     def add_limit_arguments(self):
         self.add_argument(
-            "--limit", help="maximum number of return values (default=25)",
-            type=int, default=25)
+            "--limit",
+            help="maximum number of return values (default=25)",
+            type=int,
+            default=25,
+        )
         self.add_argument(
-            "--offset", help="number of entries to skip (default=0)",
-            type=int, default=0)
+            "--offset",
+            help="number of entries to skip (default=0)",
+            type=int,
+            default=0,
+        )
 
     def add_style_argument(self):
         from omero.util.text import list_styles
+
         self.add_argument(
-            "--style", help="use alternative output style (default=sql)",
-            choices=list_styles())
+            "--style",
+            help="use alternative output style (default=sql)",
+            choices=list_styles(),
+        )
 
     def add_login_arguments(self):
         group = self.add_argument_group(
-            'Login arguments', ENV_HELP + """
+            "Login arguments",
+            ENV_HELP
+            + """
 
 Optional session arguments:
-""")
+""",
+        )
         group.add_argument(
-            "-C", "--create", action="store_true",
-            help="Create a new session regardless of existing ones")
+            "-C",
+            "--create",
+            action="store_true",
+            help="Create a new session regardless of existing ones",
+        )
         group.add_argument("-s", "--server", help="OMERO server hostname")
         group.add_argument("-p", "--port", help="OMERO server port")
         group.add_argument("-g", "--group", help="OMERO server default group")
         group.add_argument("-u", "--user", help="OMERO username")
         group.add_argument("-w", "--password", help="OMERO password")
         group.add_argument(
-            "-k", "--key",
-            help="OMERO session key (UUID of an active session)")
+            "-k", "--key", help="OMERO session key (UUID of an active session)"
+        )
         group.add_argument(
-            "--sudo", metavar="ADMINUSER",
-            help="Create session as this admin. Changes meaning of password!")
+            "--sudo",
+            metavar="ADMINUSER",
+            help="Create session as this admin. Changes meaning of password!",
+        )
         group.add_argument(
-            "-q", "--quiet", action="store_true",
+            "-q",
+            "--quiet",
+            action="store_true",
             help="Quiet mode. Causes most warning and diagnostic messages to "
-            "be suppressed.")
+            "be suppressed.",
+        )
 
     def add_group_print_arguments(self):
         printgroup = self.add_mutually_exclusive_group()
         printgroup.add_argument(
-            "--long", action="store_true", default=True,
-            help="Print comma-separated list of all groups (default)")
+            "--long",
+            action="store_true",
+            default=True,
+            help="Print comma-separated list of all groups (default)",
+        )
         printgroup.add_argument(
-            "--count", action="store_true", default=False,
-            help="Print count of all groups")
+            "--count",
+            action="store_true",
+            default=False,
+            help="Print count of all groups",
+        )
 
     def add_user_print_arguments(self):
         printgroup = self.add_mutually_exclusive_group()
         printgroup.add_argument(
-            "--count", action="store_true", default=True,
-            help="Print count of all users and owners (default)")
+            "--count",
+            action="store_true",
+            default=True,
+            help="Print count of all users and owners (default)",
+        )
         printgroup.add_argument(
-            "--long", action="store_true", default=False,
-            help="Print comma-separated list of all users and owners")
+            "--long",
+            action="store_true",
+            default=False,
+            help="Print comma-separated list of all users and owners",
+        )
 
     def add_user_sorting_arguments(self):
         sortgroup = self.add_mutually_exclusive_group()
         sortgroup.add_argument(
-            "--sort-by-id", action="store_true", default=True,
-            help="Sort users by ID (default)")
+            "--sort-by-id",
+            action="store_true",
+            default=True,
+            help="Sort users by ID (default)",
+        )
         sortgroup.add_argument(
-            "--sort-by-login", action="store_true", default=False,
-            help="Sort users by login")
+            "--sort-by-login",
+            action="store_true",
+            default=False,
+            help="Sort users by login",
+        )
         sortgroup.add_argument(
-            "--sort-by-first-name", action="store_true", default=False,
-            help="Sort users by first name")
+            "--sort-by-first-name",
+            action="store_true",
+            default=False,
+            help="Sort users by first name",
+        )
         sortgroup.add_argument(
-            "--sort-by-last-name", action="store_true", default=False,
-            help="Sort users by last name")
+            "--sort-by-last-name",
+            action="store_true",
+            default=False,
+            help="Sort users by last name",
+        )
         sortgroup.add_argument(
-            "--sort-by-email", action="store_true", default=False,
-            help="Sort users by email")
+            "--sort-by-email",
+            action="store_true",
+            default=False,
+            help="Sort users by email",
+        )
 
     def add_group_sorting_arguments(self):
         sortgroup = self.add_mutually_exclusive_group()
         sortgroup.add_argument(
-            "--sort-by-id", action="store_true", default=True,
-            help="Sort groups by ID (default)")
+            "--sort-by-id",
+            action="store_true",
+            default=True,
+            help="Sort groups by ID (default)",
+        )
         sortgroup.add_argument(
-            "--sort-by-name", action="store_true", default=False,
-            help="Sort groups by name")
+            "--sort-by-name",
+            action="store_true",
+            default=False,
+            help="Sort groups by name",
+        )
 
     def set_args_unsorted(self):
         self._sort_args = False
@@ -284,7 +347,7 @@ Optional session arguments:
     def _check_value(self, action, value):
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
-            msg = 'invalid choice: %r\n\nchoose from:\n' % value
+            msg = "invalid choice: %r\n\nchoose from:\n" % value
             choices = list(action.choices)
             if self._sort_args:
                 choices = sorted(choices)
@@ -292,15 +355,15 @@ Optional session arguments:
             raise ArgumentError(action, msg)
 
     def _format_list(self, choices):
-            lines = ["\t"]
-            if choices:
-                while len(choices) > 1:
-                    choice = choices.pop(0)
-                    lines[-1] += ("%s, " % choice)
-                    if len(lines[-1]) > 62:
-                        lines.append("\t")
-                lines[-1] += choices.pop(0)
-            return "\n".join(lines)
+        lines = ["\t"]
+        if choices:
+            while len(choices) > 1:
+                choice = choices.pop(0)
+                lines[-1] += "%s, " % choice
+                if len(lines[-1]) > 62:
+                    lines.append("\t")
+            lines[-1] += choices.pop(0)
+        return "\n".join(lines)
 
 
 class ProxyStringType(object):
@@ -330,6 +393,7 @@ class NewFileType(FileType):
     Extension of the argparse.FileType to prevent
     overwrite existing files.
     """
+
     def __call__(self, s):
         if s != "-" and os.path.exists(s):
             raise ArgumentTypeError("File exists: %s" % s)
@@ -341,6 +405,7 @@ class ExistingFile(FileType):
     Extension of the argparse.FileType that requires
     an existing file.
     """
+
     def __call__(self, s):
         if s == "-":
             return s
@@ -357,6 +422,7 @@ class DirectoryType(FileType):
     Extension of the argparse.FileType to only allow
     existing directories.
     """
+
     def __call__(self, s):
         p = path(s)
         if not p.exists():
@@ -372,18 +438,23 @@ class ExceptionHandler(object):
     to specific states. This could likely be moved elsewhere
     for general client-side usage.
     """
+
     def is_constraint_violation(self, ve):
         if isinstance(ve, omero.ValidationException):
-            if "org.hibernate.exception.ConstraintViolationException: " \
-                    "could not insert" in str(ve):
+            if (
+                "org.hibernate.exception.ConstraintViolationException: "
+                "could not insert" in str(ve)
+            ):
                 return True
 
     def handle_failed_request(self, rfe):
         import Ice
+
         if isinstance(rfe, Ice.OperationNotExistException):
             return "Operation not supported by the server: %s" % rfe.operation
         else:
             return "Unknown Ice.RequestFailedException"
+
 
 DEBUG_HELP = """
 Set debug options for developers
@@ -481,29 +552,41 @@ class Context(object):
         sessions = self.controls["sessions"]
 
         login = self.subparsers.add_parser(
-            "login", help="Shortcut for 'sessions login'",
-            description=sessions.login.__doc__)
+            "login",
+            help="Shortcut for 'sessions login'",
+            description=sessions.login.__doc__,
+        )
         login.set_defaults(func=lambda args: sessions.login(args))
         sessions._configure_login(login)
 
         logout = self.subparsers.add_parser(
-            "logout", help="Shortcut for 'sessions logout'")
+            "logout", help="Shortcut for 'sessions logout'"
+        )
         logout.set_defaults(func=lambda args: sessions.logout(args))
         sessions._configure_dir(logout)
 
     def parser_init(self, parser):
         parser.add_argument(
-            "-v", "--version", action="version",
-            version="%%(prog)s %s" % VERSION)
+            "-v",
+            "--version",
+            action="version",
+            version="%%(prog)s %s" % VERSION,
+        )
         parser.add_argument(
-            "-d", "--debug",
-            help="Use 'help debug' for more information", default=SUPPRESS)
+            "-d",
+            "--debug",
+            help="Use 'help debug' for more information",
+            default=SUPPRESS,
+        )
         parser.add_argument(
-            "--path",  action="append",
-            help="Add file or directory to plugin list. Supports globs.")
+            "--path",
+            action="append",
+            help="Add file or directory to plugin list. Supports globs.",
+        )
         parser.add_login_arguments()
         subparsers = parser.add_subparsers(
-            title="Subcommands", description=OMEROSUBS, metavar=OMEROSUBM)
+            title="Subcommands", description=OMEROSUBS, metavar=OMEROSUBM
+        )
         return subparsers
 
     def get(self, key, defvalue=None):
@@ -518,7 +601,9 @@ class Context(object):
         """
         try:
             if sys.version_info < (3, 0, 0):
-                if isinstance(text, basestring) and not isinstance(text, unicode):
+                if isinstance(text, basestring) and not isinstance(
+                    text, unicode
+                ):
                     text = text.encode("utf-8")
             stream.write(text)
             if newline:
@@ -544,7 +629,7 @@ class Context(object):
         """
         path = list(sys.path)
         for i in range(0, len(path) - 1):
-            if path[i] == '':
+            if path[i] == "":
                 path[i] = os.getcwd()
         pythonpath = ":".join(path)
         return pythonpath
@@ -575,6 +660,7 @@ class Context(object):
             while True:
                 if hidden:
                     import getpass
+
                     rv = getpass.getpass(prompt)
                 else:
                     rv = input(prompt)
@@ -620,6 +706,7 @@ class Context(object):
     def sleep(self, time):
         self.event.wait(time)
 
+
 #####################################################
 #
 
@@ -632,6 +719,7 @@ def admin_only(*fargs, **fkwargs):
     full admin and have all privileges. To disable this behavior, set
     `full_admin` to False.
     """
+
     def _admin_only(func):
         @wraps(func)
         def _check_admin(*args, **kwargs):
@@ -651,8 +739,9 @@ def admin_only(*fargs, **fkwargs):
                     try:
                         types = client.sf.getTypesService()
                         privs = types.allEnumerations("AdminPrivilege")
-                        need_privs = set(omero.rtypes.unwrap(
-                            [x.getValue() for x in privs]))
+                        need_privs = set(
+                            omero.rtypes.unwrap([x.getValue() for x in privs])
+                        )
                     except Exception as e:
                         self.ctx.err("Error: denying access: %s" % e)
                         # If the user can't load enums assume the worst
@@ -661,10 +750,11 @@ def admin_only(*fargs, **fkwargs):
             if not ec.isAdmin:
                 self.error_admin_only(fatal=True)
             elif not need_privs <= have_privs:
-                self.error_admin_only_privs(need_privs - have_privs,
-                                            fatal=True)
+                self.error_admin_only_privs(need_privs - have_privs, fatal=True)
             return func(*args, **kwargs)
+
         return _check_admin
+
     return _admin_only
 
 
@@ -761,10 +851,10 @@ class BaseControl(object):
 
     def _isWindows(self):
         p_s = platform.system()
-        if p_s == 'Windows':
-                return True
+        if p_s == "Windows":
+            return True
         else:
-                return False
+            return False
 
     def _host(self):
         """
@@ -789,7 +879,7 @@ class BaseControl(object):
         environment variable will be set.
         """
         if omero_node is not None:
-                os.environ["OMERO_NODE"] = omero_node
+            os.environ["OMERO_NODE"] = omero_node
 
         if "OMERO_NODE" in os.environ:
             return os.environ["OMERO_NODE"]
@@ -810,7 +900,7 @@ class BaseControl(object):
 
             created = False
             if not nodedata.exists():
-                self.ctx.out("Creating "+nodedata)
+                self.ctx.out("Creating " + nodedata)
                 nodedata.makedirs()
                 created = True
             return (nodedata, created)
@@ -904,6 +994,7 @@ class BaseControl(object):
         to return all properties.
         """
         import Ice
+
         if getattr(self, "_props", None) is None:
             self._props = Ice.createProperties()
             for cfg in self._cfglist():
@@ -911,21 +1002,27 @@ class BaseControl(object):
                     self._props.load(native_str(cfg))
                 except Exception:
                     self.ctx.dbg("Complete error: %s" % traceback.format_exc())
-                    self.ctx.die(3, "Could not find file: " + cfg +
-                                 "\nDid you specify the proper node?")
+                    self.ctx.die(
+                        3,
+                        "Could not find file: "
+                        + cfg
+                        + "\nDid you specify the proper node?",
+                    )
         return self._props.getPropertiesForPrefix(prefix)
 
     def _ask_for_password(self, reason="", root_pass=None, strict=True):
         while not root_pass or len(root_pass) < 1:
-            root_pass = self.ctx.input("Please enter password%s: "
-                                       % reason, hidden=True)
+            root_pass = self.ctx.input(
+                "Please enter password%s: " % reason, hidden=True
+            )
             if not strict:
                 return root_pass
             if root_pass is None or root_pass == "":
                 self.ctx.err("Password cannot be empty")
                 continue
-            confirm = self.ctx.input("Please re-enter password%s: "
-                                     % reason, hidden=True)
+            confirm = self.ctx.input(
+                "Please re-enter password%s: " % reason, hidden=True
+            )
             if root_pass != confirm:
                 root_pass = None
                 self.ctx.err("Passwords don't match")
@@ -935,9 +1032,12 @@ class BaseControl(object):
 
     def _add_wait(self, parser, default=-1):
         parser.add_argument(
-            "--wait", type=int,
+            "--wait",
+            type=int,
             help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=default)
+            "(Indefinite < 0; No wait=0).",
+            default=default,
+        )
 
     def get_subcommands(self):
         """Return a list of subcommands"""
@@ -947,8 +1047,11 @@ class BaseControl(object):
             self._configure(parser)
         finally:
             self.reset_errors(old)
-        subparsers_actions = [action for action in parser._actions
-                              if isinstance(action, _SubParsersAction)]
+        subparsers_actions = [
+            action
+            for action in parser._actions
+            if isinstance(action, _SubParsersAction)
+        ]
 
         subcommands = []
         for subparsers_action in subparsers_actions:
@@ -972,11 +1075,12 @@ class BaseControl(object):
         p = path(f)
         if p.exists() and p.isdir():
             if not f.endswith(os.sep):
-                return [p.basename()+os.sep]
-            return [str(x)[len(f):] for x in p.listdir(
-                unreadable_as_empty=True)]
+                return [p.basename() + os.sep]
+            return [
+                str(x)[len(f) :] for x in p.listdir(unreadable_as_empty=True)
+            ]
         else:
-            results = [str(x.basename()) for x in dir.glob(f+"*")]
+            results = [str(x.basename()) for x in dir.glob(f + "*")]
             if len(results) == 1:
                 # Relative to cwd
                 maybe_dir = path(results[0])
@@ -999,8 +1103,10 @@ class BaseControl(object):
             if actions:
                 if len(items) > 1:
                     subparsers = [
-                        x for x in actions
-                        if x.__class__.__name__ == "_SubParsersAction"]
+                        x
+                        for x in actions
+                        if x.__class__.__name__ == "_SubParsersAction"
+                    ]
                     if subparsers:
                         subparsers = subparsers[0]  # Guaranteed one
                         choice = subparsers.choices.get(items[-1])
@@ -1015,35 +1121,48 @@ class BaseControl(object):
                 elif action.__class__.__name__ == "_SubParsersAction":
                     result.extend(action.choices)
 
-            return ["%s " % x for x in result
-                    if (not text or x.startswith(text)) and
-                    line.find(" %s " % x) < 0]
+            return [
+                "%s " % x
+                for x in result
+                if (not text or x.startswith(text))
+                and line.find(" %s " % x) < 0
+            ]
 
         # Fallback
-        completions = [method for method in dir(self)
-                       if callable(getattr(self, method))]
-        return [str(method + " ") for method in completions
-                if method.startswith(text) and not method.startswith("_")]
+        completions = [
+            method for method in dir(self) if callable(getattr(self, method))
+        ]
+        return [
+            str(method + " ")
+            for method in completions
+            if method.startswith(text) and not method.startswith("_")
+        ]
 
-    def error_admin_only(self, msg="SecurityViolation: Admins only!",
-                         code=111, fatal=True):
+    def error_admin_only(
+        self, msg="SecurityViolation: Admins only!", code=111, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg)
         else:
             self.ctx.err(msg)
 
-    def error_admin_only_privs(self, restrictions,
-                               msg="SecurityViolation: Admin restrictions: ",
-                               code=111, fatal=True):
+    def error_admin_only_privs(
+        self,
+        restrictions,
+        msg="SecurityViolation: Admin restrictions: ",
+        code=111,
+        fatal=True,
+    ):
         msg += ", ".join(sorted(restrictions))
         self.error_admin_only(msg=msg, code=code, fatal=fatal)
 
     def _order_and_range_ids(self, ids):
         from itertools import groupby
         from operator import itemgetter
+
         out = ""
         ids = sorted(ids)
-        for k, g in groupby(enumerate(ids), lambda i_x: i_x[0]-i_x[1]):
+        for k, g in groupby(enumerate(ids), lambda i_x: i_x[0] - i_x[1]):
             g = list(map(str, list(map(itemgetter(1), g))))
             out += g[0]
             if len(g) > 2:
@@ -1064,20 +1183,24 @@ class DiagnosticsControl(BaseControl):
 
     def _add_diagnostics(self, parser, sub):
         diagnostics = parser.add(
-            sub, self.diagnostics,
-            "Run a set of checks on the current, "
-            "preferably active server")
+            sub,
+            self.diagnostics,
+            "Run a set of checks on the current, " "preferably active server",
+        )
         diagnostics.add_argument(
-            "--no-logs", action="store_true",
-            help="Skip log parsing")
+            "--no-logs", action="store_true", help="Skip log parsing"
+        )
 
     def _diagnostics_banner(self, control_name):
 
-        self.ctx.out("""
+        self.ctx.out(
+            """
 %s
 OMERO Diagnostics (%s) %s
 %s
-        """ % ("="*80, control_name, VERSION, "="*80))
+        """
+            % ("=" * 80, control_name, VERSION, "=" * 80)
+        )
 
     def _sz_str(self, sz):
         if sz < 1000:
@@ -1108,10 +1231,13 @@ OMERO Diagnostics (%s) %s
             elif not p.size:
                 self.ctx.out("empty")
             else:
-                warn_regex = (r'(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
-                              r'warn(i(ng:)?)?\s')
-                err_regex = (r'(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
-                             r'error:?\s')
+                warn_regex = (
+                    r"(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?"
+                    r"warn(i(ng:)?)?\s"
+                )
+                err_regex = (
+                    r"(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?" r"error:?\s"
+                )
                 warn = 0
                 err = 0
                 for l in p.lines():
@@ -1139,6 +1265,7 @@ class CLI(cmd.Cmd, Context):
         Thread-safe class for storing whether or not all the plugins
         have been loaded
         """
+
         def __init__(self):
             self.lock = Lock()
             self.done = False
@@ -1165,10 +1292,10 @@ class CLI(cmd.Cmd, Context):
         """
         cmd.Cmd.__init__(self)
         Context.__init__(self, prog=prog)
-        self.prompt = 'omero> '
+        self.prompt = "omero> "
         self.interrupt_loop = False
-        self.rv = 0          #: Return value to be returned
-        self._stack = []     #: List of commands being processed
+        self.rv = 0  #: Return value to be returned
+        self._stack = []  #: List of commands being processed
         self._client = None  #: Single client for all activities
         #: Paths to be loaded; initially official plugins
         self._plugin_paths = [old_div(OMEROCLI, "plugins")]
@@ -1192,28 +1319,29 @@ class CLI(cmd.Cmd, Context):
             if len(self._stack) == 0:
                 self.close()
             else:
-                self.dbg("Delaying close for stack: %s"
-                         % len(self._stack), level=2)
+                self.dbg(
+                    "Delaying close for stack: %s" % len(self._stack), level=2
+                )
 
     def invokeloop(self):
         # First we add a few special commands to the loop
         class PWD(BaseControl):
             def __call__(self, args):
-                    self.ctx.out(os.getcwd())
+                self.ctx.out(os.getcwd())
 
         class LS(BaseControl):
             def __call__(self, args):
-                for p in sorted(path(os.getcwd()).listdir(
-                        unreadable_as_empty=True)):
+                for p in sorted(
+                    path(os.getcwd()).listdir(unreadable_as_empty=True)
+                ):
                     self.ctx.out(str(p.basename()))
 
         class CD(BaseControl):
-
             def _complete(self, text, line, begidx, endidx):
                 RE = re.compile(r"\s*cd\s*")
                 m = RE.match(line)
                 if m:
-                    replaced = RE.sub('', line)
+                    replaced = RE.sub("", line)
                     return self._complete_file(replaced, path(os.getcwd()))
                 return []
 
@@ -1345,15 +1473,18 @@ class CLI(cmd.Cmd, Context):
             if len(debug_opts) == 0:
                 args.func(args)
             elif len(debug_opts) > 1:
-                self.die(9, "Conflicting debug options: %s"
-                         % ", ".join(debug_opts))
+                self.die(
+                    9, "Conflicting debug options: %s" % ", ".join(debug_opts)
+                )
             elif "t" in debug_opts or "trace" in debug_opts:
                 import trace
+
                 tracer = trace.Trace()
                 tracer.runfunc(args.func, args)
             elif "p" in debug_opts or "profile" in debug_opts:
                 from hotshot import stats, Profile
                 from omero.util import get_omero_userdir
+
                 profile_file = old_div(get_omero_userdir(), "hotshot_edi_stats")
                 prof = Profile(profile_file)
                 prof.runcall(lambda: args.func(args))
@@ -1436,13 +1567,20 @@ class CLI(cmd.Cmd, Context):
             raise NonZeroReturnCode(rv, "%s => %d" % (" ".join(args), rv))
         return rv
 
-    def popen(self, args, cwd=None, stdout=subprocess.PIPE,
-              stderr=subprocess.PIPE, **kwargs):
+    def popen(
+        self,
+        args,
+        cwd=None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs
+    ):
         self.dbg("Returning popen: %s" % args)
         env = self._env()
         env.update(kwargs)
-        return subprocess.Popen(args, env=env, cwd=self._cwd(cwd),
-                                stdout=stdout, stderr=stderr)
+        return subprocess.Popen(
+            args, env=env, cwd=self._cwd(cwd), stdout=stdout, stderr=stderr
+        )
 
     def get_config_property_lines(self, root_path):
         """
@@ -1450,16 +1588,17 @@ class CLI(cmd.Cmd, Context):
         property files from OMERO components then from the top level.
         Trailing whitespace is stripped from each line.
         """
-        jar_root = root_path / 'lib' / 'server'
+        jar_root = root_path / "lib" / "server"
         for component in OMERO_COMPONENTS:
             from zipfile import ZipFile, is_zipfile, BadZipfile
-            jar_name = old_div(jar_root, 'omero-{}.jar'.format(component))
+
+            jar_name = old_div(jar_root, "omero-{}.jar".format(component))
             if is_zipfile(jar_name):
-                config_name = 'omero-{}.properties'.format(component)
+                config_name = "omero-{}.properties".format(component)
                 try:
-                    with ZipFile(jar_name, 'r') as jar_file:
-                        with jar_file.open(config_name, 'r') as config:
-                            for line in iter(config.readline, ''):
+                    with ZipFile(jar_name, "r") as jar_file:
+                        with jar_file.open(config_name, "r") as config:
+                            for line in iter(config.readline, ""):
                                 if not line:
                                     break
                                 yield line.rstrip()
@@ -1467,9 +1606,9 @@ class CLI(cmd.Cmd, Context):
                     pass
         # etc/omero.properties comes last because it may contain "### END"
         try:
-            file_path = root_path / 'etc' / 'omero.properties'
-            with open(file_path, 'r') as config:
-                for line in iter(config.readline, ''):
+            file_path = root_path / "etc" / "omero.properties"
+            with open(file_path, "r") as config:
+                for line in iter(config.readline, ""):
                     if not line:
                         break
                     yield line.rstrip()
@@ -1493,17 +1632,17 @@ class CLI(cmd.Cmd, Context):
         for line in output.splitlines():
             if isbytes(line):
                 line = bytes_to_native_str(line)
-            if line.startswith(
-                    "Listening for transport dt_socket at address"):
+            if line.startswith("Listening for transport dt_socket at address"):
                 self.dbg(
-                    "Ignoring stdout 'Listening for transport' from DEBUG=1")
+                    "Ignoring stdout 'Listening for transport' from DEBUG=1"
+                )
                 continue
             parts = line.split("=", 1)
             if len(parts) == 2:
                 data.properties.setProperty(parts[0], parts[1])
                 self.dbg("Set property: %s=%s" % (parts[0], parts[1]))
             else:
-                self.dbg("Bad property:"+str(parts))
+                self.dbg("Bad property:" + str(parts))
         return data
 
     def initData(self, properties=None):
@@ -1515,14 +1654,18 @@ class CLI(cmd.Cmd, Context):
             properties = {}
 
         from omero.plugins.prefs import getprefs
+
         try:
-            output = getprefs(["get"], str(old_div(path(self._cwd(None)), "lib")))
+            output = getprefs(
+                ["get"], str(old_div(path(self._cwd(None)), "lib"))
+            )
         except OSError as err:
             self.err("Error getting preferences")
             self.dbg(err)
             output = ""
 
         import Ice
+
         data = Ice.InitializationData()
         data.properties = Ice.createProperties()
         for k, v in list(properties.items()):
@@ -1660,16 +1803,16 @@ class CLI(cmd.Cmd, Context):
                 traceback.print_exc()
 
     def get_event_context(self):
-        return getattr(self, '_event_context', None)
+        return getattr(self, "_event_context", None)
 
     def set_event_context(self, ec):
-        setattr(self, '_event_context', ec)
+        setattr(self, "_event_context", ec)
 
     def get_client(self):
-        return getattr(self, '_client', None)
+        return getattr(self, "_client", None)
 
     def set_client(self, client):
-        setattr(self, '_client', client)
+        setattr(self, "_client", client)
 
     # End Cli
     ###########################################################
@@ -1739,8 +1882,10 @@ def argv(args=sys.argv):
         # parser.add_argument("-d", "--debug", help="Use 'help debug' for more
         # information", default = SUPPRESS)
         parser.add_argument(
-            "--path", action="append",
-            help="Add file or directory to plugin list. Supports globs.")
+            "--path",
+            action="append",
+            help="Add file or directory to plugin list. Supports globs.",
+        )
         ns, args = parser.parse_known_args(args)
         if getattr(ns, "path"):
             for p in ns.path:
@@ -1760,13 +1905,13 @@ def argv(args=sys.argv):
         if old_ice_config:
             os.putenv("ICE_CONFIG", old_ice_config)
 
+
 #####################################################
 #
 # Specific argument types
 
 
 class ExperimenterArg(object):
-
     def __init__(self, arg):
         self.orig = arg
         self.usr = None
@@ -1784,6 +1929,7 @@ class ExperimenterArg(object):
     def lookup(self, client):
         if self.usr is None:
             import omero
+
             a = client.sf.getAdminService()
             try:
                 self.usr = a.lookupExperimenter(self.orig).id.val
@@ -1793,7 +1939,6 @@ class ExperimenterArg(object):
 
 
 class ExperimenterGroupArg(object):
-
     def __init__(self, arg):
         self.orig = arg
         self.grp = None
@@ -1811,6 +1956,7 @@ class ExperimenterGroupArg(object):
     def lookup(self, client):
         if self.grp is None:
             import omero
+
             a = client.sf.getAdminService()
             try:
                 self.grp = a.lookupGroup(self.orig).id.val
@@ -1820,7 +1966,6 @@ class ExperimenterGroupArg(object):
 
 
 class GraphArg(object):
-
     def __init__(self, cmd_type):
         self.cmd_type = cmd_type
 
@@ -1830,7 +1975,7 @@ class GraphArg(object):
         try:
             parts = arg.split(":", 1)
             assert len(parts) == 2
-            assert '+' not in parts[0]
+            assert "+" not in parts[0]
             parts[0] = parts[0].lstrip("/")
             graph = parts[0].split("/")
             ids = []
@@ -1841,7 +1986,7 @@ class GraphArg(object):
                     low, high = list(map(int, id.split("-")))
                     if high < low:
                         raise ValueError("Bad range: %s", arg)
-                    ids.extend(list(range(low, high+1)))
+                    ids.extend(list(range(low, high + 1)))
                 else:
                     ids.append(int(id))
             targetObjects[graph[0]] = ids
@@ -1859,13 +2004,13 @@ class GraphArg(object):
     def __repr__(self):
         return "argument"
 
+
 #####################################################
 #
 # Specific superclasses for various controls
 
 
 class CmdControl(BaseControl):
-
     def cmd_type(self):
         raise Exception("Must be overridden by subclasses")
 
@@ -1900,7 +2045,7 @@ class CmdControl(BaseControl):
 
     def create_error_report(self, rsp):
         if isinstance(rsp, omero.cmd.GraphException):
-            return 'failed: %s' % rsp.message
+            return "failed: %s" % rsp.message
 
         """
         Generate default error report aggregating the response parameters
@@ -1918,7 +2063,7 @@ class CmdControl(BaseControl):
         if err:
             self.ctx.err(err)
         else:
-            if hasattr(req, 'dryRun') and req.dryRun:
+            if hasattr(req, "dryRun") and req.dryRun:
                 self.ctx.out("Dry run performed")
             self.ctx.out("ok")
 
@@ -1926,7 +2071,9 @@ class CmdControl(BaseControl):
             self.ctx.out("Steps: %s" % status.steps)
             if status.stopTime > 0 and status.startTime > 0:
                 elapse = status.stopTime - status.startTime
-                self.ctx.out("Elapsed time: %s secs." % (old_div(elapse,1000.0)))
+                self.ctx.out(
+                    "Elapsed time: %s secs." % (old_div(elapse, 1000.0))
+                )
             else:
                 self.ctx.out("Unfinished.")
             self.ctx.out("Flags: %s" % status.flags)
@@ -1948,6 +2095,7 @@ class CmdControl(BaseControl):
 
     def response(self, client, req, loops=8, ms=500, wait=None):
         import omero.callbacks
+
         handle = client.sf.submit(req)
         cb = omero.callbacks.CmdCallbackI(client, handle)
 
@@ -1980,7 +2128,6 @@ class CmdControl(BaseControl):
 
 
 class GraphControl(CmdControl):
-
     def cmd_type(self):
         raise Exception("Must be overridden by subclasses")
 
@@ -1989,29 +2136,46 @@ class GraphControl(CmdControl):
         self._add_wait(parser, default=-1)
         parser.add_argument(
             "--include",
-            help="Modifies the given option by including a list of classes")
+            help="Modifies the given option by including a list of classes",
+        )
         parser.add_argument(
             "--exclude",
-            help="Modifies the given option by excluding a list of classes")
+            help="Modifies the given option by excluding a list of classes",
+        )
         parser.add_argument(
-            "--ordered", action="store_true",
-            help=("Pass multiple objects to commands strictly in the order "
-                  "given, otherwise group into as few commands as possible."))
+            "--ordered",
+            action="store_true",
+            help=(
+                "Pass multiple objects to commands strictly in the order "
+                "given, otherwise group into as few commands as possible."
+            ),
+        )
         parser.add_argument(
-            "--list", action="store_true",
-            help="Print a list of all available graph specs")
+            "--list",
+            action="store_true",
+            help="Print a list of all available graph specs",
+        )
         parser.add_argument(
-            "--list-details", action="store_true", help=SUPPRESS)
+            "--list-details", action="store_true", help=SUPPRESS
+        )
         parser.add_argument(
-            "--report", action="store_true",
-            help="Print more detailed report of each action")
+            "--report",
+            action="store_true",
+            help="Print more detailed report of each action",
+        )
         parser.add_argument(
-            "--dry-run", action="store_true",
-            help=("Do a dry run of the command, providing a "
-                  "report of what would have been done"))
+            "--dry-run",
+            action="store_true",
+            help=(
+                "Do a dry run of the command, providing a "
+                "report of what would have been done"
+            ),
+        )
         parser.add_argument(
-            "--force", action="store_true",
-            help=("Force an action that otherwise defaults to a dry run"))
+            "--force",
+            action="store_true",
+            help=("Force an action that otherwise defaults to a dry run"),
+        )
         self._pre_objects(parser)
         self._objects(parser)
 
@@ -2026,8 +2190,11 @@ class GraphControl(CmdControl):
         Allows configuring the "obj" n-argument by overriding this method.
         """
         parser.add_argument(
-            "obj", nargs="*", type=GraphArg(self.cmd_type()),
-            help="Objects to be processed in the form <Class>:<Id>")
+            "obj",
+            nargs="*",
+            type=GraphArg(self.cmd_type()),
+            help="Objects to be processed in the form <Class>:<Id>",
+        )
 
     def as_doall(self, req_or_doall):
         if not isinstance(req_or_doall, omero.cmd.DoAll):
@@ -2084,10 +2251,12 @@ class GraphControl(CmdControl):
         show = not (args.force or args.dry_run)
         needsForce = any(forces)
         if needsForce and show:
-            warnings.warn("\nUsing '--dry-run'.\
+            warnings.warn(
+                "\nUsing '--dry-run'.\
                           Future versions will switch to '--force'.\
                           Explicitly set the parameter for portability",
-                          DeprecationWarning)
+                DeprecationWarning,
+            )
         for req in commands:
             req.dryRun = args.dry_run or needsForce
             if args.force:
@@ -2123,7 +2292,8 @@ class GraphControl(CmdControl):
                 "x.details.owner.id, "
                 "x.details.group.details.permissions "
                 "from %s x "
-                "where x.id = :id") % k
+                "where x.id = :id"
+            ) % k
             if not v:
                 return
             for w in v:
@@ -2132,13 +2302,15 @@ class GraphControl(CmdControl):
                         query.projection(
                             query_str,
                             omero.sys.ParametersI().addId(w),
-                            {"omero.group": "-1"})[0])
+                            {"omero.group": "-1"},
+                        )[0]
+                    )
                     perms = perms["perm"]
                     perms = omero.model.PermissionsI(perms)
                     if perms.isGroupWrite() and uid != own_id:
                         self.ctx.err(
-                            "WARNING: %s:%s belongs to user %s" % (
-                                k, w, uid))
+                            "WARNING: %s:%s belongs to user %s" % (k, w, uid)
+                        )
                 except:
                     self.ctx.dbg(traceback.format_exc())
                     # Doing nothing since this is a best effort
@@ -2151,6 +2323,7 @@ class GraphControl(CmdControl):
         combined using their startFrom object type.
         """
         from omero.cmd import SkipHead
+
         skipheads = [req for req in commands if isinstance(req, SkipHead)]
         others = [req for req in commands if not isinstance(req, SkipHead)]
 
@@ -2191,12 +2364,13 @@ class GraphControl(CmdControl):
             for type in list(req.targetObjects.keys()):
                 ids = self._order_and_range_ids(req.targetObjects[type])
                 if isinstance(req, omero.cmd.SkipHead):
-                    type += ("/" + req.startFrom[0])
-                objects.append('%s:%s' % (type, ids))
-        return "%s %s " % (cmd_type, ' '.join(objects))
+                    type += "/" + req.startFrom[0]
+                objects.append("%s:%s" % (type, ids))
+        return "%s %s " % (cmd_type, " ".join(objects))
 
     def _get_object_ids(self, objDict):
         import collections
+
         objIds = {}
         for k in list(objDict.keys()):
             if objDict[k]:
@@ -2204,65 +2378,73 @@ class GraphControl(CmdControl):
         newIds = collections.OrderedDict(sorted(objIds.items()))
         objIds = collections.OrderedDict()
         for k in newIds:
-            key = k[k.rfind('.')+1:]
+            key = k[k.rfind(".") + 1 :]
             objIds[key] = newIds[k]
         return objIds
 
 
 class UserGroupControl(BaseControl):
-
-    def error_no_input_group(self, msg="No input group is specified",
-                             code=501, fatal=True):
+    def error_no_input_group(
+        self, msg="No input group is specified", code=501, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg)
         else:
             self.ctx.err(msg)
 
-    def error_invalid_groupid(self, group_id, msg="Not a valid group ID: %s",
-                              code=502, fatal=True):
+    def error_invalid_groupid(
+        self, group_id, msg="Not a valid group ID: %s", code=502, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg % group_id)
         else:
             self.ctx.err(msg % group_id)
 
-    def error_invalid_group(self, group, msg="Unknown group: %s", code=503,
-                            fatal=True):
+    def error_invalid_group(
+        self, group, msg="Unknown group: %s", code=503, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg % group)
         else:
             self.ctx.err(msg % group)
 
-    def error_no_group_found(self, msg="No group found", code=504,
-                             fatal=True):
+    def error_no_group_found(self, msg="No group found", code=504, fatal=True):
         if fatal:
             self.ctx.die(code, msg)
         else:
             self.ctx.err(msg)
 
-    def error_ambiguous_group(self, id_or_name,
-                              msg="Ambiguous group identifier: %s", code=505,
-                              fatal=True):
+    def error_ambiguous_group(
+        self,
+        id_or_name,
+        msg="Ambiguous group identifier: %s",
+        code=505,
+        fatal=True,
+    ):
         if fatal:
             self.ctx.die(code, msg % id_or_name)
         else:
             self.ctx.err(msg % id_or_name)
 
-    def error_no_input_user(self, msg="No input user is specified", code=511,
-                            fatal=True):
+    def error_no_input_user(
+        self, msg="No input user is specified", code=511, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg)
         else:
             self.ctx.err(msg)
 
-    def error_invalid_userid(self, user_id, msg="Not a valid user ID: %s",
-                             code=512, fatal=True):
+    def error_invalid_userid(
+        self, user_id, msg="Not a valid user ID: %s", code=512, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg % user_id)
         else:
             self.ctx.err(msg % user_id)
 
-    def error_invalid_user(self, user, msg="Unknown user: %s", code=513,
-                           fatal=True):
+    def error_invalid_user(
+        self, user, msg="Unknown user: %s", code=513, fatal=True
+    ):
         if fatal:
             self.ctx.die(code, msg % user)
         else:
@@ -2274,9 +2456,13 @@ class UserGroupControl(BaseControl):
         else:
             self.ctx.err(msg)
 
-    def error_ambiguous_user(self, id_or_name,
-                             msg="Ambiguous user identifier: %s", code=515,
-                             fatal=True):
+    def error_ambiguous_user(
+        self,
+        id_or_name,
+        msg="Ambiguous user identifier: %s",
+        code=515,
+        fatal=True,
+    ):
         if fatal:
             self.ctx.die(code, msg % id_or_name)
         else:
@@ -2284,6 +2470,7 @@ class UserGroupControl(BaseControl):
 
     def find_group_by_id(self, admin, group_id, fatal=False):
         import omero
+
         try:
             gid = int(group_id)
             g = admin.getGroup(gid)
@@ -2297,6 +2484,7 @@ class UserGroupControl(BaseControl):
 
     def find_group_by_name(self, admin, group_name, fatal=False):
         import omero
+
         try:
             g = admin.lookupGroup(group_name)
             gid = g.id.val
@@ -2339,6 +2527,7 @@ class UserGroupControl(BaseControl):
 
     def find_user_by_id(self, admin, user_id, fatal=False):
         import omero
+
         try:
             uid = int(user_id)
             u = admin.getExperimenter(uid)
@@ -2352,6 +2541,7 @@ class UserGroupControl(BaseControl):
 
     def find_user_by_name(self, admin, user_name, fatal=False):
         import omero
+
         try:
             u = admin.lookupExperimenter(user_name)
             uid = u.id.val
@@ -2394,44 +2584,59 @@ class UserGroupControl(BaseControl):
 
     def addusersbyid(self, admin, group, users):
         import omero
+
         for user in list(users):
             admin.addGroups(omero.model.ExperimenterI(user, False), [group])
             self.ctx.out("Added %s to group %s" % (user, group.id.val))
 
     def removeusersbyid(self, admin, group, users):
         import omero
+
         for user in list(users):
             admin.removeGroups(omero.model.ExperimenterI(user, False), [group])
             self.ctx.out("Removed %s from group %s" % (user, group.id.val))
 
     def addownersbyid(self, admin, group, users):
         import omero
+
         for user in list(users):
-            admin.addGroupOwners(group,
-                                 [omero.model.ExperimenterI(user, False)])
-            self.ctx.out("Added %s to the owner list of group %s"
-                         % (user, group.id.val))
+            admin.addGroupOwners(
+                group, [omero.model.ExperimenterI(user, False)]
+            )
+            self.ctx.out(
+                "Added %s to the owner list of group %s" % (user, group.id.val)
+            )
 
     def removeownersbyid(self, admin, group, users):
         import omero
+
         for user in list(users):
-            admin.removeGroupOwners(group,
-                                    [omero.model.ExperimenterI(user, False)])
-            self.ctx.out("Removed %s from the owner list of group %s"
-                         % (user, group.id.val))
+            admin.removeGroupOwners(
+                group, [omero.model.ExperimenterI(user, False)]
+            )
+            self.ctx.out(
+                "Removed %s from the owner list of group %s"
+                % (user, group.id.val)
+            )
 
     def getuserids(self, group):
         ids = [x.child.id.val for x in group.copyGroupExperimenterMap()]
         return ids
 
     def getmemberids(self, group):
-        ids = [x.child.id.val for x in group.copyGroupExperimenterMap()
-               if not x.owner.val]
+        ids = [
+            x.child.id.val
+            for x in group.copyGroupExperimenterMap()
+            if not x.owner.val
+        ]
         return ids
 
     def getownerids(self, group):
-        ids = [x.child.id.val for x in group.copyGroupExperimenterMap()
-               if x.owner.val]
+        ids = [
+            x.child.id.val
+            for x in group.copyGroupExperimenterMap()
+            if x.owner.val
+        ]
         return ids
 
     def output_users_list(self, admin, users, args):
@@ -2440,14 +2645,33 @@ class UserGroupControl(BaseControl):
         sys_group = roles.systemGroupId
 
         from omero.util.text import TableBuilder
+
         if args.count:
-            tb = TableBuilder("id", "login", "first name", "last name",
-                              "email", "active", "ldap", "admin",
-                              "# group memberships", "# group ownerships")
+            tb = TableBuilder(
+                "id",
+                "login",
+                "first name",
+                "last name",
+                "email",
+                "active",
+                "ldap",
+                "admin",
+                "# group memberships",
+                "# group ownerships",
+            )
         else:
-            tb = TableBuilder("id", "login", "first name", "last name",
-                              "email", "active", "ldap", "admin", "member of",
-                              "owner of")
+            tb = TableBuilder(
+                "id",
+                "login",
+                "first name",
+                "last name",
+                "email",
+                "active",
+                "ldap",
+                "admin",
+                "member of",
+                "owner of",
+            )
         if args.style:
             tb.set_style(args.style)
 
@@ -2467,8 +2691,12 @@ class UserGroupControl(BaseControl):
             users = [users]
 
         for user in users:
-            row = [user.id.val, user.omeName.val, user.firstName.val,
-                   user.lastName.val]
+            row = [
+                user.id.val,
+                user.omeName.val,
+                user.firstName.val,
+                user.lastName.val,
+            ]
             row.append(user.email and user.email.val or "")
             active = ""
             admin = ""
@@ -2520,17 +2748,23 @@ class UserGroupControl(BaseControl):
             groups.sort(key=lambda x: x.id.val)
 
         if args.long:
-            tb = TableBuilder("id", "name", "perms", "ldap", "owner ids",
-                              "member ids")
+            tb = TableBuilder(
+                "id", "name", "perms", "ldap", "owner ids", "member ids"
+            )
         else:
-            tb = TableBuilder("id", "name", "perms", "ldap", "# of owners",
-                              "# of members")
+            tb = TableBuilder(
+                "id", "name", "perms", "ldap", "# of owners", "# of members"
+            )
         if args.style:
             tb.set_style(args.style)
 
         for group in groups:
-            row = [group.id.val, group.name.val,
-                   str(group.details.permissions), group.ldap.val]
+            row = [
+                group.id.val,
+                group.name.val,
+                str(group.details.permissions),
+                group.ldap.val,
+            ]
             ownerids = self.getownerids(group)
             memberids = self.getmemberids(group)
             if args.long:
@@ -2544,14 +2778,11 @@ class UserGroupControl(BaseControl):
 
     def add_id_name_arguments(self, parser, objtype=""):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument(
-            "--id", help="ID of the %s" % objtype)
-        group.add_argument(
-            "--name", help="Name of the %s" % objtype)
+        group.add_argument("--id", help="ID of the %s" % objtype)
+        group.add_argument("--name", help="Name of the %s" % objtype)
         return group
 
-    def add_user_and_group_arguments(self, parser, *args,
-                                     **kwargs):
+    def add_user_and_group_arguments(self, parser, *args, **kwargs):
 
         group = parser
         try:
@@ -2560,35 +2791,47 @@ class UserGroupControl(BaseControl):
         except:
             pass
 
-        group.add_argument("--user-id",
-                           help="ID of the user.",
-                           *args, **kwargs)
-        group.add_argument("--user-name",
-                           help="Name of the user.",
-                           *args, **kwargs)
-        group.add_argument("--group-id",
-                           help="ID of the group.",
-                           *args, **kwargs)
-        group.add_argument("--group-name",
-                           help="Name of the group.",
-                           *args, **kwargs)
+        group.add_argument("--user-id", help="ID of the user.", *args, **kwargs)
+        group.add_argument(
+            "--user-name", help="Name of the user.", *args, **kwargs
+        )
+        group.add_argument(
+            "--group-id", help="ID of the group.", *args, **kwargs
+        )
+        group.add_argument(
+            "--group-name", help="Name of the group.", *args, **kwargs
+        )
 
     def add_user_arguments(self, parser, action=""):
-        group = parser.add_argument_group('User arguments')
-        group.add_argument("user_id_or_name",  metavar="user", nargs="*",
-                           help="ID or name of the user(s)%s" % action)
-        group.add_argument("--user-id", metavar="user", nargs="+",
-                           help="ID of the user(s)%s" % action)
-        group.add_argument("--user-name", metavar="user", nargs="+",
-                           help="Name of the user(s)%s" % action)
+        group = parser.add_argument_group("User arguments")
+        group.add_argument(
+            "user_id_or_name",
+            metavar="user",
+            nargs="*",
+            help="ID or name of the user(s)%s" % action,
+        )
+        group.add_argument(
+            "--user-id",
+            metavar="user",
+            nargs="+",
+            help="ID of the user(s)%s" % action,
+        )
+        group.add_argument(
+            "--user-name",
+            metavar="user",
+            nargs="+",
+            help="Name of the user(s)%s" % action,
+        )
         return group
 
     def add_single_user_argument(self, parser, action="", required=True):
         group = parser.add_mutually_exclusive_group(required=required)
-        group.add_argument("--user-id", metavar="user",
-                           help="ID of the user%s" % action)
-        group.add_argument("--user-name", metavar="user",
-                           help="Name of the user%s" % action)
+        group.add_argument(
+            "--user-id", metavar="user", help="ID of the user%s" % action
+        )
+        group.add_argument(
+            "--user-name", metavar="user", help="Name of the user%s" % action
+        )
         return group
 
     def list_users(self, a, args, use_context=False):
@@ -2598,9 +2841,10 @@ class UserGroupControl(BaseControl):
         """
 
         # Check input arguments
-        has_user_arguments = (args.user_id_or_name or args.user_id
-                              or args.user_name)
-        if (not use_context and not has_user_arguments):
+        has_user_arguments = (
+            args.user_id_or_name or args.user_id or args.user_name
+        )
+        if not use_context and not has_user_arguments:
             self.error_no_input_user(fatal=True)
 
         # Retrieve groups by id or name
@@ -2639,24 +2883,35 @@ class UserGroupControl(BaseControl):
         return uid_list, u_list
 
     def add_group_arguments(self, parser, action=""):
-        group = parser.add_argument_group('Group arguments')
+        group = parser.add_argument_group("Group arguments")
         group.add_argument(
-            "group_id_or_name",  metavar="group", nargs="*",
-            help="ID or name of the group(s)%s" % action)
+            "group_id_or_name",
+            metavar="group",
+            nargs="*",
+            help="ID or name of the group(s)%s" % action,
+        )
         group.add_argument(
-            "--group-id", metavar="group", nargs="+",
-            help="ID  of the group(s)%s" % action)
+            "--group-id",
+            metavar="group",
+            nargs="+",
+            help="ID  of the group(s)%s" % action,
+        )
         group.add_argument(
-            "--group-name", metavar="group", nargs="+",
-            help="Name of the group(s)%s" % action)
+            "--group-name",
+            metavar="group",
+            nargs="+",
+            help="Name of the group(s)%s" % action,
+        )
         return group
 
     def add_single_group_argument(self, parser, action="", required=True):
         group = parser.add_mutually_exclusive_group(required=required)
-        group.add_argument("--group-id", metavar="group",
-                           help="ID of the group%s" % action)
-        group.add_argument("--group-name", metavar="group",
-                           help="Name of the group%s" % action)
+        group.add_argument(
+            "--group-id", metavar="group", help="ID of the group%s" % action
+        )
+        group.add_argument(
+            "--group-name", metavar="group", help="Name of the group%s" % action
+        )
         return group
 
     def list_groups(self, a, args, use_context=False):
@@ -2666,9 +2921,10 @@ class UserGroupControl(BaseControl):
         """
 
         # Check input arguments
-        has_group_arguments = (args.group_id_or_name or args.group_id
-                               or args.group_name)
-        if (not use_context and not has_group_arguments):
+        has_group_arguments = (
+            args.group_id_or_name or args.group_id or args.group_name
+        )
+        if not use_context and not has_group_arguments:
             self.error_no_input_group(fatal=True)
 
         # Retrieve groups by id or name
@@ -2712,29 +2968,27 @@ class UserGroupControl(BaseControl):
 
         if args.user_name:
             for user_name in args.user_name:
-                uid, u = self.find_user_by_name(
-                    iadmin, user_name, fatal=False)
+                uid, u = self.find_user_by_name(iadmin, user_name, fatal=False)
                 if uid is not None:
                     users.append(uid)
 
         if args.user_id:
             for user_id in args.user_id:
-                uid, u = self.find_user_by_id(
-                    iadmin, user_id, fatal=False)
+                uid, u = self.find_user_by_id(iadmin, user_id, fatal=False)
                 if uid is not None:
                     users.append(uid)
 
         if args.group_name:
             for group_name in args.group_name:
                 gid, g = self.find_group_by_name(
-                    iadmin, group_name, fatal=False)
+                    iadmin, group_name, fatal=False
+                )
                 if gid is not None:
                     groups.append(gid)
 
         if args.group_id:
             for group_id in args.group_id:
-                gid, g = self.find_group_by_id(
-                    iadmin, group_id, fatal=False)
+                gid, g = self.find_group_by_id(iadmin, group_id, fatal=False)
                 if gid is not None:
                     groups.append(gid)
 
@@ -2744,20 +2998,20 @@ class UserGroupControl(BaseControl):
         u = None
         g = None
         if args.user_name:
-            uid, u = self.find_user_by_name(
-                iadmin, args.user_name, fatal=False)
+            uid, u = self.find_user_by_name(iadmin, args.user_name, fatal=False)
 
         if args.user_id:
-            uid, u = self.find_user_by_id(
-                iadmin, args.user_id, fatal=False)
+            uid, u = self.find_user_by_id(iadmin, args.user_id, fatal=False)
 
         if args.group_name:
             gid, g = self.find_group_by_name(
-                iadmin, args.group_name, fatal=False)
+                iadmin, args.group_name, fatal=False
+            )
 
         if args.group_id:
             for group_id in args.group_id:
                 gid, g = self.find_group_by_id(
-                    iadmin, args.group_id, fatal=False)
+                    iadmin, args.group_id, fatal=False
+                )
 
         return u, g

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -24,11 +24,13 @@ from future.utils import native, bytes_to_native_str, isbytes
 import omero
 import Ice
 import IceImport
+
 IceImport.load("omero_Tables_ice")
 python_sys = __import__("sys")  # Python sys
 
 try:
     import numpy
+
     tables = __import__("tables")  # Pytables
     has_pytables = True
     if hasattr(tables, "open_file"):
@@ -50,7 +52,8 @@ def columns2definition(cols):
         instance = column.descriptor(pos=i)
         if column.name in definition:
             raise omero.ApiUsageException(
-                None, None, "Duplicate column name: %s" % column.name)
+                None, None, "Duplicate column name: %s" % column.name
+            )
         definition[column.name] = instance
         # Descriptions are handled separately
     return definition
@@ -161,7 +164,6 @@ class AbstractColumn(object):
 
 
 class FileColumnI(AbstractColumn, omero.grid.FileColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.FileColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -171,7 +173,6 @@ class FileColumnI(AbstractColumn, omero.grid.FileColumn):
 
 
 class ImageColumnI(AbstractColumn, omero.grid.ImageColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.ImageColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -181,7 +182,6 @@ class ImageColumnI(AbstractColumn, omero.grid.ImageColumn):
 
 
 class WellColumnI(AbstractColumn, omero.grid.WellColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.WellColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -191,7 +191,6 @@ class WellColumnI(AbstractColumn, omero.grid.WellColumn):
 
 
 class PlateColumnI(AbstractColumn, omero.grid.PlateColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.PlateColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -201,7 +200,6 @@ class PlateColumnI(AbstractColumn, omero.grid.PlateColumn):
 
 
 class RoiColumnI(AbstractColumn, omero.grid.RoiColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.RoiColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -211,7 +209,6 @@ class RoiColumnI(AbstractColumn, omero.grid.RoiColumn):
 
 
 class BoolColumnI(AbstractColumn, omero.grid.BoolColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.BoolColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -221,7 +218,6 @@ class BoolColumnI(AbstractColumn, omero.grid.BoolColumn):
 
 
 class DoubleColumnI(AbstractColumn, omero.grid.DoubleColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.DoubleColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -231,7 +227,6 @@ class DoubleColumnI(AbstractColumn, omero.grid.DoubleColumn):
 
 
 class LongColumnI(AbstractColumn, omero.grid.LongColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.LongColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -288,9 +283,11 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
         for bv in bytevalues:
             if len(bv) > self.size:
                 raise omero.ValidationException(
-                    None, None,
-                    "Maximum string (byte) length in column %s is %d" %
-                    (self.name, self.size))
+                    None,
+                    None,
+                    "Maximum string (byte) length in column %s is %d"
+                    % (self.name, self.size),
+                )
         return [bytevalues]
 
     def dtypes(self):
@@ -308,8 +305,8 @@ class StringColumnI(AbstractColumn, omero.grid.StringColumn):
             return tables.StringCol(pos=pos, itemsize=1)
         if self.size < 1:
             raise omero.ApiUsageException(
-                None, None, "String size must be > 0 (Column: %s)"
-                % self.name)
+                None, None, "String size must be > 0 (Column: %s)" % self.name
+            )
         return tables.StringCol(pos=pos, itemsize=self.size)
 
     def fromrows(self, rows):
@@ -356,8 +353,11 @@ class AbstractArrayColumn(AbstractColumn):
         for v in self.values:
             if len(v) != self.size:
                 raise omero.ValidationException(
-                    None, None, "Column %s requires arrays of length %d" %
-                    (self.name, self.size))
+                    None,
+                    None,
+                    "Column %s requires arrays of length %d"
+                    % (self.name, self.size),
+                )
 
         if self.size == 1:
             return [[v[0] for v in self.values]]
@@ -371,7 +371,6 @@ class AbstractArrayColumn(AbstractColumn):
 
 
 class FloatArrayColumnI(AbstractArrayColumn, omero.grid.FloatArrayColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.FloatArrayColumn.__init__(self, name, *args)
         AbstractArrayColumn.__init__(self)
@@ -382,13 +381,12 @@ class FloatArrayColumnI(AbstractArrayColumn, omero.grid.FloatArrayColumn):
             return tables.Float32Col(pos=pos)
         if self.size < 1:
             raise omero.ApiUsageException(
-                None, None, "Array length must be > 0 (Column: %s)"
-                % self.name)
+                None, None, "Array length must be > 0 (Column: %s)" % self.name
+            )
         return tables.Float32Col(pos=pos, shape=self.size)
 
 
 class DoubleArrayColumnI(AbstractArrayColumn, omero.grid.DoubleArrayColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.DoubleArrayColumn.__init__(self, name, *args)
         AbstractArrayColumn.__init__(self)
@@ -399,13 +397,12 @@ class DoubleArrayColumnI(AbstractArrayColumn, omero.grid.DoubleArrayColumn):
             return tables.Float64Col(pos=pos)
         if self.size < 1:
             raise omero.ApiUsageException(
-                None, None, "Array length must be > 0 (Column: %s)"
-                % self.name)
+                None, None, "Array length must be > 0 (Column: %s)" % self.name
+            )
         return tables.Float64Col(pos=pos, shape=self.size)
 
 
 class LongArrayColumnI(AbstractArrayColumn, omero.grid.LongArrayColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.LongArrayColumn.__init__(self, name, *args)
         AbstractArrayColumn.__init__(self)
@@ -416,13 +413,12 @@ class LongArrayColumnI(AbstractArrayColumn, omero.grid.LongArrayColumn):
             return tables.Int64Col(pos=pos)
         if self.size < 1:
             raise omero.ApiUsageException(
-                None, None, "Array length must be > 0 (Column: %s)"
-                % self.name)
+                None, None, "Array length must be > 0 (Column: %s)" % self.name
+            )
         return tables.Int64Col(pos=pos, shape=self.size)
 
 
 class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
-
     def __init__(self, name="Unknown", *args):
         omero.grid.MaskColumn.__init__(self, name, *args)
         AbstractColumn.__init__(self)
@@ -456,6 +452,7 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
             y = tables.Float64Col(pos=4)
             w = tables.Float64Col(pos=5)
             h = tables.Float64Col(pos=6)
+
         return MaskDescription()
 
     def arrays(self):
@@ -468,7 +465,7 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
             self.y,
             self.w,
             self.h,
-            ]
+        ]
         return a
 
     def getsize(self):
@@ -538,8 +535,9 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
                 # This occurs primarily in testing.
                 masks.append(numpy.array(x, dtype=tables.UInt8Atom()))
             else:
-                masks.append(numpy.fromstring(x, count=len(x),
-                                              dtype=tables.UInt8Atom()))
+                masks.append(
+                    numpy.fromstring(x, count=len(x), dtype=tables.UInt8Atom())
+                )
 
     def _getmasks(self, tbl):
         n = tbl._v_name
@@ -557,13 +555,13 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
                 masks = f.createVLArray(p, "%s_masks" % n, tables.UInt8Atom())
         return masks
 
+
 # Helpers
 # ========================================================================
 
 
 # Conversion classes are for omero.model <--> ome.model only (no python)
 class ObjectFactory(Ice.ObjectFactory):
-
     def __init__(self, cls, f):
         self.id = cls.ice_staticId()
         self.f = f
@@ -592,10 +590,13 @@ ObjectFactories = {
     LongColumnI: ObjectFactory(LongColumnI, lambda: LongColumnI()),
     StringColumnI: ObjectFactory(StringColumnI, lambda: StringColumnI()),
     FloatArrayColumnI: ObjectFactory(
-        FloatArrayColumnI, lambda: FloatArrayColumnI()),
+        FloatArrayColumnI, lambda: FloatArrayColumnI()
+    ),
     DoubleArrayColumnI: ObjectFactory(
-        DoubleArrayColumnI, lambda: DoubleArrayColumnI()),
+        DoubleArrayColumnI, lambda: DoubleArrayColumnI()
+    ),
     LongArrayColumnI: ObjectFactory(
-        LongArrayColumnI, lambda: LongArrayColumnI()),
-    MaskColumnI: ObjectFactory(MaskColumnI, lambda: MaskColumnI())
-    }
+        LongArrayColumnI, lambda: LongArrayColumnI()
+    ),
+    MaskColumnI: ObjectFactory(MaskColumnI, lambda: MaskColumnI()),
+}

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -30,7 +30,12 @@ sys = __import__("sys")
 import xml.dom.minidom
 
 from xml.etree.ElementTree import (
-    XML, Element, ElementTree, SubElement, Comment, tostring
+    XML,
+    Element,
+    ElementTree,
+    SubElement,
+    Comment,
+    tostring,
 )
 import omero_ext.path as path
 from omero_ext import portalocker
@@ -86,14 +91,16 @@ class ConfigXml(object):
     dict-like wrapper around the config.xml file usually stored
     in etc/grid. For a copy of the dict, use "as_map"
     """
+
     KEY = "omero.config.version"
     VERSION = "5.1.0"
     INTERNAL = "__ACTIVE__"
     DEFAULT = "omero.config.profile"
     IGNORE = (KEY, DEFAULT)
 
-    def __init__(self, filename, env_config=None, exclusive=True,
-                 read_only=False):
+    def __init__(
+        self, filename, env_config=None, exclusive=True, read_only=False
+    ):
         # Logs to the class name
         self.logger = logging.getLogger(self.__class__.__name__)
         self.XML = None  # Parsed XML Element
@@ -109,7 +116,8 @@ class ConfigXml(object):
         if self.exclusive:  # must be "a+"
             try:
                 portalocker.lock(
-                    self.lock, portalocker.LOCK_NB | portalocker.LOCK_EX)
+                    self.lock, portalocker.LOCK_NB | portalocker.LOCK_EX
+                )
             except portalocker.LockException:
                 self.lock = None  # Prevent deleting of the file
                 self.close()
@@ -133,13 +141,14 @@ class ConfigXml(object):
             default = self.default()
             self.XML = Element("icegrid")
             properties = SubElement(self.XML, "properties", id=self.INTERNAL)
-            SubElement(properties, "property", name=self.DEFAULT,
-                       value=default)
-            SubElement(properties, "property", name=self.KEY,
-                       value=self.VERSION)
+            SubElement(properties, "property", name=self.DEFAULT, value=default)
+            SubElement(
+                properties, "property", name=self.KEY, value=self.VERSION
+            )
             properties = SubElement(self.XML, "properties", id=default)
-            SubElement(properties, "property", name=self.KEY,
-                       value=self.VERSION)
+            SubElement(
+                properties, "property", name=self.KEY, value=self.VERSION
+            )
 
     def open_source(self):
         self.source = None
@@ -157,7 +166,8 @@ class ConfigXml(object):
                 val = self.env_config.is_non_default()
                 if val is not None:
                     raise Exception(
-                        "Non-default OMERO_CONFIG on read-only: %s" % val)
+                        "Non-default OMERO_CONFIG on read-only: %s" % val
+                    )
             else:
                 self.lock = self._open_lock()  # Open file handle for lock
 
@@ -180,8 +190,9 @@ class ConfigXml(object):
             except:
                 # On windows a WindowsError 32 can happen (file opened by
                 # another process), ignoring
-                self.logger.error("Failed to removed lock file, ignoring",
-                                  exc_info=True)
+                self.logger.error(
+                    "Failed to removed lock file, ignoring", exc_info=True
+                )
                 pass
 
     def version(self, id=None):
@@ -208,14 +219,21 @@ class ConfigXml(object):
                         val = x.get("value", "")
                         toplinks = json.loads(val)
                         defaultlinks = [
-                            ["Data", "webindex",
-                                {"title":
-                                 "Browse Data via Projects, Tags etc"}],
-                            ["History", "history",
-                                {"title": "History"}],
-                            ["Help", "https://help.openmicroscopy.org/",
-                                {"target": "new", "title":
-                                    "Open OMERO user guide in a new tab"}]]
+                            [
+                                "Data",
+                                "webindex",
+                                {"title": "Browse Data via Projects, Tags etc"},
+                            ],
+                            ["History", "history", {"title": "History"}],
+                            [
+                                "Help",
+                                "https://help.openmicroscopy.org/",
+                                {
+                                    "target": "new",
+                                    "title": "Open OMERO user guide in a new tab",
+                                },
+                            ],
+                        ]
                         toplinks = defaultlinks + toplinks
                         val = json.dumps(toplinks)
                         x.set("value", val)
@@ -240,11 +258,13 @@ class ConfigXml(object):
                         val = orig.replace("${omero.dollar}", "")
                         val = val.replace("${", "@{")
                         x.set("value", val)
-                        self.logger.info("Upgraded 4.2.0 property:  %s => %s",
-                                         orig, val)
+                        self.logger.info(
+                            "Upgraded 4.2.0 property:  %s => %s", orig, val
+                        )
         else:
-            raise Exception("Version mismatch: %s has %s" %
-                            (props.get("id"), version))
+            raise Exception(
+                "Version mismatch: %s has %s" % (props.get("id"), version)
+            )
 
     def internal(self):
         return self.properties(self.INTERNAL)
@@ -295,12 +315,18 @@ class ConfigXml(object):
         intra-element whitespace) and overwrites the file on disk.
         """
         icegrid = Element("icegrid")
-        comment = Comment("\n".join([
-            "\n",
-            "\tThis file was generated at %s by the OmeroConfig system.",
-            "\tDo not edit directly but see `omero config` for details.",
-            "\tThis file may be included into your IceGrid application.",
-            "\n"]) % time.ctime())
+        comment = Comment(
+            "\n".join(
+                [
+                    "\n",
+                    "\tThis file was generated at %s by the OmeroConfig system.",
+                    "\tDo not edit directly but see `omero config` for details.",
+                    "\tThis file may be included into your IceGrid application.",
+                    "\n",
+                ]
+            )
+            % time.ctime()
+        )
         icegrid.append(comment)
         # First step is to add a new self.INTERNAL block to it
         # which has self.DEFAULT set to the current default,
@@ -318,8 +344,9 @@ class ConfigXml(object):
         else:
             # Doesn't exist, create it
             properties = SubElement(icegrid, "properties", id=default)
-            SubElement(properties, "property", name=self.KEY,
-                       value=self.VERSION)
+            SubElement(
+                properties, "property", name=self.KEY, value=self.VERSION
+            )
 
         # Now we simply reproduce all the other blocks
         prop_list = self.properties(None, True)
@@ -391,9 +418,8 @@ class ConfigXml(object):
         return rv
 
     def element_to_xml(self, elem):
-        string = tostring(elem, 'utf-8')
-        return xml.dom.minidom.parseString(string).toprettyxml("  ", "\n",
-                                                               None)
+        string = tostring(elem, "utf-8")
+        return xml.dom.minidom.parseString(string).toprettyxml("  ", "\n", None)
 
     def clear_text(self, p):
         """

--- a/src/omero/conversions.py
+++ b/src/omero/conversions.py
@@ -28,6 +28,8 @@ from __future__ import division
 from builtins import str
 from past.utils import old_div
 from builtins import object
+
+
 class Conversion(object):
     """
     Base-functor like object which can be used for preparing complex

--- a/src/omero/fs/__init__.py
+++ b/src/omero/fs/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import IceImport
+
 IceImport.load("omero_FS_ice")
 
 #
@@ -15,4 +16,4 @@ TRANSFERS = {
     "ome.formats.importer.transfers.SymlinkFileTransfer": "ln_s",
     "ome.formats.importer.transfers.UploadRmFileTransfer": "upload_rm",
     "ome.formats.importer.transfers.UploadFileTransfer": "",
-    }
+}

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -16,6 +16,7 @@ from __future__ import division
 # Set up the python include paths
 from past.builtins import cmp
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import chr
 from builtins import map
@@ -87,7 +88,7 @@ logger = logging.getLogger(__name__)
 THISPATH = os.path.dirname(os.path.abspath(__file__))
 
 try:
-    from PIL import Image, ImageDraw, ImageFont     # see ticket:2597
+    from PIL import Image, ImageDraw, ImageFont  # see ticket:2597
 except:  # pragma: nocover
     try:
         # see ticket:2597
@@ -96,7 +97,8 @@ except:  # pragma: nocover
         import ImageFont
     except:
         logger.error(
-            'No Pillow installed, line plots and split channel will fail!')
+            "No Pillow installed, line plots and split channel will fail!"
+        )
 
 
 def omero_type(val):
@@ -118,7 +120,7 @@ def omero_type(val):
     if isinstance(val, StringType):
         return rstring(val)
     elif isinstance(val, UnicodeType):
-        return rstring(val.encode('utf-8'))
+        return rstring(val.encode("utf-8"))
     elif isinstance(val, BooleanType):
         return rbool(val)
     elif isinstance(val, IntType):
@@ -145,10 +147,10 @@ def fileread(fin, fsize, bufsize):
     """
     # Read it all in one go
     p = 0
-    rv = b''
+    rv = b""
     try:
         while p < fsize:
-            s = min(bufsize, fsize-p)
+            s = min(bufsize, fsize - p)
             rv += fin.read(p, s)
             p += s
     finally:
@@ -172,7 +174,7 @@ def fileread_gen(fin, fsize, bufsize):
     p = 0
     try:
         while p < fsize:
-            s = min(bufsize, fsize-p)
+            s = min(bufsize, fsize - p)
             yield fin.read(p, s)
             p += s
     finally:
@@ -189,9 +191,9 @@ def getAnnotationLinkTableName(objecttype):
     if objecttype == "project":
         return "ProjectAnnotationLink"
     if objecttype == "dataset":
-        return"DatasetAnnotationLink"
+        return "DatasetAnnotationLink"
     if objecttype == "image":
-        return"ImageAnnotationLink"
+        return "ImageAnnotationLink"
     if objecttype == "screen":
         return "ScreenAnnotationLink"
     if objecttype == "plate":
@@ -205,30 +207,33 @@ def getAnnotationLinkTableName(objecttype):
 
 def getPixelsQuery(imageName):
     """Helper for building Query for Images or Wells & Images"""
-    return (' left outer join fetch %s.pixels as pixels'
-            ' left outer join fetch pixels.pixelsType' % imageName)
+    return (
+        " left outer join fetch %s.pixels as pixels"
+        " left outer join fetch pixels.pixelsType" % imageName
+    )
 
 
 def getChannelsQuery():
     """Helper for building Query for Images or Wells & Images"""
-    return (' join fetch pixels.channels as channels'
-            ' join fetch channels.logicalChannel as logicalChannel'
-            ' left outer join fetch '
-            ' logicalChannel.photometricInterpretation'
-            ' left outer join fetch logicalChannel.illumination'
-            ' left outer join fetch logicalChannel.mode'
-            ' left outer join fetch logicalChannel.contrastMethod')
+    return (
+        " join fetch pixels.channels as channels"
+        " join fetch channels.logicalChannel as logicalChannel"
+        " left outer join fetch "
+        " logicalChannel.photometricInterpretation"
+        " left outer join fetch logicalChannel.illumination"
+        " left outer join fetch logicalChannel.mode"
+        " left outer join fetch logicalChannel.contrastMethod"
+    )
 
 
 def add_plate_filter(clauses, params, opts):
     """Helper for adding 'plate' to filtering clauses and parameters."""
-    if opts is not None and 'plate' in opts:
-        clauses.append('obj.plate.id = :pid')
-        params.add('pid', rlong(opts['plate']))
+    if opts is not None and "plate" in opts:
+        clauses.append("obj.plate.id = :pid")
+        params.add("pid", rlong(opts["plate"]))
 
 
-class OmeroRestrictionWrapper (object):
-
+class OmeroRestrictionWrapper(object):
     def canDownload(self):
         """
         Determines if the current user can Download raw data linked to this
@@ -239,11 +244,14 @@ class OmeroRestrictionWrapper (object):
         :rtype:     Boolean
         :return:    True if user can download.
         """
-        return not self.getDetails().getPermissions().isRestricted(
-            omero.constants.permissions.BINARYACCESS)
+        return (
+            not self.getDetails()
+            .getPermissions()
+            .isRestricted(omero.constants.permissions.BINARYACCESS)
+        )
 
 
-class BlitzObjectWrapper (object):
+class BlitzObjectWrapper(object):
     """
     Object wrapper class which provides various methods for hierarchy
     traversing, saving, handling permissions etc. This is the 'abstract' super
@@ -256,7 +264,7 @@ class BlitzObjectWrapper (object):
     # E.g. 'Project', 'Dataset', 'Experimenter' etc.
     OMERO_CLASS = None
     LINK_CLASS = None
-    LINK_CHILD = 'child'
+    LINK_CHILD = "child"
     CHILD_WRAPPER_CLASS = None
     PARENT_WRAPPER_CLASS = None
 
@@ -283,12 +291,14 @@ class BlitzObjectWrapper (object):
         self._creationDate = None
         if conn is None:
             return
-        if hasattr(obj, 'id') and obj.id is not None:
+        if hasattr(obj, "id") and obj.id is not None:
             self._oid = obj.id.val
             if not self._obj.loaded:
                 self._obj = self._conn.getQueryService().get(
-                    self._obj.__class__.__name__, self._oid,
-                    self._conn.SERVICE_OPTS)
+                    self._obj.__class__.__name__,
+                    self._oid,
+                    self._conn.SERVICE_OPTS,
+                )
         self.__prepare__(**kwargs)
 
     def __eq__(self, a):
@@ -299,9 +309,11 @@ class BlitzObjectWrapper (object):
         :return:    True if objects are same - see above
         :rtype:     Boolean
         """
-        return (type(a) == type(self) and
-                self._obj.id == a._obj.id and
-                self.getName() == a.getName())
+        return (
+            type(a) == type(self)
+            and self._obj.id == a._obj.id
+            and self.getName() == a.getName()
+        )
 
     def __bstrap__(self):
         """
@@ -324,8 +336,8 @@ class BlitzObjectWrapper (object):
         :return:    String E.g. '<DatasetWrapper id=123>'
         :rtype:     String
         """
-        if hasattr(self, '_oid'):
-            return '<%s id=%s>' % (self.__class__.__name__, str(self._oid))
+        if hasattr(self, "_oid"):
+            return "<%s id=%s>" % (self.__class__.__name__, str(self._oid))
         return super(BlitzObjectWrapper, self).__repr__()
 
     def _unwrapunits(self, obj, units=None):
@@ -372,9 +384,11 @@ class BlitzObjectWrapper (object):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from %s obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent" % cls.OMERO_CLASS)
+        query = (
+            "select obj from %s obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent" % cls.OMERO_CLASS
+        )
 
         params = omero.sys.ParametersI()
         clauses = []
@@ -396,13 +410,14 @@ class BlitzObjectWrapper (object):
         """
         if self.CHILD_WRAPPER_CLASS is None:  # pragma: no cover
             raise NotImplementedError(
-                '%s has no child wrapper defined' % self.__class__)
+                "%s has no child wrapper defined" % self.__class__
+            )
         if isinstance(self.CHILD_WRAPPER_CLASS, StringTypes):
             # resolve class
             if hasattr(omero.gateway, self.CHILD_WRAPPER_CLASS):
-                self.__class__.CHILD_WRAPPER_CLASS \
-                    = self.CHILD_WRAPPER_CLASS \
-                    = getattr(omero.gateway, self.CHILD_WRAPPER_CLASS)
+                self.__class__.CHILD_WRAPPER_CLASS = (
+                    self.CHILD_WRAPPER_CLASS
+                ) = getattr(omero.gateway, self.CHILD_WRAPPER_CLASS)
             else:  # pragma: no cover
                 raise NotImplementedError
         return self.CHILD_WRAPPER_CLASS
@@ -420,7 +435,9 @@ class BlitzObjectWrapper (object):
             raise NotImplementedError
         pwc = self.PARENT_WRAPPER_CLASS
         if not isinstance(pwc, ListType):
-            pwc = [pwc, ]
+            pwc = [
+                pwc,
+            ]
         for i in range(len(pwc)):
             if isinstance(pwc[i], StringTypes):
                 # resolve class
@@ -430,10 +447,13 @@ class BlitzObjectWrapper (object):
                 pwc[i] = g[pwc[i]]
 
         # Cache this so we don't need to resolve classes again
-        if (pwc != self.PARENT_WRAPPER_CLASS or
-                pwc != self.__class__.PARENT_WRAPPER_CLASS):
-            self.__class__.PARENT_WRAPPER_CLASS \
-                = self.PARENT_WRAPPER_CLASS = pwc
+        if (
+            pwc != self.PARENT_WRAPPER_CLASS
+            or pwc != self.__class__.PARENT_WRAPPER_CLASS
+        ):
+            self.__class__.PARENT_WRAPPER_CLASS = (
+                self.PARENT_WRAPPER_CLASS
+            ) = pwc
         return self.PARENT_WRAPPER_CLASS
 
     def __loadedHotSwap__(self):
@@ -443,7 +463,8 @@ class BlitzObjectWrapper (object):
         specify how/which linked objects are loaded
         """
         self._obj = self._conn.getContainerService().loadContainerHierarchy(
-            self.OMERO_CLASS, (self._oid,), None, self._conn.SERVICE_OPTS)[0]
+            self.OMERO_CLASS, (self._oid,), None, self._conn.SERVICE_OPTS
+        )[0]
 
     def _moveLink(self, newParent):
         """
@@ -463,19 +484,26 @@ class BlitzObjectWrapper (object):
         if p.OMERO_CLASS == newParent.OMERO_CLASS:
             link = self._conn.getQueryService().findAllByQuery(
                 "select l from %s as l where l.parent.id=%i and l.child.id=%i"
-                % (p.LINK_CLASS, p.id, self.id), None, self._conn.SERVICE_OPTS)
+                % (p.LINK_CLASS, p.id, self.id),
+                None,
+                self._conn.SERVICE_OPTS,
+            )
             if len(link):
                 link[0].parent = newParent._obj
                 self._conn.getUpdateService().saveObject(
-                    link[0], self._conn.SERVICE_OPTS)
+                    link[0], self._conn.SERVICE_OPTS
+                )
                 return True
             logger.debug(
                 "## query didn't return objects: 'select l from %s as l "
                 "where l.parent.id=%i and l.child.id=%i'"
-                % (p.LINK_CLASS, p.id, self.id))
+                % (p.LINK_CLASS, p.id, self.id)
+            )
         else:
-            logger.debug("## %s != %s ('%s' - '%s')" %
-                         (type(p), type(newParent), str(p), str(newParent)))
+            logger.debug(
+                "## %s != %s ('%s' - '%s')"
+                % (type(p), type(newParent), str(p), str(newParent))
+            )
         return False
 
     def findChildByName(self, name, description=None):
@@ -490,9 +518,9 @@ class BlitzObjectWrapper (object):
         """
         for c in self.listChildren():
             if c.getName() == name:
-                if (description is None or
-                        omero_type(description) ==
-                        omero_type(c.getDescription())):
+                if description is None or omero_type(description) == omero_type(
+                    c.getDescription()
+                ):
                     return c
         return None
 
@@ -504,8 +532,9 @@ class BlitzObjectWrapper (object):
         :rtype:     :class:`DetailsWrapper`
         """
         if self._obj.loaded:
-            return omero.gateway.DetailsWrapper(self._conn,
-                                                self._obj.getDetails())
+            return omero.gateway.DetailsWrapper(
+                self._conn, self._obj.getDetails()
+            )
         return None
 
     def getDate(self):
@@ -518,10 +547,12 @@ class BlitzObjectWrapper (object):
         """
 
         try:
-            if (self._obj.acquisitionDate.val is not None and
-                    self._obj.acquisitionDate.val > 0):
+            if (
+                self._obj.acquisitionDate.val is not None
+                and self._obj.acquisitionDate.val > 0
+            ):
                 t = self._obj.acquisitionDate.val
-                return datetime.fromtimestamp(old_div(t,1000))
+                return datetime.fromtimestamp(old_div(t, 1000))
         except:
             # object doesn't have acquisitionDate
             pass
@@ -540,7 +571,8 @@ class BlitzObjectWrapper (object):
             # matches
             ctx.setOmeroGroup(self.getDetails().getGroup().getId())
         self._obj = self._conn.getUpdateService().saveAndReturnObject(
-            self._obj, ctx)
+            self._obj, ctx
+        )
 
     def saveAs(self, details):
         """
@@ -556,13 +588,16 @@ class BlitzObjectWrapper (object):
         """
         if self._conn.isAdmin():
             d = self.getDetails()
-            if (d.getOwner() and
-                    d.getOwner().omeName == details.getOwner().omeName and
-                    d.getGroup().name == details.getGroup().name):
+            if (
+                d.getOwner()
+                and d.getOwner().omeName == details.getOwner().omeName
+                and d.getGroup().name == details.getGroup().name
+            ):
                 return self.save()
             else:
                 newConn = self._conn.suConn(
-                    details.getOwner().omeName, details.getGroup().name)
+                    details.getOwner().omeName, details.getGroup().name
+                )
                 # p = omero.sys.Principal()
                 # p.name = details.getOwner().omeName
                 # p.group = details.getGroup().name
@@ -603,7 +638,7 @@ class BlitzObjectWrapper (object):
         :rtype:     Boolean
         :return:    True if current user owns this object
         """
-        return (self._obj.details.owner.id.val == self._conn.getUserId())
+        return self._obj.details.owner.id.val == self._conn.getUserId()
 
     def isLeaded(self):
         """
@@ -728,10 +763,11 @@ class BlitzObjectWrapper (object):
         #     self._conn.getQueryService().findAllByQuery(
         #         "from %s as c where c.parent.id=%i"
         #         % (self.LINK_CLASS, self._oid), None))
-        self._cached_countChildren = self._conn.getContainerService(
-            ).getCollectionCount(
-                self.OMERO_CLASS, klass, [self._oid], None,
-                self._conn.SERVICE_OPTS)[self._oid]
+        self._cached_countChildren = self._conn.getContainerService().getCollectionCount(
+            self.OMERO_CLASS, klass, [self._oid], None, self._conn.SERVICE_OPTS
+        )[
+            self._oid
+        ]
         return self._cached_countChildren
 
     def countChildren_cached(self):
@@ -745,7 +781,7 @@ class BlitzObjectWrapper (object):
         :rtype:     Long
         """
 
-        if not hasattr(self, '_cached_countChildren'):
+        if not hasattr(self, "_cached_countChildren"):
             return self.countChildren()
         return self._cached_countChildren
 
@@ -775,8 +811,12 @@ class BlitzObjectWrapper (object):
                     params.map["val"] = omero_type(val)
                     query += " and a.textValue=:val"
         query += " order by c.child.name"
-        for child in (x.child for x in self._conn.getQueryService(
-                ).findAllByQuery(query, params, self._conn.SERVICE_OPTS)):
+        for child in (
+            x.child
+            for x in self._conn.getQueryService().findAllByQuery(
+                query, params, self._conn.SERVICE_OPTS
+            )
+        ):
             yield child
 
     def listChildren(self, ns=None, val=None, params=None):
@@ -830,23 +870,32 @@ class BlitzObjectWrapper (object):
             pwck = pwc()
             if withlinks:
                 parentnodes.extend(
-                    [(pwc(self._conn, pwck.LINK_PARENT(x), self._cache),
-                        BlitzObjectWrapper(self._conn, x))
-                        for x in self._conn.getQueryService(
-                            ).findAllByQuery(
-                                "from %s as c where c.%s.id=%i"
-                                % (pwck.LINK_CLASS, pwck.LINK_CHILD,
-                                   self._oid),
-                                param, self._conn.SERVICE_OPTS)])
+                    [
+                        (
+                            pwc(self._conn, pwck.LINK_PARENT(x), self._cache),
+                            BlitzObjectWrapper(self._conn, x),
+                        )
+                        for x in self._conn.getQueryService().findAllByQuery(
+                            "from %s as c where c.%s.id=%i"
+                            % (pwck.LINK_CLASS, pwck.LINK_CHILD, self._oid),
+                            param,
+                            self._conn.SERVICE_OPTS,
+                        )
+                    ]
+                )
             else:
                 t = self._conn.getQueryService().findAllByQuery(
                     "from %s as c where c.%s.id=%i"
-                    % (pwck.LINK_CLASS, pwck.LINK_CHILD,
-                       self._oid),
-                    param, self._conn.SERVICE_OPTS)
+                    % (pwck.LINK_CLASS, pwck.LINK_CHILD, self._oid),
+                    param,
+                    self._conn.SERVICE_OPTS,
+                )
                 parentnodes.extend(
-                    [pwc(self._conn, pwck.LINK_PARENT(x), self._cache)
-                        for x in t])
+                    [
+                        pwc(self._conn, pwck.LINK_PARENT(x), self._cache)
+                        for x in t
+                    ]
+                )
         return parentnodes
 
     def getAncestry(self):
@@ -884,15 +933,18 @@ class BlitzObjectWrapper (object):
                 break
         if link_class is None:
             raise AttributeError(
-                "This object has no parent objects with a link class!")
+                "This object has no parent objects with a link class!"
+            )
         query_serv = self._conn.getQueryService()
         p = omero.sys.Parameters()
         p.map = {}
         p.map["child"] = rlong(self.id)
-        sql = "select pchl from %s as pchl " \
-            "left outer join fetch pchl.parent as parent " \
-            "left outer join fetch pchl.child as child " \
+        sql = (
+            "select pchl from %s as pchl "
+            "left outer join fetch pchl.parent as parent "
+            "left outer join fetch pchl.child as child "
             "where child.id=:child" % link_class
+        )
         if isinstance(pids, list) and len(pids) > 0:
             p.map["parent"] = rlist([rlong(pa) for pa in pids])
             sql += " and parent.id in (:parent)"
@@ -915,10 +967,12 @@ class BlitzObjectWrapper (object):
         p = omero.sys.Parameters()
         p.map = {}
         p.map["parent"] = rlong(self.id)
-        sql = ("select pchl from %s as pchl left outer join "
-               "fetch pchl.child as child left outer join "
-               "fetch pchl.parent as parent where parent.id=:parent"
-               % self.LINK_CLASS)
+        sql = (
+            "select pchl from %s as pchl left outer join "
+            "fetch pchl.child as child left outer join "
+            "fetch pchl.parent as parent where parent.id=:parent"
+            % self.LINK_CLASS
+        )
         if isinstance(chids, list) and len(chids) > 0:
             p.map["children"] = rlist([rlong(ch) for ch in chids])
             sql += " and child.id in (:children)"
@@ -932,22 +986,25 @@ class BlitzObjectWrapper (object):
         Also loads file for file annotations.
         """
         # pragma: no cover
-        if not hasattr(self._obj, 'isAnnotationLinksLoaded'):
+        if not hasattr(self._obj, "isAnnotationLinksLoaded"):
             raise NotImplementedError
         # Need to set group context. If '-1' then canDelete() etc on
         # annotations will be False
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
         if not self._obj.isAnnotationLinksLoaded():
-            query = ("select l from %sAnnotationLink as l join "
-                     "fetch l.details.owner join "
-                     "fetch l.details.creationEvent "
-                     "join fetch l.child as a join fetch a.details.owner "
-                     "left outer join fetch a.file "
-                     "join fetch a.details.creationEvent where l.parent.id=%i"
-                     % (self.OMERO_CLASS, self._oid))
+            query = (
+                "select l from %sAnnotationLink as l join "
+                "fetch l.details.owner join "
+                "fetch l.details.creationEvent "
+                "join fetch l.child as a join fetch a.details.owner "
+                "left outer join fetch a.file "
+                "join fetch a.details.creationEvent where l.parent.id=%i"
+                % (self.OMERO_CLASS, self._oid)
+            )
             links = self._conn.getQueryService().findAllByQuery(
-                query, None, ctx)
+                query, None, ctx
+            )
             self._obj._annotationLinksLoaded = True
             self._obj._annotationLinksSeq = links
 
@@ -965,8 +1022,11 @@ class BlitzObjectWrapper (object):
         self._loadAnnotationLinks()
         rv = self.copyAnnotationLinks()
         if ns is not None:
-            rv = [x for x in rv if x.getChild().getNs() and
-                x.getChild().getNs().val == ns]
+            rv = [
+                x
+                for x in rv
+                if x.getChild().getNs() and x.getChild().getNs().val == ns
+            ]
         return rv
 
     def unlinkAnnotations(self, ns):
@@ -1006,7 +1066,7 @@ class BlitzObjectWrapper (object):
             a = al.child
             ids.append(a.id.val)
         if len(ids):
-            handle = self._conn.deleteObjects('Annotation', ids)
+            handle = self._conn.deleteObjects("Annotation", ids)
             try:
                 self._conn._waitOnCmd(handle)
             finally:
@@ -1044,8 +1104,9 @@ class BlitzObjectWrapper (object):
         for ann in self._getAnnotationLinks(ns):
             yield AnnotationWrapper._wrap(self._conn, ann.child, link=ann)
 
-    def listOrphanedAnnotations(self, eid=None, ns=None, anntype=None,
-                                addedByMe=True):
+    def listOrphanedAnnotations(
+        self, eid=None, ns=None, anntype=None, addedByMe=True
+    ):
         """
         Retrieve all Annotations not linked to the given Project, Dataset,
         Image, Screen, Plate, Well ID controlled by the security system.
@@ -1059,7 +1120,8 @@ class BlitzObjectWrapper (object):
         """
 
         return self._conn.listOrphanedAnnotations(
-            self.OMERO_CLASS, [self.getId()], eid, ns, anntype, addedByMe)
+            self.OMERO_CLASS, [self.getId()], eid, ns, anntype, addedByMe
+        )
 
     def _linkObject(self, obj, lnkobjtype):
         """
@@ -1078,7 +1140,9 @@ class BlitzObjectWrapper (object):
             obj = obj.__class__(
                 self._conn,
                 self._conn.getUpdateService().saveAndReturnObject(
-                    obj._obj, ctx))
+                    obj._obj, ctx
+                ),
+            )
         lnk = getattr(omero.model, lnkobjtype)()
         lnk.setParent(self._obj.__class__(self._obj.id, False))
         lnk.setChild(obj._obj.__class__(obj._obj.id, False))
@@ -1128,12 +1192,16 @@ class BlitzObjectWrapper (object):
         if sameOwner:
             d = self.getDetails()
             ad = ann.getDetails()
-            if (self._conn.isAdmin() and
-                    self._conn.getUserId() != d.getOwner().id):
+            if (
+                self._conn.isAdmin()
+                and self._conn.getUserId() != d.getOwner().id
+            ):
                 # Keep the annotation owner the same as the linked of object's
-                if (ad.getOwner() and
-                        d.getOwner().omeName == ad.getOwner().omeName and
-                        d.getGroup().name == ad.getGroup().name):
+                if (
+                    ad.getOwner()
+                    and d.getOwner().omeName == ad.getOwner().omeName
+                    and d.getGroup().name == ad.getGroup().name
+                ):
                     newConn = ann._conn
                 else:
                     # p = omero.sys.Principal()
@@ -1183,12 +1251,13 @@ class BlitzObjectWrapper (object):
         :return:            A dict representation of this object
         :rtype:             Dict
         """
-        rv = {'type': self.OMERO_CLASS,
-              'id': self.getId(),
-              'name': self.getName(),
-              'description': self.getDescription(),
-              }
-        if hasattr(self, '_attrs'):
+        rv = {
+            "type": self.OMERO_CLASS,
+            "id": self.getId(),
+            "name": self.getName(),
+            "description": self.getDescription(),
+        }
+        if hasattr(self, "_attrs"):
             # for each of the lines in _attrs an instance variable named
             #  'key' or 'title' where the line value can be:
             #   'key' -> _obj[key]
@@ -1202,22 +1271,22 @@ class BlitzObjectWrapper (object):
             #                         _obj[key]).simpleMarshal()
             #   'key|' ->  key.simpleMarshal() (useful with ()key )
             for k in self._attrs:
-                if ';' in k:
-                    s = k.split(';')
+                if ";" in k:
+                    s = k.split(";")
                     k = s[0]
-                    rk = ';'.join(s[1:])
+                    rk = ";".join(s[1:])
                 else:
                     rk = k
-                if '|' in k:
-                    s = k.split('|')
+                if "|" in k:
+                    s = k.split("|")
                     if rk == k:
                         rk = s[0]
                     k = s[0]
-                    wrapper = '|'.join(s[1:])
+                    wrapper = "|".join(s[1:])
                 else:
                     wrapper = None
 
-                if k.startswith('()'):
+                if k.startswith("()"):
                     if k == rk:
                         rk = k[2:]
                     k = k[2:]
@@ -1225,34 +1294,35 @@ class BlitzObjectWrapper (object):
                 else:
                     getter = False
 
-                if k.startswith('#'):
+                if k.startswith("#"):
                     k = k[1:]
                     unwrapit = True
                 else:
                     unwrapit = False
 
                 if getter:
-                    v = getattr(self, 'get'+k[0].upper()+k[1:])()
+                    v = getattr(self, "get" + k[0].upper() + k[1:])()
                 else:
                     v = getattr(self, k)
                 if unwrapit and v is not None:
                     v = v._value
                 if wrapper is not None and v is not None:
-                    if wrapper == '':
+                    if wrapper == "":
                         if isinstance(v, ListType):
                             v = [x.simpleMarshal() for x in v]
                         else:
                             v = v.simpleMarshal()
                     else:
                         v = getattr(omero.gateway, wrapper)(
-                            self._conn, v).simpleMarshal()
+                            self._conn, v
+                        ).simpleMarshal()
 
                 rv[rk] = v
         if xtra:  # TODO check if this can be moved to a more specific place
-            if 'childCount' in xtra:
-                rv['child_count'] = self.countChildren()
+            if "childCount" in xtra:
+                rv["child_count"] = self.countChildren()
         if parents:
-            rv['parents'] = [x.simpleMarshal() for x in self.getAncestry()]
+            rv["parents"] = [x.simpleMarshal() for x in self.getAncestry()]
         return rv
 
     # def __str__ (self):
@@ -1282,45 +1352,46 @@ class BlitzObjectWrapper (object):
 
         # handle lookup of 'get' methods, using '_attrs' dict to define how we
         # wrap returned objects.
-        if (attr != 'get' and
-                attr.startswith('get') and
-                hasattr(self, '_attrs')):
-            tattr = attr[3].lower() + attr[4:]      # 'getName' -> 'name'
+        if attr != "get" and attr.startswith("get") and hasattr(self, "_attrs"):
+            tattr = attr[3].lower() + attr[4:]  # 'getName' -> 'name'
             # find attr with 'name'
             attrs = [x for x in self._attrs if tattr in x]
             for a in attrs:
-                if a.startswith('#') and a[1:] == tattr:
+                if a.startswith("#") and a[1:] == tattr:
                     v = getattr(self, tattr)
                     if v is not None:
                         v = v._value
 
                     def wrap():
                         return v
+
                     return wrap
                 # E.g.  a = lightSource|LightSourceWrapper
-                if len(a) > len(tattr) and a[len(tattr)] == '|':
+                if len(a) > len(tattr) and a[len(tattr)] == "|":
                     # E.g. method returns a
                     # LightSourceWrapper(omero.model.lightSource)
                     def wrap():
-                        return getattr(
-                            omero.gateway,
-                            a[len(tattr)+1:])(self._conn, getattr(self, tattr))
+                        return getattr(omero.gateway, a[len(tattr) + 1 :])(
+                            self._conn, getattr(self, tattr)
+                        )
+
                     return wrap
 
         # handle lookup of 'get' methods when we don't have '_attrs' on the
         # object, E.g. image.getAcquisitionDate
-        if attr != 'get' and attr.startswith('get'):
+        if attr != "get" and attr.startswith("get"):
             # E.g. getAcquisitionDate -> acquisitionDate
             attrName = attr[3].lower() + attr[4:]
             if hasattr(self._obj, attrName):
+
                 def wrap():
                     rv = getattr(self._obj, attrName)
-                    if hasattr(rv, 'val'):
+                    if hasattr(rv, "val"):
                         if isinstance(rv.val, StringType):
                             if isinstance(rv.val, str):
                                 return rv.val
                             else:
-                                return rv.val.decode('utf8')
+                                return rv.val.decode("utf8")
                         # E.g. pixels.getPhysicalSizeX()
                         if hasattr(rv, "_unit"):
                             return rv
@@ -1328,28 +1399,30 @@ class BlitzObjectWrapper (object):
                     elif isinstance(rv, omero.model.IObject):
                         return BlitzObjectWrapper(self._conn, rv)
                     return rv
+
                 return wrap
 
         # handle direct access of attributes. E.g. image.acquisitionDate
         # also handles access to other methods E.g. image.unloadPixels()
-        if not hasattr(self._obj, attr) and hasattr(self._obj, '_'+attr):
-            attr = '_' + attr
+        if not hasattr(self._obj, attr) and hasattr(self._obj, "_" + attr):
+            attr = "_" + attr
         if hasattr(self._obj, attr):
             rv = getattr(self._obj, attr)
-            if hasattr(rv, 'val'):   # unwrap rtypes
+            if hasattr(rv, "val"):  # unwrap rtypes
                 # If this is a _unit, then we ignore val
                 # since it's not an rtype to unwrap.
                 if not hasattr(rv, "_unit"):
                     rv = rv.val
                     if isinstance(rv, StringType):
                         try:
-                            rv = rv.decode('utf8')
+                            rv = rv.decode("utf8")
                         except:
                             pass
             return rv
         raise AttributeError(
             "'%s' object has no attribute '%s'"
-            % (self._obj.__class__.__name__, attr))
+            % (self._obj.__class__.__name__, attr)
+        )
 
     # some methods are accessors in _obj and return and omero:: type. The
     # obvious ones we wrap to return a python type
@@ -1371,8 +1444,8 @@ class BlitzObjectWrapper (object):
 
         :return: String or None
         """
-        if hasattr(self._obj, 'name'):
-            if hasattr(self._obj.name, 'val'):
+        if hasattr(self._obj, "name"):
+            if hasattr(self._obj.name, "val"):
                 return self._obj.getName().val
             else:
                 return self._obj.getName()
@@ -1385,9 +1458,12 @@ class BlitzObjectWrapper (object):
 
         :return: String
         """
-        rv = hasattr(
-            self._obj, 'description') and self._obj.getDescription() or None
-        return rv and rv.val or ''
+        rv = (
+            hasattr(self._obj, "description")
+            and self._obj.getDescription()
+            or None
+        )
+        return rv and rv.val or ""
 
     def getOwner(self):
         """
@@ -1408,7 +1484,7 @@ class BlitzObjectWrapper (object):
             firstName = self.getDetails().getOwner().firstName
             middleName = self.getDetails().getOwner().middleName
 
-            if middleName is not None and middleName != '':
+            if middleName is not None and middleName != "":
                 name = "%s %s. %s" % (firstName, middleName, lastName)
             else:
                 name = "%s %s" % (firstName, lastName)
@@ -1435,20 +1511,32 @@ class BlitzObjectWrapper (object):
         """
 
         if self._creationDate is not None:
-            return datetime.fromtimestamp(old_div(self._creationDate,1000))
+            return datetime.fromtimestamp(old_div(self._creationDate, 1000))
 
         try:
             if self._obj.details.creationEvent._time is not None:
                 self._creationDate = self._obj.details.creationEvent._time.val
             else:
-                self._creationDate = self._conn.getQueryService().get(
-                    "Event", self._obj.details.creationEvent.id.val,
-                    self._conn.SERVICE_OPTS).time.val
+                self._creationDate = (
+                    self._conn.getQueryService()
+                    .get(
+                        "Event",
+                        self._obj.details.creationEvent.id.val,
+                        self._conn.SERVICE_OPTS,
+                    )
+                    .time.val
+                )
         except:
-            self._creationDate = self._conn.getQueryService().get(
-                "Event", self._obj.details.creationEvent.id.val,
-                self._conn.SERVICE_OPTS).time.val
-        return datetime.fromtimestamp(old_div(self._creationDate,1000))
+            self._creationDate = (
+                self._conn.getQueryService()
+                .get(
+                    "Event",
+                    self._obj.details.creationEvent.id.val,
+                    self._conn.SERVICE_OPTS,
+                )
+                .time.val
+            )
+        return datetime.fromtimestamp(old_div(self._creationDate, 1000))
 
     def updateEventDate(self):
         """
@@ -1463,14 +1551,26 @@ class BlitzObjectWrapper (object):
             if self._obj.details.updateEvent.time is not None:
                 t = self._obj.details.updateEvent.time.val
             else:
-                t = self._conn.getQueryService().get(
-                    "Event", self._obj.details.updateEvent.id.val,
-                    self._conn.SERVICE_OPTS).time.val
+                t = (
+                    self._conn.getQueryService()
+                    .get(
+                        "Event",
+                        self._obj.details.updateEvent.id.val,
+                        self._conn.SERVICE_OPTS,
+                    )
+                    .time.val
+                )
         except:
-            t = self._conn.getQueryService().get(
-                "Event", self._obj.details.updateEvent.id.val,
-                self._conn.SERVICE_OPTS).time.val
-        return datetime.fromtimestamp(old_div(t,1000))
+            t = (
+                self._conn.getQueryService()
+                .get(
+                    "Event",
+                    self._obj.details.updateEvent.id.val,
+                    self._conn.SERVICE_OPTS,
+                )
+                .time.val
+            )
+        return datetime.fromtimestamp(old_div(t, 1000))
 
     # setters are also provided
 
@@ -1492,10 +1592,11 @@ class BlitzObjectWrapper (object):
         """
         self._obj.setDescription(omero_type(value))
 
+
 # BASIC #
 
 
-class NoProxies (object):
+class NoProxies(object):
     """ A dummy placeholder to indicate that proxies haven't been created """
 
     def __getitem__(self, k):
@@ -1505,7 +1606,7 @@ class NoProxies (object):
         return ()
 
 
-class _BlitzGateway (object):
+class _BlitzGateway(object):
     """
     Connection wrapper. Handles connecting and keeping the session alive,
     creation of various services, context switching, security privileges etc.
@@ -1518,13 +1619,25 @@ class _BlitzGateway (object):
     """
     ICE_CONFIG - Defines the path to the Ice configuration
     """
-# def __init__ (self, username, passwd, server, port, client_obj=None,
-# group=None, clone=False):
+    # def __init__ (self, username, passwd, server, port, client_obj=None,
+    # group=None, clone=False):
 
-    def __init__(self, username=None, passwd=None, client_obj=None, group=None,
-                 clone=False, try_super=False, host=None, port=None,
-                 extra_config=None, secure=False, anonymous=True,
-                 useragent=None, userip=None):
+    def __init__(
+        self,
+        username=None,
+        passwd=None,
+        client_obj=None,
+        group=None,
+        clone=False,
+        try_super=False,
+        host=None,
+        port=None,
+        extra_config=None,
+        secure=False,
+        anonymous=True,
+        useragent=None,
+        userip=None,
+    ):
         """
         Create the connection wrapper.
         Does not attempt to connect at this stage
@@ -1568,7 +1681,10 @@ class _BlitzGateway (object):
         self.extra_config = extra_config
         self.ice_config = [self.ICE_CONFIG]
         self.ice_config.extend(extra_config)
-        self.ice_config = [os.path.abspath(str(x)) for x in [_f for _f in self.ice_config if _f]]
+        self.ice_config = [
+            os.path.abspath(str(x))
+            for x in [_f for _f in self.ice_config if _f]
+        ]
 
         self.host = host
         self.port = port
@@ -1600,7 +1716,7 @@ class _BlitzGateway (object):
             self.SERVICE_OPTS = self.createServiceOptsDict()
         if try_super:
             # self.c.ic.getProperties().getProperty('omero.gateway.admin_group')
-            self.group = 'system'
+            self.group = "system"
         else:
             self.group = group and group or None
 
@@ -1668,8 +1784,9 @@ class _BlitzGateway (object):
             if stack_list:
                 count += 1
                 stack_msg = "".join(traceback.format_list(stack_list))
-                logger.error("%s - %s\n%s" % (
-                    prefix, service_string, stack_msg))
+                logger.error(
+                    "%s - %s\n%s" % (prefix, service_string, stack_msg)
+                )
         return count
 
     def createServiceOptsDict(self):
@@ -1706,8 +1823,9 @@ class _BlitzGateway (object):
         if self._maxPlaneSize is None:
             c = self.getConfigService()
             self._maxPlaneSize = (
-                int(c.getConfigValue('omero.pixeldata.max_plane_width')),
-                int(c.getConfigValue('omero.pixeldata.max_plane_height')))
+                int(c.getConfigValue("omero.pixeldata.max_plane_width")),
+                int(c.getConfigValue("omero.pixeldata.max_plane_height")),
+            )
         return self._maxPlaneSize
 
     def getClientSettings(self):
@@ -1721,8 +1839,14 @@ class _BlitzGateway (object):
 
     def getRoiLimitSetting(self):
         try:
-            roi_limit = (int(self.getConfigService().getConfigValue(
-                             "omero.client.viewer.roi_limit")) or 2000)
+            roi_limit = (
+                int(
+                    self.getConfigService().getConfigValue(
+                        "omero.client.viewer.roi_limit"
+                    )
+                )
+                or 2000
+            )
         except:
             roi_limit = 2000
         return roi_limit
@@ -1732,8 +1856,12 @@ class _BlitzGateway (object):
         Returns default initial zoom level set on the server.
         """
         try:
-            initzoom = (self.getConfigService().getConfigValue(
-                        "omero.client.viewer.initial_zoom_level") or 0)
+            initzoom = (
+                self.getConfigService().getConfigValue(
+                    "omero.client.viewer.initial_zoom_level"
+                )
+                or 0
+            )
         except:
             initzoom = 0
         return initzoom
@@ -1746,9 +1874,10 @@ class _BlitzGateway (object):
         :return:    String
         """
         try:
-            interpolate = (
-                toBoolean(self.getConfigService().getConfigValue(
-                    "omero.client.viewer.interpolate_pixels"))
+            interpolate = toBoolean(
+                self.getConfigService().getConfigValue(
+                    "omero.client.viewer.interpolate_pixels"
+                )
             )
         except:
             interpolate = True
@@ -1765,7 +1894,8 @@ class _BlitzGateway (object):
         size = 144000000
         try:
             size = self.getConfigService().getConfigValue(
-                "omero.client.download_as.max_size")
+                "omero.client.download_as.max_size"
+            )
             size = int(size)
         except:
             pass
@@ -1776,8 +1906,9 @@ class _BlitzGateway (object):
         Returns default initial zoom level set on the server.
         """
         try:
-            host = self.getConfigService() \
-                       .getConfigValue("omero.client.web.host")
+            host = self.getConfigService().getConfigValue(
+                "omero.client.web.host"
+            )
         except:
             host = None
         return host
@@ -1807,16 +1938,18 @@ class _BlitzGateway (object):
         :return:    Clone of this connection wrapper
         :rtype:     :class:`_BlitzGateway`
         """
-        return self.__class__(self._ic_props[omero.constants.USERNAME],
-                              self._ic_props[omero.constants.PASSWORD],
-                              host=self.host,
-                              port=self.port,
-                              extra_config=self.extra_config,
-                              clone=True,
-                              secure=self.secure,
-                              anonymous=self._anonymous,
-                              useragent=self.useragent,
-                              userip=self.userip)
+        return self.__class__(
+            self._ic_props[omero.constants.USERNAME],
+            self._ic_props[omero.constants.PASSWORD],
+            host=self.host,
+            port=self.port,
+            extra_config=self.extra_config,
+            clone=True,
+            secure=self.secure,
+            anonymous=self._anonymous,
+            useragent=self.useragent,
+            userip=self.userip,
+        )
         # self.server, self.port, clone=True)
 
     def setIdentity(self, username, passwd, _internal=False):
@@ -1830,8 +1963,10 @@ class _BlitzGateway (object):
         :param _internal:   If False, set _anonymous = False
         :type _internal:    Boolean
         """
-        self._ic_props = {omero.constants.USERNAME: username,
-                          omero.constants.PASSWORD: passwd}
+        self._ic_props = {
+            omero.constants.USERNAME: username,
+            omero.constants.PASSWORD: passwd,
+        }
         if not _internal:
             self._anonymous = False
 
@@ -1853,7 +1988,8 @@ class _BlitzGateway (object):
         if self.isAdmin():
             if group is None:
                 e = self.getObject(
-                    "Experimenter", attributes={'omeName': username})
+                    "Experimenter", attributes={"omeName": username}
+                )
                 if e is None:
                     return
                 group = e._obj._groupExperimenterMapSeq[0].parent.name.val
@@ -1862,7 +1998,8 @@ class _BlitzGateway (object):
             p.group = group
             p.eventType = "User"
             newConnId = self.getSessionService().createSessionWithTimeout(
-                p, ttl)
+                p, ttl
+            )
             newConn = self.clone()
             newConn.connect(sUuid=newConnId.getUuid().val)
             return newConn
@@ -1879,9 +2016,9 @@ class _BlitzGateway (object):
 
         try:
             if self.c.sf is None:  # pragma: no cover
-                logger.debug('... c.sf is None, reconnecting')
+                logger.debug("... c.sf is None, reconnecting")
                 return self.connect()
-            return self.c.sf.keepAlive(self._proxies['admin']._getObj())
+            return self.c.sf.keepAlive(self._proxies["admin"]._getObj())
         except Ice.ObjectNotExistException:  # pragma: no cover
             # The connection is there, but it has been reset, because the proxy
             # no longer exists...
@@ -1915,9 +2052,10 @@ class _BlitzGateway (object):
         except Ice.UnknownException as x:  # pragma: no cover
             # Probably a wrapped RemovedSession
             logger.debug(traceback.format_exc())
-            logger.debug('Ice.UnknownException: %s' % str(x))
+            logger.debug("Ice.UnknownException: %s" % str(x))
             logger.debug(
-                "... ice says something bad happened, not reconnecting")
+                "... ice says something bad happened, not reconnecting"
+            )
             return False
         except:
             # Something else happened
@@ -1936,8 +2074,7 @@ class _BlitzGateway (object):
         ** Deprecated ** Use :meth:`close`.
         Our apologies for any offense caused by this previous method name.
         """
-        warnings.warn("Deprecated. Use close()",
-                      DeprecationWarning)
+        warnings.warn("Deprecated. Use close()", DeprecationWarning)
         self._connected = False
         oldC = self.c
         if oldC is not None:
@@ -1945,7 +2082,8 @@ class _BlitzGateway (object):
                 if softclose:
                     try:
                         r = oldC.sf.getSessionService().getReferenceCount(
-                            self._sessionUuid)
+                            self._sessionUuid
+                        )
                         oldC.closeSession()
                         if r < 2:
                             self._session_cb and self._session_cb.close(self)
@@ -2000,50 +2138,63 @@ class _BlitzGateway (object):
         else:
             logger.debug("## Creating proxies")
             self._proxies = {}
-            self._proxies['admin'] = ProxyObjectWrapper(
-                self, 'getAdminService')
-            self._proxies['config'] = ProxyObjectWrapper(
-                self, 'getConfigService')
-            self._proxies['container'] = ProxyObjectWrapper(
-                self, 'getContainerService')
-            self._proxies['ldap'] = ProxyObjectWrapper(self, 'getLdapService')
-            self._proxies['metadata'] = ProxyObjectWrapper(
-                self, 'getMetadataService')
-            self._proxies['query'] = ProxyObjectWrapper(
-                self, 'getQueryService')
-            self._proxies['pixel'] = ProxyObjectWrapper(
-                self, 'getPixelsService')
-            self._proxies['projection'] = ProxyObjectWrapper(
-                self, 'getProjectionService')
-            self._proxies['rawpixels'] = ProxyObjectWrapper(
-                self, 'createRawPixelsStore')
-            self._proxies['rendering'] = ProxyObjectWrapper(
-                self, 'createRenderingEngine')
-            self._proxies['rendsettings'] = ProxyObjectWrapper(
-                self, 'getRenderingSettingsService')
-            self._proxies['thumbs'] = ProxyObjectWrapper(
-                self, 'createThumbnailStore')
-            self._proxies['rawfile'] = ProxyObjectWrapper(
-                self, 'createRawFileStore')
-            self._proxies['repository'] = ProxyObjectWrapper(
-                self, 'getRepositoryInfoService')
-            self._proxies['roi'] = ProxyObjectWrapper(self, 'getRoiService')
-            self._proxies['script'] = ProxyObjectWrapper(
-                self, 'getScriptService')
-            self._proxies['search'] = ProxyObjectWrapper(
-                self, 'createSearchService')
-            self._proxies['session'] = ProxyObjectWrapper(
-                self, 'getSessionService')
-            self._proxies['share'] = ProxyObjectWrapper(
-                self, 'getShareService')
-            self._proxies['sharedres'] = ProxyObjectWrapper(
-                self, 'sharedResources')
-            self._proxies['timeline'] = ProxyObjectWrapper(
-                self, 'getTimelineService')
-            self._proxies['types'] = ProxyObjectWrapper(
-                self, 'getTypesService')
-            self._proxies['update'] = ProxyObjectWrapper(
-                self, 'getUpdateService')
+            self._proxies["admin"] = ProxyObjectWrapper(self, "getAdminService")
+            self._proxies["config"] = ProxyObjectWrapper(
+                self, "getConfigService"
+            )
+            self._proxies["container"] = ProxyObjectWrapper(
+                self, "getContainerService"
+            )
+            self._proxies["ldap"] = ProxyObjectWrapper(self, "getLdapService")
+            self._proxies["metadata"] = ProxyObjectWrapper(
+                self, "getMetadataService"
+            )
+            self._proxies["query"] = ProxyObjectWrapper(self, "getQueryService")
+            self._proxies["pixel"] = ProxyObjectWrapper(
+                self, "getPixelsService"
+            )
+            self._proxies["projection"] = ProxyObjectWrapper(
+                self, "getProjectionService"
+            )
+            self._proxies["rawpixels"] = ProxyObjectWrapper(
+                self, "createRawPixelsStore"
+            )
+            self._proxies["rendering"] = ProxyObjectWrapper(
+                self, "createRenderingEngine"
+            )
+            self._proxies["rendsettings"] = ProxyObjectWrapper(
+                self, "getRenderingSettingsService"
+            )
+            self._proxies["thumbs"] = ProxyObjectWrapper(
+                self, "createThumbnailStore"
+            )
+            self._proxies["rawfile"] = ProxyObjectWrapper(
+                self, "createRawFileStore"
+            )
+            self._proxies["repository"] = ProxyObjectWrapper(
+                self, "getRepositoryInfoService"
+            )
+            self._proxies["roi"] = ProxyObjectWrapper(self, "getRoiService")
+            self._proxies["script"] = ProxyObjectWrapper(
+                self, "getScriptService"
+            )
+            self._proxies["search"] = ProxyObjectWrapper(
+                self, "createSearchService"
+            )
+            self._proxies["session"] = ProxyObjectWrapper(
+                self, "getSessionService"
+            )
+            self._proxies["share"] = ProxyObjectWrapper(self, "getShareService")
+            self._proxies["sharedres"] = ProxyObjectWrapper(
+                self, "sharedResources"
+            )
+            self._proxies["timeline"] = ProxyObjectWrapper(
+                self, "getTimelineService"
+            )
+            self._proxies["types"] = ProxyObjectWrapper(self, "getTypesService")
+            self._proxies["update"] = ProxyObjectWrapper(
+                self, "getUpdateService"
+            )
         self._userid = None
         self._user = None
         self._ctx = None
@@ -2062,7 +2213,7 @@ class _BlitzGateway (object):
         :param secure:  If False, use an insecure connection
         :type secure:   Boolean
         """
-        if hasattr(self.c, 'createClient') and (secure ^ self.c.isSecure()):
+        if hasattr(self.c, "createClient") and (secure ^ self.c.isSecure()):
             oldC = self.c
             self.c = oldC.createClient(secure=secure)
             oldC.__del__()  # only needs to be called if previous doesn't throw
@@ -2074,7 +2225,7 @@ class _BlitzGateway (object):
         Returns 'True' if the underlying omero.clients.BaseClient is connected
         using SSL
         """
-        return hasattr(self.c, 'isSecure') and self.c.isSecure() or False
+        return hasattr(self.c, "isSecure") and self.c.isSecure() or False
 
     def _getSessionId(self):
         return self.c.getSessionId()
@@ -2084,8 +2235,10 @@ class _BlitzGateway (object):
         Creates a new session for the principal given in the constructor.
         Used during :meth`connect` method
         """
-        s = self.c.createSession(self._ic_props[omero.constants.USERNAME],
-                                 self._ic_props[omero.constants.PASSWORD])
+        s = self.c.createSession(
+            self._ic_props[omero.constants.USERNAME],
+            self._ic_props[omero.constants.PASSWORD],
+        )
         s.detachOnDestroy()
         self._sessionUuid = self._getSessionId()
         ss = self.c.sf.getSessionService()
@@ -2133,16 +2286,20 @@ class _BlitzGateway (object):
         if self.host is not None:
             if self.port is not None:
                 self.c = omero.client(
-                    host=str(self.host), port=int(self.port),
-                    args=['--Ice.Config='+','.join(self.ice_config)])
+                    host=str(self.host),
+                    port=int(self.port),
+                    args=["--Ice.Config=" + ",".join(self.ice_config)],
+                )
                 # , pmap=['--Ice.Config='+','.join(self.ice_config)])
             else:
                 self.c = omero.client(
                     host=str(self.host),
-                    args=['--Ice.Config='+','.join(self.ice_config)])
+                    args=["--Ice.Config=" + ",".join(self.ice_config)],
+                )
         else:
             self.c = omero.client(
-                args=['--Ice.Config='+','.join(self.ice_config)])
+                args=["--Ice.Config=" + ",".join(self.ice_config)]
+            )
 
         if hasattr(self.c, "setAgent"):
             if self.useragent is not None:
@@ -2163,8 +2320,10 @@ class _BlitzGateway (object):
         :return:        Boolean
         """
 
-        logger.debug("Connect attempt, sUuid=%s, group=%s, self.sUuid=%s" % (
-            str(sUuid), str(self.group), self._sessionUuid))
+        logger.debug(
+            "Connect attempt, sUuid=%s, group=%s, self.sUuid=%s"
+            % (str(sUuid), str(self.group), self._sessionUuid)
+        )
         if not self.c:  # pragma: no cover
             self._connected = False
             logger.debug("Ooops. no self._c")
@@ -2174,11 +2333,10 @@ class _BlitzGateway (object):
                 self._sessionUuid = sUuid
             if self._sessionUuid is not None:
                 try:
-                    logger.debug('connected? %s' % str(self._connected))
+                    logger.debug("connected? %s" % str(self._connected))
                     if self._connected:
                         self._connected = False
-                        logger.debug(
-                            "was connected, creating new omero.client")
+                        logger.debug("was connected, creating new omero.client")
                         self._resetOmeroClient()
                     # timeout to allow this is $ omero config set
                     # omero.sessions.timeout 3600000
@@ -2186,8 +2344,8 @@ class _BlitzGateway (object):
                     s.detachOnDestroy()
                     self.SERVICE_OPTS = self.createServiceOptsDict()
                     logger.debug(
-                        'Joined Session OK with Uuid: %s'
-                        % (self._sessionUuid,))
+                        "Joined Session OK with Uuid: %s" % (self._sessionUuid,)
+                    )
                     self._was_join = True
                 except Ice.SyscallException:  # pragma: no cover
                     raise
@@ -2204,7 +2362,8 @@ class _BlitzGateway (object):
                     try:
                         logger.debug(
                             "Closing previous connection..."
-                            "creating new client")
+                            "creating new client"
+                        )
                         # args = self.c._ic_args
                         # logger.debug(str(args))
                         self._closeSession()
@@ -2215,14 +2374,18 @@ class _BlitzGateway (object):
                         pass
                 for key, value in list(self._ic_props.items()):
                     if isinstance(value, str):
-                        value = value.encode('utf_8')
-                    self.c.ic.getProperties().setProperty(key, native_str(value))
+                        value = value.encode("utf_8")
+                    self.c.ic.getProperties().setProperty(
+                        key, native_str(value)
+                    )
                 if self._anonymous:
                     self.c.ic.getImplicitContext().put(
-                        omero.constants.EVENT, 'Internal')
+                        omero.constants.EVENT, "Internal"
+                    )
                 if self.group is not None:
                     self.c.ic.getImplicitContext().put(
-                        omero.constants.GROUP, self.group)
+                        omero.constants.GROUP, self.group
+                    )
                 try:
                     logger.debug("Creating Session...")
                     self._createSession()
@@ -2238,11 +2401,13 @@ class _BlitzGateway (object):
                         return self.connect()
                     else:  # pragma: no cover
                         logger.debug(
-                            "BlitzGateway.connect().createSession(): " +
-                            traceback.format_exc())
+                            "BlitzGateway.connect().createSession(): "
+                            + traceback.format_exc()
+                        )
                         logger.info(
                             "first create session threw SecurityViolation, "
-                            "retry (but only once)")
+                            "retry (but only once)"
+                        )
                         # time.sleep(10)
                         try:
                             self._createSession()
@@ -2250,7 +2415,8 @@ class _BlitzGateway (object):
                             if self.group is not None:
                                 # User don't have access to group
                                 logger.debug(
-                                    "## User not in '%s' group" % self.group)
+                                    "## User not in '%s' group" % self.group
+                                )
                                 self.group = None
                                 self._connected = True
                                 return self.connect()
@@ -2261,18 +2427,18 @@ class _BlitzGateway (object):
                 except:
                     logger.info("Failed to create session.")
                     logger.debug(
-                        "BlitzGateway.connect().createSession(): " +
-                        traceback.format_exc())
+                        "BlitzGateway.connect().createSession(): "
+                        + traceback.format_exc()
+                    )
                     # time.sleep(10)
                     self._createSession()
 
             self._last_error = None
             self._createProxies()
             self._connected = True
-            logger.info('created connection (uuid=%s)' %
-                        str(self._sessionUuid))
+            logger.info("created connection (uuid=%s)" % str(self._sessionUuid))
         except Ice.SyscallException:  # pragma: no cover
-            logger.debug('This one is a SyscallException', exc_info=True)
+            logger.debug("This one is a SyscallException", exc_info=True)
             raise
         except Ice.LocalException as x:  # pragma: no cover
             logger.debug("connect(): " + traceback.format_exc())
@@ -2319,7 +2485,7 @@ class _BlitzGateway (object):
         :rtype:     :class:`omero.sys.EventContext`
         """
         if self._ctx is None:
-            self._ctx = self._proxies['admin'].getEventContext()
+            self._ctx = self._proxies["admin"].getEventContext()
         return self._ctx
 
     def getUserId(self):
@@ -2350,8 +2516,9 @@ class _BlitzGateway (object):
         if self._user is None:
             uid = self.getUserId()
             if uid is not None:
-                self._user = self.getObject(
-                    "Experimenter", self._userid) or None
+                self._user = (
+                    self.getObject("Experimenter", self._userid) or None
+                )
         return self._user
 
     def getAdministrators(self):
@@ -2363,7 +2530,8 @@ class _BlitzGateway (object):
         """
         sysGroup = self.getObject(
             "ExperimenterGroup",
-            self.getAdminService().getSecurityRoles().systemGroupId)
+            self.getAdminService().getSecurityRoles().systemGroupId,
+        )
         for gem in sysGroup.copyGroupExperimenterMap():
             yield ExperimenterWrapper(self, gem.child)
 
@@ -2393,7 +2561,8 @@ class _BlitzGateway (object):
         :return:    List of strings such as ["ModifyUser", "ModifyGroup"]
         """
         privileges = self.getAdminService().getAdminPrivileges(
-            omero.model.ExperimenterI(user_id, False))
+            omero.model.ExperimenterI(user_id, False)
+        )
         return [unwrap(p.getValue()) for p in privileges]
 
     def updateAdminPrivileges(self, exp_id, add=[], remove=[]):
@@ -2439,7 +2608,7 @@ class _BlitzGateway (object):
         """
 
         if self.getEventContext().isAdmin:
-            allPrivs = list(self.getEnumerationEntries('AdminPrivilege'))
+            allPrivs = list(self.getEnumerationEntries("AdminPrivilege"))
             return len(allPrivs) == len(self.getCurrentAdminPrivileges())
 
         return False
@@ -2476,9 +2645,10 @@ class _BlitzGateway (object):
         :return:    Boolean
         """
 
-        return (self.isAdmin() or
-                (self.getUserId() == obj.getDetails().getOwner().getId() and
-                    obj.getDetails().getPermissions().isUserWrite()))
+        return self.isAdmin() or (
+            self.getUserId() == obj.getDetails().getOwner().getId()
+            and obj.getDetails().getPermissions().isUserWrite()
+        )
 
     def canOwnerWrite(self, obj):
         """
@@ -2526,15 +2696,18 @@ class _BlitzGateway (object):
         """
         if self.getEventContext().groupId == groupid:
             return None
-        if (groupid not in self._ctx.memberOfGroups and
-                0 not in self._ctx.memberOfGroups):
+        if (
+            groupid not in self._ctx.memberOfGroups
+            and 0 not in self._ctx.memberOfGroups
+        ):
             return False
         self._lastGroupId = self._ctx.groupId
         self._ctx = None
         for s in self.c.getStatefulServices():
             s.close()
         self.c.sf.setSecurityContext(
-            omero.model.ExperimenterGroupI(groupid, False))
+            omero.model.ExperimenterGroupI(groupid, False)
+        )
         return True
 
     def revertGroupForSession(self):
@@ -2553,7 +2726,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['admin']
+        return self._proxies["admin"]
 
     def getQueryService(self):
         """
@@ -2561,7 +2734,7 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['query']
+        return self._proxies["query"]
 
     def getContainerService(self):
         """
@@ -2570,7 +2743,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['container']
+        return self._proxies["container"]
 
     def getPixelsService(self):
         """
@@ -2579,7 +2752,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['pixel']
+        return self._proxies["pixel"]
 
     def getMetadataService(self):
         """
@@ -2588,7 +2761,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['metadata']
+        return self._proxies["metadata"]
 
     def getRoiService(self):
         """
@@ -2597,7 +2770,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['roi']
+        return self._proxies["roi"]
 
     def getScriptService(self):
         """
@@ -2606,7 +2779,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['script']
+        return self._proxies["script"]
 
     def createRawFileStore(self):
         """
@@ -2616,7 +2789,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['rawfile']
+        return self._proxies["rawfile"]
 
     def getRepositoryInfoService(self):
         """
@@ -2625,7 +2798,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['repository']
+        return self._proxies["repository"]
 
     def getShareService(self):
         """
@@ -2634,7 +2807,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['share']
+        return self._proxies["share"]
 
     def getSharedResources(self):
         """
@@ -2643,7 +2816,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['sharedres']
+        return self._proxies["sharedres"]
 
     def getTimelineService(self):
         """
@@ -2652,7 +2825,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['timeline']
+        return self._proxies["timeline"]
 
     def getTypesService(self):
         """
@@ -2661,7 +2834,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['types']
+        return self._proxies["types"]
 
     def getConfigService(self):
         """
@@ -2670,7 +2843,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['config']
+        return self._proxies["config"]
 
     def createRenderingEngine(self):
         """
@@ -2682,9 +2855,9 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        rv = self._proxies['rendering']
+        rv = self._proxies["rendering"]
         if rv._tainted:
-            rv = self._proxies['rendering'] = rv.clone()
+            rv = self._proxies["rendering"] = rv.clone()
         rv.taint()
         return rv
 
@@ -2696,7 +2869,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['rendsettings']
+        return self._proxies["rendsettings"]
 
     def createRawPixelsStore(self):
         """
@@ -2706,7 +2879,7 @@ class _BlitzGateway (object):
         :return:    omero.gateway.ProxyObjectWrapper
         """
 
-        return self._proxies['rawpixels']
+        return self._proxies["rawpixels"]
 
     def createThumbnailStore(self):
         """
@@ -2717,7 +2890,7 @@ class _BlitzGateway (object):
         :return: The proxy wrapper of the thumbnail store
         """
 
-        return self._proxies['thumbs']
+        return self._proxies["thumbs"]
 
     def createSearchService(self):
         """
@@ -2726,7 +2899,7 @@ class _BlitzGateway (object):
 
         :return: omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['search']
+        return self._proxies["search"]
 
     def getUpdateService(self):
         """
@@ -2734,7 +2907,7 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['update']
+        return self._proxies["update"]
 
     def getSessionService(self):
         """
@@ -2742,7 +2915,7 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return self._proxies['session']
+        return self._proxies["session"]
 
     def createExporter(self):
         """
@@ -2750,7 +2923,7 @@ class _BlitzGateway (object):
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
-        return ProxyObjectWrapper(self, 'createExporter')
+        return ProxyObjectWrapper(self, "createExporter")
 
     ####################
     # Read-only status #
@@ -2764,13 +2937,13 @@ class _BlitzGateway (object):
                   False if the server is wholly in read-only mode,
                   otherwise None
         """
-        key_regex = r'^omero\.cluster\.read_only\.runtime\.'
+        key_regex = r"^omero\.cluster\.read_only\.runtime\."
         properties = self.getConfigService().getConfigValues(key_regex)
         values = frozenset(list(properties.values()))
         if not values:
             return True
         elif len(values) == 1:
-            return 'false' in values
+            return "false" in values
         else:
             return None
 
@@ -2831,12 +3004,16 @@ class _BlitzGateway (object):
 
         """
 
-        links = {'Dataset': ('ProjectDatasetLink', DatasetWrapper),
-                 'Image': ('DatasetImageLink', ImageWrapper),
-                 'Plate': ('ScreenPlateLink', PlateWrapper)}
+        links = {
+            "Dataset": ("ProjectDatasetLink", DatasetWrapper),
+            "Image": ("DatasetImageLink", ImageWrapper),
+            "Plate": ("ScreenPlateLink", PlateWrapper),
+        }
 
         if obj_type not in list(links.keys()):
-            raise AttributeError("obj_type must be in %s" % str(list(links.keys())))
+            raise AttributeError(
+                "obj_type must be in %s" % str(list(links.keys()))
+            )
 
         if params is None:
             params = omero.sys.ParametersI()
@@ -2844,11 +3021,13 @@ class _BlitzGateway (object):
         wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
         query = wrapper._getQueryString()[0]
 
-        if loadPixels and obj_type == 'Image':
+        if loadPixels and obj_type == "Image":
             # left outer join so we don't exclude
             # images that have no thumbnails
-            query += (" join fetch obj.pixels as pix "
-                      "left outer join fetch pix.thumbnails")
+            query += (
+                " join fetch obj.pixels as pix "
+                "left outer join fetch pix.thumbnails"
+            )
 
         if eid is not None:
             params.exp(eid)
@@ -2856,12 +3035,16 @@ class _BlitzGateway (object):
             params.map["eid"] = params.theFilter.ownerId
 
         query += "where" not in query and " where " or " and "
-        query += " not exists (select obl from %s as obl where " \
-                 "obl.child=obj.id) " % (links[obj_type][0])
+        query += (
+            " not exists (select obl from %s as obl where "
+            "obl.child=obj.id) " % (links[obj_type][0])
+        )
 
-        if obj_type == 'Image':
-            query += " and not exists ( select ws from WellSample as ws "\
-                     "where ws.image=obj.id "
+        if obj_type == "Image":
+            query += (
+                " and not exists ( select ws from WellSample as ws "
+                "where ws.image=obj.id "
+            )
             if eid is not None:
                 query += " and ws.details.owner.id=:eid "
             query += ")"
@@ -2869,9 +3052,11 @@ class _BlitzGateway (object):
         query += " order by lower(obj.name), obj.id"
 
         result = self.getQueryService().findAllByQuery(
-            query, params, self.SERVICE_OPTS)
+            query, params, self.SERVICE_OPTS
+        )
         for r in result:
             yield wrapper(self, r)
+
     #################################################
     # IAdmin
 
@@ -2928,11 +3113,11 @@ class _BlitzGateway (object):
         :rtype:         :class:`ExperimenterGroupWrapper` generator
         """
 
-        system_groups = [
-            self.getAdminService().getSecurityRoles().userGroupId]
+        system_groups = [self.getAdminService().getSecurityRoles().userGroupId]
         if len(self.getEventContext().leaderOfGroups) > 0:
-            for g in self.getObjects("ExperimenterGroup",
-                                     self.getEventContext().leaderOfGroups):
+            for g in self.getObjects(
+                "ExperimenterGroup", self.getEventContext().leaderOfGroups
+            ):
                 if g.getId() not in system_groups:
                     yield g
 
@@ -2944,16 +3129,23 @@ class _BlitzGateway (object):
         :rtype:         :class:`ExperimenterGroupWrapper` generator
         """
 
-        system_groups = [
-            self.getAdminService().getSecurityRoles().userGroupId]
+        system_groups = [self.getAdminService().getSecurityRoles().userGroupId]
         if len(self.getEventContext().memberOfGroups) > 0:
-            for g in self.getObjects("ExperimenterGroup",
-                                     self.getEventContext().memberOfGroups):
+            for g in self.getObjects(
+                "ExperimenterGroup", self.getEventContext().memberOfGroups
+            ):
                 if g.getId() not in system_groups:
                     yield g
 
-    def createGroup(self, name, owner_Ids=None, member_Ids=None, perms=None,
-                    description=None, ldap=False):
+    def createGroup(
+        self,
+        name,
+        owner_Ids=None,
+        member_Ids=None,
+        perms=None,
+        description=None,
+        ldap=False,
+    ):
         """
         Creates a new ExperimenterGroup.
         Must have Admin permissions to call this.
@@ -2974,8 +3166,10 @@ class _BlitzGateway (object):
         group = omero.model.ExperimenterGroupI()
         group.name = rstring(str(name))
         group.description = (
-            (description != "" and description is not None) and
-            rstring(str(description)) or None)
+            (description != "" and description is not None)
+            and rstring(str(description))
+            or None
+        )
         if perms is not None:
             group.details.permissions = omero.model.PermissionsI(perms)
         group.ldap = rbool(ldap)
@@ -2984,24 +3178,28 @@ class _BlitzGateway (object):
 
         if owner_Ids is not None:
             group_owners = [
-                owner._obj for owner in self.getObjects(
-                    "Experimenter", owner_Ids)]
+                owner._obj
+                for owner in self.getObjects("Experimenter", owner_Ids)
+            ]
             admin_serv.addGroupOwners(
-                omero.model.ExperimenterGroupI(gr_id, False), group_owners)
+                omero.model.ExperimenterGroupI(gr_id, False), group_owners
+            )
 
         if member_Ids is not None:
             group_members = [
-                member._obj for member in self.getObjects(
-                    "Experimenter", member_Ids)]
+                member._obj
+                for member in self.getObjects("Experimenter", member_Ids)
+            ]
             for user in group_members:
                 admin_serv.addGroups(
-                    user, [omero.model.ExperimenterGroupI(gr_id, False)])
+                    user, [omero.model.ExperimenterGroupI(gr_id, False)]
+                )
 
         return gr_id
 
     # EXPERIMENTERS
 
-    def findExperimenters(self, start=''):
+    def findExperimenters(self, start=""):
         """
         Return a generator for all Experimenters whose omeName starts with
         'start'. Experimenters ordered by omeName.
@@ -3013,13 +3211,15 @@ class _BlitzGateway (object):
         """
 
         if isinstance(start, UnicodeType):
-            start = start.encode('utf8')
+            start = start.encode("utf8")
         params = omero.sys.Parameters()
-        params.map = {'start': rstring('%s%%' % start.lower())}
+        params.map = {"start": rstring("%s%%" % start.lower())}
         q = self.getQueryService()
         rv = q.findAllByQuery(
             "from Experimenter e where lower(e.omeName) like :start",
-            params, self.SERVICE_OPTS)
+            params,
+            self.SERVICE_OPTS,
+        )
         rv.sort(lambda x, y: cmp(x.omeName.val, y.omeName.val))
         for e in rv:
             yield ExperimenterWrapper(self, e)
@@ -3050,7 +3250,8 @@ class _BlitzGateway (object):
         """
 
         default = self.getObject(
-            "ExperimenterGroup", self.getEventContext().groupId)
+            "ExperimenterGroup", self.getEventContext().groupId
+        )
         if not default.isPrivate() or self.isLeader():
             for d in default.copyGroupExperimenterMap():
                 if d is None:
@@ -3071,7 +3272,8 @@ class _BlitzGateway (object):
         """
         warnings.warn(
             "Deprecated. Use ExperimenterGroupWrapper.groupSummary()",
-            DeprecationWarning)
+            DeprecationWarning,
+        )
 
         if gid is None:
             gid = self.getEventContext().groupId
@@ -3091,11 +3293,14 @@ class _BlitzGateway (object):
         p = omero.sys.Parameters()
         p.map = {}
         p.map["gids"] = rlist(
-            [rlong(a) for a in set(self.getEventContext().leaderOfGroups)])
-        sql = ("select e from Experimenter as e where exists "
-               "( select gem from GroupExperimenterMap as gem "
-               "where gem.child = e.id and gem.parent.id in (:gids)) "
-               "order by e.omeName")
+            [rlong(a) for a in set(self.getEventContext().leaderOfGroups)]
+        )
+        sql = (
+            "select e from Experimenter as e where exists "
+            "( select gem from GroupExperimenterMap as gem "
+            "where gem.child = e.id and gem.parent.id in (:gids)) "
+            "order by e.omeName"
+        )
         for e in q.findAllByQuery(sql, p, self.SERVICE_OPTS):
             if e.id.val != self.getUserId():
                 yield ExperimenterWrapper(self, e)
@@ -3137,43 +3342,47 @@ class _BlitzGateway (object):
         """
         params = omero.sys.ParametersI()
         params.addIds(imageIds)
-        query = 'select count(fse), sum(fse.originalFile.size) '\
-                'from FilesetEntry as fse where fse.id in ('\
-                '   select distinct(i_fse.id) from FilesetEntry as i_fse '\
-                '   join i_fse.fileset as i_fileset'\
-                '   join i_fileset.images as i_image '\
-                '   where i_image.id in (:ids)'\
-                ')'
+        query = (
+            "select count(fse), sum(fse.originalFile.size) "
+            "from FilesetEntry as fse where fse.id in ("
+            "   select distinct(i_fse.id) from FilesetEntry as i_fse "
+            "   join i_fse.fileset as i_fileset"
+            "   join i_fileset.images as i_image "
+            "   where i_image.id in (:ids)"
+            ")"
+        )
         queryService = self.getQueryService()
-        count, size = queryService.projection(
-            query, params, self.SERVICE_OPTS
-        )[0]
+        count, size = queryService.projection(query, params, self.SERVICE_OPTS)[
+            0
+        ]
         if size is None:
             size = 0
 
-        query = 'select ann.id, ann.ns, ann.textValue '\
-                'from Fileset as fileset '\
-                'join fileset.annotationLinks as a_link '\
-                'join a_link.child as ann '\
-                'where fileset.id in ('\
-                '   select distinct(i_fileset.id) from Fileset as i_fileset '\
-                '   join i_fileset.images as i_image '\
-                '   where i_image.id in (:ids)'\
-                ')'
+        query = (
+            "select ann.id, ann.ns, ann.textValue "
+            "from Fileset as fileset "
+            "join fileset.annotationLinks as a_link "
+            "join a_link.child as ann "
+            "where fileset.id in ("
+            "   select distinct(i_fileset.id) from Fileset as i_fileset "
+            "   join i_fileset.images as i_image "
+            "   where i_image.id in (:ids)"
+            ")"
+        )
         queryService = self.getQueryService()
         annotations = list()
         rows = queryService.projection(query, params, self.SERVICE_OPTS)
         for row in rows:
             annotation_id, ns, text_value = row
-            annotation = {
-                'id': unwrap(annotation_id), 'ns': unwrap(ns)
-            }
+            annotation = {"id": unwrap(annotation_id), "ns": unwrap(ns)}
             if text_value is not None:
-                annotation['value'] = unwrap(text_value)
+                annotation["value"] = unwrap(text_value)
             annotations.append(annotation)
         return {
-            'fileset': True, 'count': unwrap(count), 'size': unwrap(size),
-            'annotations': annotations
+            "fileset": True,
+            "count": unwrap(count),
+            "size": unwrap(size),
+            "annotations": annotations,
         }
 
     def getArchivedFilesInfo(self, imageIds):
@@ -3186,26 +3395,29 @@ class _BlitzGateway (object):
         """
         params = omero.sys.ParametersI()
         params.addIds(imageIds)
-        query = 'select count(link), sum(link.parent.size) '\
-                'from PixelsOriginalFileMap as link '\
-                'where link.id in ('\
-                '    select distinct(i_link.id) '\
-                '        from PixelsOriginalFileMap as i_link '\
-                '    where i_link.child.image.id in (:ids)'\
-                ')'
+        query = (
+            "select count(link), sum(link.parent.size) "
+            "from PixelsOriginalFileMap as link "
+            "where link.id in ("
+            "    select distinct(i_link.id) "
+            "        from PixelsOriginalFileMap as i_link "
+            "    where i_link.child.image.id in (:ids)"
+            ")"
+        )
         queryService = self.getQueryService()
-        count, size = queryService.projection(
-            query, params, self.SERVICE_OPTS
-        )[0]
+        count, size = queryService.projection(query, params, self.SERVICE_OPTS)[
+            0
+        ]
         if size is None:
             size = 0
-        return {'fileset': False, 'count': unwrap(count), 'size': unwrap(size)}
+        return {"fileset": False, "count": unwrap(count), "size": unwrap(size)}
 
     ############################
     # Timeline service getters #
 
-    def timelineListImages(self, tfrom=None, tto=None, limit=10,
-                           only_owned=True):
+    def timelineListImages(
+        self, tfrom=None, tto=None, limit=10, only_owned=True
+    ):
         """
         List images based on their creation times.
         If both tfrom and tto are None, grab the most recent batch.
@@ -3230,7 +3442,7 @@ class _BlitzGateway (object):
         f.limit = rint(limit)
         p.theFilter = f
         if tfrom is None and tto is None:
-            for e in tm.getMostRecentObjects(['Image'], p, False)["Image"]:
+            for e in tm.getMostRecentObjects(["Image"], p, False)["Image"]:
                 yield ImageWrapper(self, e)
         else:
             if tfrom is None:
@@ -3238,15 +3450,16 @@ class _BlitzGateway (object):
             if tto is None:
                 tto = time.time() * 1000
             for e in tm.getByPeriod(
-                    ['Image'], rtime(int(tfrom)),
-                    rtime(int(tto)), p, False)['Image']:
+                ["Image"], rtime(int(tfrom)), rtime(int(tto)), p, False
+            )["Image"]:
                 yield ImageWrapper(self, e)
 
     ###########################
     # Specific Object Getters #
 
-    def getObject(self, obj_type, oid=None, params=None, attributes=None,
-                  opts=None):
+    def getObject(
+        self, obj_type, oid=None, params=None, attributes=None, opts=None
+    ):
         """
         Retrieve single Object by type E.g. "Image" or None if not found.
         If more than one object found, raises ome.conditions.ApiUsageException
@@ -3265,14 +3478,23 @@ class _BlitzGateway (object):
         """
         oids = (oid is not None) and [oid] or None
         query, params, wrapper = self.buildQuery(
-            obj_type, oids, params, attributes, opts)
+            obj_type, oids, params, attributes, opts
+        )
         result = self.getQueryService().findByQuery(
-            query, params, self.SERVICE_OPTS)
+            query, params, self.SERVICE_OPTS
+        )
         if result is not None:
             return wrapper(self, result)
 
-    def getObjects(self, obj_type, ids=None, params=None, attributes=None,
-                   respect_order=False, opts=None):
+    def getObjects(
+        self,
+        obj_type,
+        ids=None,
+        params=None,
+        attributes=None,
+        respect_order=False,
+        opts=None,
+    ):
         """
         Retrieve Objects by type E.g. "Image"
         Returns generator of appropriate :class:`BlitzObjectWrapper` type.
@@ -3299,20 +3521,22 @@ class _BlitzGateway (object):
         :return:            Generator of :class:`BlitzObjectWrapper` subclasses
         """
         query, params, wrapper = self.buildQuery(
-            obj_type, ids, params, attributes, opts)
+            obj_type, ids, params, attributes, opts
+        )
         qs = self.getQueryService()
         result = qs.findAllByQuery(query, params, self.SERVICE_OPTS)
         if respect_order and ids is not None:
             idMap = {}
             for r in result:
                 idMap[r.id.val] = r
-            ids = unwrap(ids)       # in case we had a list of rlongs
+            ids = unwrap(ids)  # in case we had a list of rlongs
             result = [idMap.get(i) for i in ids if i in idMap]
         for r in result:
             yield wrapper(self, r)
 
-    def buildQuery(self, obj_type, ids=None, params=None, attributes=None,
-                   opts=None):
+    def buildQuery(
+        self, obj_type, ids=None, params=None, attributes=None, opts=None
+    ):
         """
         Prepares a query for iQuery. Also prepares params and determines
         appropriate wrapper for result Returns (query, params, wrapper) which
@@ -3342,11 +3566,13 @@ class _BlitzGateway (object):
             if wrapper is None:
                 raise KeyError(
                     "obj_type of %s not supported by getOjbects(). "
-                    "E.g. use 'Image' etc" % obj_type)
+                    "E.g. use 'Image' etc" % obj_type
+                )
         else:
             raise AttributeError(
                 "getObjects uses a string to define obj_type, E.g. "
-                "'Image' not %r" % obj_type)
+                "'Image' not %r" % obj_type
+            )
 
         owner = None
         order_by = None
@@ -3365,13 +3591,13 @@ class _BlitzGateway (object):
         # Handle dict of parameters -> convert to ParametersI()
         if opts is not None:
             # Parse opts dict to build params
-            if 'offset' in opts and 'limit' in opts:
-                limit = opts['limit']
-                offset = opts['offset']
-            if 'owner' in opts:
-                owner = rlong(opts['owner'])
-            if 'order_by' in opts:
-                order_by = opts['order_by']
+            if "offset" in opts and "limit" in opts:
+                limit = opts["limit"]
+                offset = opts["offset"]
+            if "owner" in opts:
+                owner = rlong(opts["owner"])
+            if "order_by" in opts:
+                order_by = opts["order_by"]
         # Handle additional Parameters - need to retrieve owner filter
         if params is not None and params.theFilter is not None:
             if params.theFilter.ownerId is not None:
@@ -3393,23 +3619,25 @@ class _BlitzGateway (object):
             baseParams.map["ids"] = rlist([rlong(a) for a in ids])
 
         # support filtering by owner (not for some object types)
-        if (owner is not None and
-                obj_type.lower() not in
-                ["experimentergroup", "experimenter"]):
+        if owner is not None and obj_type.lower() not in [
+            "experimentergroup",
+            "experimenter",
+        ]:
             clauses.append("owner.id = (:eid)")
             baseParams.map["eid"] = owner
 
         # finding by attributes
         if attributes is not None:
             for k, v in list(attributes.items()):
-                clauses.append('obj.%s=:%s' % (k, k))
-                if k == 'id':
+                clauses.append("obj.%s=:%s" % (k, k))
+                if k == "id":
                     rv = rlong(v)
                 elif isinstance(v, IntType):
                     # lookup rint vv rlong from class
                     if wrapper.OMERO_CLASS is not None:
-                        klass = getattr(omero.model,
-                                        "%sI" % wrapper.OMERO_CLASS)
+                        klass = getattr(
+                            omero.model, "%sI" % wrapper.OMERO_CLASS
+                        )
                     else:
                         # AnnotationWrappers don't have OMERO_CLASS
                         klass = wrapper.OMERO_TYPE
@@ -3444,8 +3672,8 @@ class _BlitzGateway (object):
         """
         # We disable pagination since we want to count ALL results
         opts_copy = opts.copy()
-        if 'limit' in opts_copy:
-            del opts_copy['limit']
+        if "limit" in opts_copy:
+            del opts_copy["limit"]
 
         # Get query with other options
         query, params, wrapper = self.buildQuery(obj_type, opts=opts_copy)
@@ -3484,13 +3712,15 @@ class _BlitzGateway (object):
             toExclude.append(omero.constants.namespaces.NSEXPERIMENTERPHOTO)
 
         anns = self.getMetadataService().loadSpecifiedAnnotations(
-            "FileAnnotation", toInclude, toExclude, params, self.SERVICE_OPTS)
+            "FileAnnotation", toInclude, toExclude, params, self.SERVICE_OPTS
+        )
 
         for a in anns:
-            yield(FileAnnotationWrapper(self, a))
+            yield (FileAnnotationWrapper(self, a))
 
-    def getAnnotationLinks(self, parent_type, parent_ids=None, ann_ids=None,
-                           ns=None, params=None):
+    def getAnnotationLinks(
+        self, parent_type, parent_ids=None, ann_ids=None, ns=None, params=None
+    ):
         """
         Retrieve Annotation Links by parent_type E.g. "Image". Not Ordered.
         Returns generator of :class:`AnnotationLinkWrapper`
@@ -3506,8 +3736,10 @@ class _BlitzGateway (object):
 
         if parent_type.lower() not in KNOWN_WRAPPERS:
             wrapper_types = ", ".join(list(KNOWN_WRAPPERS.keys()))
-            err_msg = ("getAnnotationLinks() does not support type: '%s'. "
-                       "Must be one of: %s" % (parent_type, wrapper_types))
+            err_msg = (
+                "getAnnotationLinks() does not support type: '%s'. "
+                "Must be one of: %s" % (parent_type, wrapper_types)
+            )
             raise AttributeError(err_msg)
         wrapper = KNOWN_WRAPPERS.get(parent_type.lower(), None)
         class_string = wrapper().OMERO_CLASS
@@ -3515,13 +3747,15 @@ class _BlitzGateway (object):
         if class_string is None and "annotation" in parent_type.lower():
             class_string = "Annotation"
 
-        query = ("select annLink from %sAnnotationLink as annLink "
-                 "join fetch annLink.details.owner as owner "
-                 "join fetch annLink.details.creationEvent "
-                 "join fetch annLink.child as ann "
-                 "join fetch ann.details.owner "
-                 "join fetch ann.details.creationEvent "
-                 "join fetch annLink.parent as parent" % class_string)
+        query = (
+            "select annLink from %sAnnotationLink as annLink "
+            "join fetch annLink.details.owner as owner "
+            "join fetch annLink.details.creationEvent "
+            "join fetch annLink.child as ann "
+            "join fetch ann.details.owner "
+            "join fetch ann.details.creationEvent "
+            "join fetch annLink.parent as parent" % class_string
+        )
 
         q = self.getQueryService()
         if params is None:
@@ -3568,7 +3802,8 @@ class _BlitzGateway (object):
             "CommentAnnotation": 0,
             "LongAnnotation": 0,
             "MapAnnotation": 0,
-            "OtherAnnotation": 0}
+            "OtherAnnotation": 0,
+        }
 
         if obj_type is None or not obj_ids:
             return counts
@@ -3578,10 +3813,12 @@ class _BlitzGateway (object):
 
         params = omero.sys.ParametersI()
         params.addIds(obj_ids)
-        params.add('ratingns',
-                   rstring(omero.constants.metadata.NSINSIGHTRATING))
+        params.add(
+            "ratingns", rstring(omero.constants.metadata.NSINSIGHTRATING)
+        )
 
-        q = """
+        q = (
+            """
             select sum( case when an.ns = :ratingns
                         and an.class = LongAnnotation
                         then 1 else 0 end),
@@ -3596,30 +3833,39 @@ class _BlitzGateway (object):
                         join ial.parent as i
                 where i.id in (:ids))
                     group by an.class
-            """ % obj_type
+            """
+            % obj_type
+        )
 
         queryResult = self.getQueryService().projection(q, params, ctx)
 
         for r in queryResult:
             ur = unwrap(r)
-            if ur[3] == 'ome.model.annotations.LongAnnotation':
-                counts['LongAnnotation'] += ur[0]
-                counts['OtherAnnotation'] += ur[1]
-            elif ur[3] == 'ome.model.annotations.CommentAnnotation':
-                counts['CommentAnnotation'] += ur[2]
-            elif ur[3] == 'ome.model.annotations.TagAnnotation':
-                counts['TagAnnotation'] += ur[2]
-            elif ur[3] == 'ome.model.annotations.FileAnnotation':
-                counts['FileAnnotation'] += ur[2]
-            elif ur[3] == 'ome.model.annotations.MapAnnotation':
-                counts['MapAnnotation'] += ur[2]
+            if ur[3] == "ome.model.annotations.LongAnnotation":
+                counts["LongAnnotation"] += ur[0]
+                counts["OtherAnnotation"] += ur[1]
+            elif ur[3] == "ome.model.annotations.CommentAnnotation":
+                counts["CommentAnnotation"] += ur[2]
+            elif ur[3] == "ome.model.annotations.TagAnnotation":
+                counts["TagAnnotation"] += ur[2]
+            elif ur[3] == "ome.model.annotations.FileAnnotation":
+                counts["FileAnnotation"] += ur[2]
+            elif ur[3] == "ome.model.annotations.MapAnnotation":
+                counts["MapAnnotation"] += ur[2]
             else:
-                counts['OtherAnnotation'] += ur[2]
+                counts["OtherAnnotation"] += ur[2]
 
         return counts
 
-    def listOrphanedAnnotations(self, parent_type, parent_ids, eid=None,
-                                ns=None, anntype=None, addedByMe=True):
+    def listOrphanedAnnotations(
+        self,
+        parent_type,
+        parent_ids,
+        eid=None,
+        ns=None,
+        anntype=None,
+        addedByMe=True,
+    ):
         """
         Retrieve all Annotations not linked to the given parents: Projects,
         Datasets, Images, Screens, Plates OR Wells etc.
@@ -3635,14 +3881,19 @@ class _BlitzGateway (object):
         """
 
         if anntype is not None:
-            if (anntype.title()
-                    not in ('Text', 'Tag', 'File', 'Long', 'Boolean')):
+            if anntype.title() not in (
+                "Text",
+                "Tag",
+                "File",
+                "Long",
+                "Boolean",
+            ):
                 raise AttributeError(
-                    'Use annotation type: Text, Tag, File, Long, Boolean')
+                    "Use annotation type: Text, Tag, File, Long, Boolean"
+                )
             sql = "select an from %sAnnotation as an " % anntype.title()
         else:
-            sql = "select an from Annotation as an " \
-
+            sql = "select an from Annotation as an "
         if anntype.title() == "File":
             sql += " join fetch an.file "
 
@@ -3664,23 +3915,28 @@ class _BlitzGateway (object):
             wheres.append(
                 "not exists ( select link from %sAnnotationLink as link "
                 "where link.child=an.id and link.parent.id=:oid%s)"
-                % (parent_type, filterlink))
+                % (parent_type, filterlink)
+            )
         else:
             # for multiple parents, we first need to find annotations linked to
             # ALL of them, then exclude those from query
             p.map["oids"] = omero.rtypes.wrap([rlong(id) for id in parent_ids])
-            query = ("select link.child.id, count(link.id) "
-                     "from %sAnnotationLink link where link.parent.id in "
-                     "(:oids)%s group by link.child.id"
-                     % (parent_type, filterlink))
+            query = (
+                "select link.child.id, count(link.id) "
+                "from %sAnnotationLink link where link.parent.id in "
+                "(:oids)%s group by link.child.id" % (parent_type, filterlink)
+            )
             # count annLinks and check if count == number of parents (all
             # parents linked to annotation)
-            usedAnnIds = [e[0].getValue() for e in
-                          q.projection(query, p, self.SERVICE_OPTS)
-                          if e[1].getValue() == len(parent_ids)]
+            usedAnnIds = [
+                e[0].getValue()
+                for e in q.projection(query, p, self.SERVICE_OPTS)
+                if e[1].getValue() == len(parent_ids)
+            ]
             if len(usedAnnIds) > 0:
                 p.map["usedAnnIds"] = omero.rtypes.wrap(
-                        [rlong(id) for id in usedAnnIds])
+                    [rlong(id) for id in usedAnnIds]
+                )
                 wheres.append("an.id not in (:usedAnnIds)")
 
         if ns is None:
@@ -3710,21 +3966,32 @@ class _BlitzGateway (object):
                 if obj_type is not None and obj_type != key:
                     raise AttributeError(
                         "getAnnotationCounts cannot be used with "
-                        "different types of objects")
+                        "different types of objects"
+                    )
                 obj_type = key
                 obj_ids.append(o.id)
 
         if obj_type is None:
             return self.countAnnotations()
 
-        obj_type = obj_type.title().replace("Plateacquisition",
-                                            "PlateAcquisition")
+        obj_type = obj_type.title().replace(
+            "Plateacquisition", "PlateAcquisition"
+        )
 
         return self.countAnnotations(obj_type, obj_ids)
 
-    def createImageFromNumpySeq(self, zctPlanes, imageName, sizeZ=1, sizeC=1,
-                                sizeT=1, description=None, dataset=None,
-                                sourceImageId=None, channelList=None):
+    def createImageFromNumpySeq(
+        self,
+        zctPlanes,
+        imageName,
+        sizeZ=1,
+        sizeC=1,
+        sizeT=1,
+        description=None,
+        dataset=None,
+        sourceImageId=None,
+        channelList=None,
+    ):
         """
         Creates a new multi-dimensional image from the sequence of 2D numpy
         arrays in zctPlanes. zctPlanes should be a generator of numpy 2D
@@ -3782,20 +4049,30 @@ class _BlitzGateway (object):
                 if channelList is None:
                     channelList = list(range(sizeC))
                 iId = pixelsService.copyAndResizeImage(
-                    sourceImageId, rint(sizeX), rint(sizeY), rint(sizeZ),
-                    rint(sizeT), channelList, None, False, self.SERVICE_OPTS)
+                    sourceImageId,
+                    rint(sizeX),
+                    rint(sizeY),
+                    rint(sizeZ),
+                    rint(sizeT),
+                    channelList,
+                    None,
+                    False,
+                    self.SERVICE_OPTS,
+                )
                 # need to ensure that the plane dtype matches the pixels type
                 # of our new image
                 img = self.getObject("Image", iId.getValue())
                 newPtype = img.getPrimaryPixels().getPixelsType().getValue()
-                omeroToNumpy = {PixelsTypeint8: 'int8',
-                                PixelsTypeuint8: 'uint8',
-                                PixelsTypeint16: 'int16',
-                                PixelsTypeuint16: 'uint16',
-                                PixelsTypeint32: 'int32',
-                                PixelsTypeuint32: 'uint32',
-                                PixelsTypefloat: 'float32',
-                                PixelsTypedouble: 'double'}
+                omeroToNumpy = {
+                    PixelsTypeint8: "int8",
+                    PixelsTypeuint8: "uint8",
+                    PixelsTypeint16: "int16",
+                    PixelsTypeuint16: "uint16",
+                    PixelsTypeint32: "int32",
+                    PixelsTypeuint32: "uint32",
+                    PixelsTypefloat: "float32",
+                    PixelsTypedouble: "double",
+                }
                 if omeroToNumpy[newPtype] != firstPlane.dtype.name:
                     convertToType = getattr(numpy, omeroToNumpy[newPtype])
                 img._obj.setName(rstring(imageName))
@@ -3804,17 +4081,19 @@ class _BlitzGateway (object):
             else:
                 # need to map numpy pixel types to omero - don't handle: bool_,
                 # character, int_, int64, object_
-                pTypes = {'int8': PixelsTypeint8,
-                          'int16': PixelsTypeint16,
-                          'uint16': PixelsTypeuint16,
-                          'int32': PixelsTypeint32,
-                          'float_': PixelsTypefloat,
-                          'float8': PixelsTypefloat,
-                          'float16': PixelsTypefloat,
-                          'float32': PixelsTypefloat,
-                          'float64': PixelsTypedouble,
-                          'complex_': PixelsTypecomplex,
-                          'complex64': PixelsTypecomplex}
+                pTypes = {
+                    "int8": PixelsTypeint8,
+                    "int16": PixelsTypeint16,
+                    "uint16": PixelsTypeuint16,
+                    "int32": PixelsTypeint32,
+                    "float_": PixelsTypefloat,
+                    "float8": PixelsTypefloat,
+                    "float16": PixelsTypefloat,
+                    "float32": PixelsTypefloat,
+                    "float64": PixelsTypedouble,
+                    "complex_": PixelsTypecomplex,
+                    "complex64": PixelsTypecomplex,
+                }
                 dType = firstPlane.dtype.name
                 if dType not in pTypes:  # try to look up any not named above
                     pType = dType
@@ -3822,19 +4101,33 @@ class _BlitzGateway (object):
                     pType = pTypes[dType]
                 # omero::model::PixelsType
                 pixelsType = queryService.findByQuery(
-                    "from PixelsType as p where p.value='%s'" % pType, None)
+                    "from PixelsType as p where p.value='%s'" % pType, None
+                )
                 if pixelsType is None:
                     raise Exception(
                         "Cannot create an image in omero from numpy array "
-                        "with dtype: %s" % dType)
+                        "with dtype: %s" % dType
+                    )
                 channelList = list(range(sizeC))
                 iId = pixelsService.createImage(
-                    sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
-                    imageName, description, self.SERVICE_OPTS)
+                    sizeX,
+                    sizeY,
+                    sizeZ,
+                    sizeT,
+                    channelList,
+                    pixelsType,
+                    imageName,
+                    description,
+                    self.SERVICE_OPTS,
+                )
 
             imageId = iId.getValue()
-            return (containerService.getImages(
-                "Image", [imageId], None, self.SERVICE_OPTS)[0], convertToType)
+            return (
+                containerService.getImages(
+                    "Image", [imageId], None, self.SERVICE_OPTS
+                )[0],
+                convertToType,
+            )
 
         def uploadPlane(plane, z, c, t, convertToType):
             # if we're given a numpy dtype, need to convert plane to that dtype
@@ -3858,10 +4151,12 @@ class _BlitzGateway (object):
                         # use the first plane to create image.
                         if image is None:
                             image, dtype = createImage(plane, channelList)
-                            pixelsId = image.getPrimaryPixels(
-                                ).getId().getValue()
+                            pixelsId = (
+                                image.getPrimaryPixels().getId().getValue()
+                            )
                             rawPixelsStore.setPixelsId(
-                                pixelsId, True, self.SERVICE_OPTS)
+                                pixelsId, True, self.SERVICE_OPTS
+                            )
                         uploadPlane(plane, theZ, theC, theT, dtype)
                         # init or update min and max for this channel
                         minValue = plane.min()
@@ -3871,13 +4166,16 @@ class _BlitzGateway (object):
                             channelsMinMax.append([minValue, maxValue])
                         else:
                             channelsMinMax[theC][0] = min(
-                                channelsMinMax[theC][0], minValue)
+                                channelsMinMax[theC][0], minValue
+                            )
                             channelsMinMax[theC][1] = max(
-                                channelsMinMax[theC][1], maxValue)
+                                channelsMinMax[theC][1], maxValue
+                            )
         except Exception as e:
             logger.error(
                 "Failed to setPlane() on rawPixelsStore while creating Image",
-                exc_info=True)
+                exc_info=True,
+            )
             exc = e
         try:
             rawPixelsStore.close(self.SERVICE_OPTS)
@@ -3896,7 +4194,8 @@ class _BlitzGateway (object):
 
         for theC, mm in enumerate(channelsMinMax):
             pixelsService.setChannelGlobalMinMax(
-                pixelsId, theC, float(mm[0]), float(mm[1]), self.SERVICE_OPTS)
+                pixelsId, theC, float(mm[0]), float(mm[1]), self.SERVICE_OPTS
+            )
             # resetRenderingSettings(
             #     renderingEngine, pixelsId, theC, mm[0], mm[1])
 
@@ -3936,7 +4235,8 @@ class _BlitzGateway (object):
             ctx.setOmeroGroup(fromimg.getDetails().getGroup().getId())
             rsettings = self.getRenderingSettingsService()
             json_data = rsettings.applySettingsToSet(
-                frompid, to_type, list(toids),  ctx)
+                frompid, to_type, list(toids), ctx
+            )
             if fromid in json_data[True]:
                 del json_data[True][json_data[True].index(fromid)]
         return json_data
@@ -3961,7 +4261,8 @@ class _BlitzGateway (object):
             imageIds = [int(i) for i in ids]
         elif data_type == "Dataset":
             images = self.getContainerService().getImages(
-                "Dataset", ids, None, self.SERVICE_OPTS)
+                "Dataset", ids, None, self.SERVICE_OPTS
+            )
             imageIds = [i.getId().getValue() for i in images]
         elif data_type == "Plate":
             imageIds = []
@@ -3973,17 +4274,20 @@ class _BlitzGateway (object):
         else:
             raise AttributeError(
                 "setChannelNames() supports data_types 'Image', 'Dataset', "
-                "'Plate' only, not '%s'" % data_type)
+                "'Plate' only, not '%s'" % data_type
+            )
 
         queryService = self.getQueryService()
         params = omero.sys.Parameters()
-        params.map = {'ids': rlist([rlong(id) for id in imageIds])}
+        params.map = {"ids": rlist([rlong(id) for id in imageIds])}
 
         # load Pixels, Channels, Logical Channels and Images
-        query = ("select p from Pixels p left outer "
-                 "join fetch p.channels as c "
-                 "join fetch c.logicalChannel as lc "
-                 "join fetch p.image as i where i.id in (:ids)")
+        query = (
+            "select p from Pixels p left outer "
+            "join fetch p.channels as c "
+            "join fetch c.logicalChannel as lc "
+            "join fetch p.image as i where i.id in (:ids)"
+        )
         pix = queryService.findAllByQuery(query, params, self.SERVICE_OPTS)
 
         maxIdx = max(nameDict.keys())
@@ -4003,18 +4307,19 @@ class _BlitzGateway (object):
             group_id = p.details.group.id.val
             ctx.setOmeroGroup(group_id)
             for i, c in enumerate(p.iterateChannels()):
-                if i+1 not in nameDict:
+                if i + 1 not in nameDict:
                     continue
                 lc = c.logicalChannel
-                lc.setName(rstring(nameDict[i+1]))
+                lc.setName(rstring(nameDict[i + 1]))
                 toSave.add(lc)
 
         toSave = list(toSave)
         self.getUpdateService().saveCollection(toSave, ctx)
-        return {'imageCount': len(imageIds), 'updateCount': updateCount}
+        return {"imageCount": len(imageIds), "updateCount": updateCount}
 
-    def createOriginalFileFromFileObj(self, fo, path, name, fileSize,
-                                      mimetype=None, ns=None):
+    def createOriginalFileFromFileObj(
+        self, fo, path, name, fileSize, mimetype=None, ns=None
+    ):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -4034,7 +4339,8 @@ class _BlitzGateway (object):
             warnings.warn(
                 "Deprecated in 5.4.0. The ns parameter was added in error"
                 " and has always been ignored",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
 
         updateService = self.getUpdateService()
         # create original file, set name, path, mimetype
@@ -4047,9 +4353,11 @@ class _BlitzGateway (object):
         # set sha1
         try:
             import hashlib
+
             hash_sha1 = hashlib.sha1
         except:
             import sha
+
             hash_sha1 = sha.new
         fo.seek(0)
         h = hash_sha1()
@@ -4062,19 +4370,21 @@ class _BlitzGateway (object):
         originalFile.setHasher(chk)
 
         originalFile = updateService.saveAndReturnObject(
-            originalFile, self.SERVICE_OPTS)
+            originalFile, self.SERVICE_OPTS
+        )
 
         # upload file
         fo.seek(0)
         rawFileStore = self.createRawFileStore()
         try:
             rawFileStore.setFileId(
-                originalFile.getId().getValue(), self.SERVICE_OPTS)
+                originalFile.getId().getValue(), self.SERVICE_OPTS
+            )
             buf = 10000
             for pos in range(0, int(fileSize), buf):
                 block = None
-                if fileSize-pos < buf:
-                    blockSize = fileSize-pos
+                if fileSize - pos < buf:
+                    blockSize = fileSize - pos
                 else:
                     blockSize = buf
                 fo.seek(pos)
@@ -4085,9 +4395,9 @@ class _BlitzGateway (object):
             rawFileStore.close()
         return OriginalFileWrapper(self, originalFile)
 
-    def createOriginalFileFromLocalFile(self, localPath,
-                                        origFilePathAndName=None,
-                                        mimetype=None, ns=None):
+    def createOriginalFileFromLocalFile(
+        self, localPath, origFilePathAndName=None, mimetype=None, ns=None
+    ):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -4107,17 +4417,25 @@ class _BlitzGateway (object):
             warnings.warn(
                 "Deprecated in 5.4.0. The ns parameter was added in error"
                 " and has always been ignored",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
         if origFilePathAndName is None:
             origFilePathAndName = localPath
         path, name = os.path.split(origFilePathAndName)
         fileSize = os.path.getsize(localPath)
-        with open(localPath, 'rb') as fileHandle:
-            return self.createOriginalFileFromFileObj(fileHandle, path, name,
-                                                      fileSize, mimetype)
+        with open(localPath, "rb") as fileHandle:
+            return self.createOriginalFileFromFileObj(
+                fileHandle, path, name, fileSize, mimetype
+            )
 
-    def createFileAnnfromLocalFile(self, localPath, origFilePathAndName=None,
-                                   mimetype=None, ns=None, desc=None):
+    def createFileAnnfromLocalFile(
+        self,
+        localPath,
+        origFilePathAndName=None,
+        mimetype=None,
+        ns=None,
+        desc=None,
+    ):
         """
         Class method to create a :class:`FileAnnotationWrapper` from a local
         file. File is uploaded to create an omero.model.OriginalFileI
@@ -4139,7 +4457,8 @@ class _BlitzGateway (object):
 
         # create and upload original file
         originalFile = self.createOriginalFileFromLocalFile(
-            localPath, origFilePathAndName, mimetype)
+            localPath, origFilePathAndName, mimetype
+        )
 
         # create FileAnnotation, set ns & description and return wrapped obj
         fa = omero.model.FileAnnotationI()
@@ -4166,10 +4485,12 @@ class _BlitzGateway (object):
         if not wrapper:
             raise AttributeError("Don't know how to handle '%s'" % obj_type)
 
-        sql = "select ob from %s ob " \
-              "left outer join fetch ob.annotationLinks obal " \
-              "left outer join fetch obal.child ann " \
-              "where ann.id in (:oids)" % wrapper().OMERO_CLASS
+        sql = (
+            "select ob from %s ob "
+            "left outer join fetch ob.annotationLinks obal "
+            "left outer join fetch obal.child ann "
+            "where ann.id in (:oids)" % wrapper().OMERO_CLASS
+        )
 
         q = self.getQueryService()
         p = omero.sys.Parameters()
@@ -4275,7 +4596,7 @@ class _BlitzGateway (object):
             r = list()
             for e in value:
                 r.append(EnumerationWrapper(self, e))
-            rv[key+"I"] = r
+            rv[key + "I"] = r
         return rv
 
     def deleteEnumeration(self, obj):
@@ -4338,9 +4659,10 @@ class _BlitzGateway (object):
         """
         warnings.warn(
             "Deprecated. Use deleteObject() or deleteObjects()",
-            DeprecationWarning)
+            DeprecationWarning,
+        )
 
-        type = obj.__class__.__name__.rstrip('I')
+        type = obj.__class__.__name__.rstrip("I")
         delete = Delete2(targetObjects={type: [obj.getId().val]})
         self.c.submit(delete, ctx=self.SERVICE_OPTS)
 
@@ -4352,11 +4674,18 @@ class _BlitzGateway (object):
         :type obj:      IObject
         """
 
-        objType = obj.__class__.__name__.rstrip('I')
+        objType = obj.__class__.__name__.rstrip("I")
         self.deleteObjects(objType, [obj.id.val], wait=True)
 
-    def deleteObjects(self, graph_spec, obj_ids, deleteAnns=False,
-                      deleteChildren=False, dryRun=False, wait=False):
+    def deleteObjects(
+        self,
+        graph_spec,
+        obj_ids,
+        deleteAnns=False,
+        deleteChildren=False,
+        dryRun=False,
+        wait=False,
+    ):
         """
         Generic method for deleting using the delete queue. Options allow to
         delete 'independent' Annotations (Tag, Term, File) and to delete
@@ -4388,30 +4717,31 @@ class _BlitzGateway (object):
         :rtype:                 :class:`omero.api.delete.DeleteHandle`
         """
 
-        if '+' in graph_spec:
+        if "+" in graph_spec:
             raise AttributeError(
                 "Graph specs containing '+'' no longer supported: '%s'"
-                % graph_spec)
+                % graph_spec
+            )
         if not isinstance(obj_ids, list) or len(obj_ids) < 1:
-            raise AttributeError('Must be a list of object IDs')
+            raise AttributeError("Must be a list of object IDs")
 
-        graph = graph_spec.lstrip('/').split('/')
+        graph = graph_spec.lstrip("/").split("/")
         obj_ids = list(map(int, obj_ids))
         delete = Delete2(targetObjects={graph[0]: obj_ids}, dryRun=dryRun)
 
         exc = list()
-        if not deleteAnns and graph[0] not in ["Annotation",
-                                               "TagAnnotation"]:
-            exc.extend(
-                ["TagAnnotation", "TermAnnotation", "FileAnnotation"])
+        if not deleteAnns and graph[0] not in ["Annotation", "TagAnnotation"]:
+            exc.extend(["TagAnnotation", "TermAnnotation", "FileAnnotation"])
 
-        childTypes = {'Project': ['Dataset', 'Image'],
-                      'Dataset': ['Image'],
-                      'Image': [],
-                      'Screen': ['Plate'],
-                      'Plate': ['Image'],
-                      'Well': [],
-                      'Annotation': []}
+        childTypes = {
+            "Project": ["Dataset", "Image"],
+            "Dataset": ["Image"],
+            "Image": [],
+            "Screen": ["Plate"],
+            "Plate": ["Image"],
+            "Well": [],
+            "Annotation": [],
+        }
 
         if not deleteChildren:
             try:
@@ -4432,10 +4762,11 @@ class _BlitzGateway (object):
             skiphead.dryRun = dryRun
             delete = skiphead
 
-        logger.debug('Deleting %s [%s]. Options: %s' %
-                     (graph_spec, str(obj_ids), exc))
+        logger.debug(
+            "Deleting %s [%s]. Options: %s" % (graph_spec, str(obj_ids), exc)
+        )
 
-        logger.debug('Delete2: \n%s' % str(delete))
+        logger.debug("Delete2: \n%s" % str(delete))
 
         handle = self.c.sf.submit(delete, self.SERVICE_OPTS)
         if wait:
@@ -4446,15 +4777,24 @@ class _BlitzGateway (object):
 
         return handle
 
-    def _waitOnCmd(self, handle, loops=10, ms=500,
-                   failonerror=True,
-                   failontimeout=False,
-                   closehandle=False):
+    def _waitOnCmd(
+        self,
+        handle,
+        loops=10,
+        ms=500,
+        failonerror=True,
+        failontimeout=False,
+        closehandle=False,
+    ):
 
-        return self.c.waitOnCmd(handle, loops=loops, ms=ms,
-                                failonerror=failonerror,
-                                failontimeout=failontimeout,
-                                closehandle=closehandle)
+        return self.c.waitOnCmd(
+            handle,
+            loops=loops,
+            ms=ms,
+            failonerror=failonerror,
+            failontimeout=failontimeout,
+            closehandle=closehandle,
+        )
 
     def chmodGroup(self, group_Id, permissions):
         """
@@ -4465,8 +4805,9 @@ class _BlitzGateway (object):
         rsp = prx.getResponse()
         """
         chmod = omero.cmd.Chmod2(
-            targetObjects={'ExperimenterGroup': [group_Id]},
-            permissions=permissions)
+            targetObjects={"ExperimenterGroup": [group_Id]},
+            permissions=permissions,
+        )
         prx = self.c.sf.submit(chmod)
         return prx
 
@@ -4485,14 +4826,15 @@ class _BlitzGateway (object):
         :param group_id:        The group to move the data to.
         """
 
-        if '+' in graph_spec:
+        if "+" in graph_spec:
             raise AttributeError(
                 "Graph specs containing '+'' no longer supported: '%s'"
-                % graph_spec)
+                % graph_spec
+            )
         if not isinstance(obj_ids, list) or len(obj_ids) < 1:
-            raise AttributeError('Must be a list of object IDs')
+            raise AttributeError("Must be a list of object IDs")
 
-        graph = graph_spec.lstrip('/').split('/')
+        graph = graph_spec.lstrip("/").split("/")
         obj_ids = list(map(int, obj_ids))
         chgrp = Chgrp2(targetObjects={graph[0]: obj_ids}, groupId=group_id)
 
@@ -4507,15 +4849,22 @@ class _BlitzGateway (object):
 
         # (link, child, parent)
         parentLinkClasses = {
-            "Image": (omero.model.DatasetImageLinkI,
-                      omero.model.ImageI,
-                      omero.model.DatasetI),
-            "Dataset": (omero.model.ProjectDatasetLinkI,
-                        omero.model.DatasetI,
-                        omero.model.ProjectI),
-            "Plate": (omero.model.ScreenPlateLinkI,
-                      omero.model.PlateI,
-                      omero.model.ScreenI)}
+            "Image": (
+                omero.model.DatasetImageLinkI,
+                omero.model.ImageI,
+                omero.model.DatasetI,
+            ),
+            "Dataset": (
+                omero.model.ProjectDatasetLinkI,
+                omero.model.DatasetI,
+                omero.model.ProjectI,
+            ),
+            "Plate": (
+                omero.model.ScreenPlateLinkI,
+                omero.model.PlateI,
+                omero.model.ScreenI,
+            ),
+        }
         da = DoAll()
         saves = []
 
@@ -4527,8 +4876,9 @@ class _BlitzGateway (object):
                 link_klass = parentLinkClasses[graph_spec][0]
                 link = link_klass()
                 link.child = parentLinkClasses[graph_spec][1](obj_id, False)
-                link.parent = parentLinkClasses[
-                    graph_spec][2](container_id, False)
+                link.parent = parentLinkClasses[graph_spec][2](
+                    container_id, False
+                )
                 link.details.owner = omero.model.ExperimenterI(ownerId, False)
                 save = Save()
                 save.obj = link
@@ -4537,10 +4887,12 @@ class _BlitzGateway (object):
         requests.extend(saves)
         da.requests = requests
 
-        logger.debug('DoAll Chgrp2: type: %s, ids: %s, grp: %s' %
-                     (graph_spec, obj_ids, group_id))
+        logger.debug(
+            "DoAll Chgrp2: type: %s, ids: %s, grp: %s"
+            % (graph_spec, obj_ids, group_id)
+        )
 
-        logger.debug('Chgrp2: \n%s' % str(da))
+        logger.debug("Chgrp2: \n%s" % str(da))
 
         ctx = self.SERVICE_OPTS.copy()
         # NB: For Save to work, we need to be in target group
@@ -4551,9 +4903,19 @@ class _BlitzGateway (object):
     ###################
     # Searching stuff #
 
-    def searchObjects(self, obj_types, text, created=None, fields=(),
-                      batchSize=1000, page=0, searchGroup=None, ownedBy=None,
-                      useAcquisitionDate=False, rawQuery=True):
+    def searchObjects(
+        self,
+        obj_types,
+        text,
+        created=None,
+        fields=(),
+        batchSize=1000,
+        page=0,
+        searchGroup=None,
+        ownedBy=None,
+        useAcquisitionDate=False,
+        rawQuery=True,
+    ):
         """
         Search objects of type "Project", "Dataset", "Image", "Screen", "Plate"
         Returns a list of results
@@ -4572,15 +4934,25 @@ class _BlitzGateway (object):
         if obj_types is None:
             types = (ProjectWrapper, DatasetWrapper, ImageWrapper)
         else:
+
             def getWrapper(obj_type):
-                objs = ["project", "dataset", "image", "screen",
-                        "plateacquisition", "plate", "well"]
+                objs = [
+                    "project",
+                    "dataset",
+                    "image",
+                    "screen",
+                    "plateacquisition",
+                    "plate",
+                    "well",
+                ]
                 if obj_type.lower() not in objs:
                     raise AttributeError(
                         "%s not recognised. Can only search for 'Project',"
                         "'Dataset', 'Image', 'Screen', 'Plate', 'Well'"
-                        % obj_type)
+                        % obj_type
+                    )
                 return KNOWN_WRAPPERS.get(obj_type.lower(), None)
+
             types = [getWrapper(o) for o in obj_types]
         search = self.createSearchService()
 
@@ -4614,13 +4986,16 @@ class _BlitzGateway (object):
 
         d_from = parse_time(created, 0)
         d_to = parse_time(created, 1)
-        d_type = (useAcquisitionDate and
-                  "acquisitionDate" or
-                  "details.creationEvent.time")
+        d_type = (
+            useAcquisitionDate
+            and "acquisitionDate"
+            or "details.creationEvent.time"
+        )
 
         try:
             rv = []
             for t in types:
+
                 def actualSearch():
                     search.onlyType(t().OMERO_CLASS, ctx)
                     if rawQuery:
@@ -4629,15 +5004,15 @@ class _BlitzGateway (object):
                         search.byFullText(text, ctx)
                     else:
                         search.byLuceneQueryBuilder(
-                            ",".join(fields),
-                            d_from, d_to, d_type,
-                            text, ctx)
+                            ",".join(fields), d_from, d_to, d_type, text, ctx
+                        )
 
                 timeit(actualSearch)()
                 # get results
 
                 def searchProcessing():
                     return search.results(ctx)
+
                 p = 0
                 # we do pagination by loading until the required page
                 while search.hasNext(ctx):
@@ -4680,15 +5055,15 @@ class _BlitzGateway (object):
                      from Pixels as p join p.image as i
                      where i.id in (:ids) """
 
-            img_pixel_ids = self.getQueryService().projection(
-                sql, p, ctx)
+            img_pixel_ids = self.getQueryService().projection(sql, p, ctx)
             _temp = dict()
             for e in img_pixel_ids:
                 e = unwrap(e)
-                _temp[e[0]['pix_id']] = e[0]['im_id']
+                _temp[e[0]["pix_id"]] = e[0]["im_id"]
 
             thumbs_map = tb.getThumbnailByLongestSideSet(
-                rint(max_size), list(_temp), ctx)
+                rint(max_size), list(_temp), ctx
+            )
             for (pix, thumb) in list(thumbs_map.items()):
                 _resp[_temp[pix]] = thumb
         except Exception:
@@ -4723,9 +5098,16 @@ class OmeroGatewaySafeCallWrapper(object):  # pragma: no cover
             self.__f__name = "unknown"
 
     def debug(self, exc_class, args, kwargs):
-        logger.warn("%s on %s to <%s> %s(%r, %r)",
-                    exc_class, self.__class__, self.__f__name, self.attr,
-                    args, kwargs, exc_info=True)
+        logger.warn(
+            "%s on %s to <%s> %s(%r, %r)",
+            exc_class,
+            self.__class__,
+            self.__f__name,
+            self.attr,
+            args,
+            kwargs,
+            exc_info=True,
+        )
 
     def handle_exception(self, e, *args, **kwargs):
         r"""
@@ -4747,6 +5129,7 @@ class OmeroGatewaySafeCallWrapper(object):  # pragma: no cover
         except Exception as e:
             self.debug(e.__class__.__name__, args, kwargs)
             return self.handle_exception(e, *args, **kwargs)
+
 
 # Extension point for API users who want to customise the semantics of
 # safe call wrap. (See #6365)
@@ -4774,21 +5157,21 @@ def splitHTMLColor(color):
         out = []
         if len(color) in (3, 4):
             c = color
-            color = ''
+            color = ""
             for e in c:
                 color += e + e
         if len(color) == 6:
-            color += 'FF'
+            color += "FF"
         if len(color) == 8:
             for i in range(0, 8, 2):
-                out.append(int(color[i:i+2], 16))
+                out.append(int(color[i : i + 2], 16))
             return out
     except:
         pass
     return None
 
 
-class ProxyObjectWrapper (object):
+class ProxyObjectWrapper(object):
     """
     Wrapper for services. E.g. Admin Service, Delete Service etc.
     Maintains reference to connection.
@@ -4828,7 +5211,8 @@ class ProxyObjectWrapper (object):
         """
 
         return ProxyObjectWrapper(
-            self._conn, self._func_str, self._cast_to, self._service_name)
+            self._conn, self._func_str, self._cast_to, self._service_name
+        )
 
     def _connect(self, forcejoin=False):  # pragma: no cover
         """
@@ -4848,8 +5232,8 @@ class ProxyObjectWrapper (object):
         else:
             sUuid = None
         if not self._conn.connect(sUuid=sUuid):
-            logger.debug('connect failed')
-            logger.debug('/n'.join(traceback.format_stack()))
+            logger.debug("connect failed")
+            logger.debug("/n".join(traceback.format_stack()))
             return False
         logger.debug("proxy_connect: b")
         self._resyncConn(self._conn)
@@ -4873,7 +5257,8 @@ class ProxyObjectWrapper (object):
         """
 
         if self._obj and isinstance(
-                self._obj, omero.api.StatefulServiceInterfacePrx):
+            self._obj, omero.api.StatefulServiceInterfacePrx
+        ):
             self._conn._unregister_service(str(self._obj))
             self._obj.close(*args, **kwargs)
         self._obj = None
@@ -4900,11 +5285,14 @@ class ProxyObjectWrapper (object):
                 if isinstance(obj, omero.api.StatefulServiceInterfacePrx):
                     conn._register_service(str(obj), traceback.extract_stack())
                 return obj
+
         self._create_func = cf
         if self._obj is not None:
             try:
-                logger.debug("## - refreshing %s" %
-                             (self._func_str or self._service_name))
+                logger.debug(
+                    "## - refreshing %s"
+                    % (self._func_str or self._service_name)
+                )
                 obj = conn.c.ic.stringToProxy(native_str(self._obj))
                 self._obj = self._obj.checkedCast(obj)
             except Ice.ObjectNotExistException:
@@ -4922,7 +5310,7 @@ class ProxyObjectWrapper (object):
             try:
                 self._obj = self._create_func()
             except Ice.ConnectionLostException:
-                logger.debug('... lost, reconnecting (_getObj)')
+                logger.debug("... lost, reconnecting (_getObj)")
                 self._connect()
                 # self._obj = self._create_func()
         else:
@@ -4997,10 +5385,11 @@ class ProxyObjectWrapper (object):
         return rv
 
 
-class AnnotationWrapper (BlitzObjectWrapper):
+class AnnotationWrapper(BlitzObjectWrapper):
     """
     omero_model_AnnotationI class wrapper extends BlitzObjectWrapper.
     """
+
     # class dict for type:wrapper
     # E.g. DoubleAnnotationI : DoubleAnnotationWrapper
     registry = {}
@@ -5011,7 +5400,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Initialises the Annotation wrapper and 'link' if in kwargs
         """
         super(AnnotationWrapper, self).__init__(*args, **kwargs)
-        self.link = kwargs.get('link')
+        self.link = kwargs.get("link")
         if self._obj is None and self.OMERO_TYPE is not None:
             self._obj = self.OMERO_TYPE()
 
@@ -5023,9 +5412,12 @@ class AnnotationWrapper (BlitzObjectWrapper):
         :return:    True if annotations are the same - see above
         :rtype:     Boolean
         """
-        return (type(a) == type(self) and self._obj.id == a._obj.id and
-                self.getValue() == a.getValue() and
-                self.getNs() == a.getNs())
+        return (
+            type(a) == type(self)
+            and self._obj.id == a._obj.id
+            and self.getValue() == a.getValue()
+            and self.getNs() == a.getNs()
+        )
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -5038,9 +5430,11 @@ class AnnotationWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from Annotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from Annotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     @classmethod
@@ -5078,7 +5472,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
         if obj.__class__ in cls.registry:
             kwargs = dict()
             if link is not None:
-                kwargs['link'] = BlitzObjectWrapper(conn, link)
+                kwargs["link"] = BlitzObjectWrapper(conn, link)
             return cls.registry[obj.__class__](conn, obj, **kwargs)
         else:  # pragma: no cover
             logger.error("Failed to _wrap() annotation: %s" % obj.__class__)
@@ -5133,28 +5527,39 @@ class AnnotationWrapper (BlitzObjectWrapper):
 
     def getParentLinks(self, ptype, pids=None):
         ptype = ptype.title().replace("Plateacquisition", "PlateAcquisition")
-        objs = ('Project', 'Dataset', 'Image', 'Screen',
-                'Plate', 'Well', 'PlateAcquisition')
+        objs = (
+            "Project",
+            "Dataset",
+            "Image",
+            "Screen",
+            "Plate",
+            "Well",
+            "PlateAcquisition",
+        )
         if ptype not in objs:
             raise AttributeError(
-                "getParentLinks(): ptype '%s' not supported" % ptype)
+                "getParentLinks(): ptype '%s' not supported" % ptype
+            )
         p = omero.sys.Parameters()
         p.map = {}
         p.map["aid"] = rlong(self.id)
-        sql = ("select oal from %sAnnotationLink as oal "
-               "left outer join fetch oal.child as ch "
-               "left outer join fetch oal.parent as pa "
-               "where ch.id=:aid " % (ptype))
+        sql = (
+            "select oal from %sAnnotationLink as oal "
+            "left outer join fetch oal.child as ch "
+            "left outer join fetch oal.parent as pa "
+            "where ch.id=:aid " % (ptype)
+        )
         if pids is not None:
             p.map["pids"] = rlist([rlong(ob) for ob in pids])
             sql += " and pa.id in (:pids)"
 
         for al in self._conn.getQueryService().findAllByQuery(
-                sql, p, self._conn.SERVICE_OPTS):
+            sql, p, self._conn.SERVICE_OPTS
+        ):
             yield AnnotationLinkWrapper(self._conn, al)
 
 
-class _AnnotationLinkWrapper (BlitzObjectWrapper):
+class _AnnotationLinkWrapper(BlitzObjectWrapper):
     """
     omero_model_AnnotationLinkI class wrapper
     extends omero.gateway.BlitzObjectWrapper.
@@ -5169,18 +5574,18 @@ class _AnnotationLinkWrapper (BlitzObjectWrapper):
         but attempts to wrap it in the correct subclass using
         L{KNOWN_WRAPPERS}, E.g. ImageWrapper
         """
-        modelClass = self.parent.__class__.__name__[
-            :-1].lower()    # E.g. 'image'
+        modelClass = self.parent.__class__.__name__[:-1].lower()  # E.g. 'image'
         if modelClass in KNOWN_WRAPPERS:
             return KNOWN_WRAPPERS[modelClass](self._conn, self.parent)
         return BlitzObjectWrapper(self._conn, self.parent)
+
 
 AnnotationLinkWrapper = _AnnotationLinkWrapper
 
 from omero_model_FileAnnotationI import FileAnnotationI
 
 
-class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
+class FileAnnotationWrapper(AnnotationWrapper, OmeroRestrictionWrapper):
     """
     omero_model_FileAnnotationI class wrapper extends AnnotationWrapper.
     """
@@ -5191,7 +5596,7 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
         super(FileAnnotationWrapper, self).__init__(*args, **kwargs)
         self._file = None
 
-    _attrs = ('file|OriginalFileWrapper',)
+    _attrs = ("file|OriginalFileWrapper",)
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -5204,9 +5609,11 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from FileAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent join fetch obj.file")
+        query = (
+            "select obj from FileAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent join fetch obj.file"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5246,11 +5653,13 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
         """
 
         try:
-            if (self._obj.ns is not None and
-                    self._obj.ns.val ==
-                    omero.constants.namespaces.NSCOMPANIONFILE and
-                    self.getFile().getName() ==
-                    omero.constants.annotation.file.ORIGINALMETADATA):
+            if (
+                self._obj.ns is not None
+                and self._obj.ns.val
+                == omero.constants.namespaces.NSCOMPANIONFILE
+                and self.getFile().getName()
+                == omero.constants.annotation.file.ORIGINALMETADATA
+            ):
                 return True
         except:
             logger.info(traceback.format_exc())
@@ -5287,6 +5696,7 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
 
         return self.getFile().getFileInChunks(buf=buf)
 
+
 AnnotationWrapper._register(FileAnnotationWrapper)
 
 
@@ -5295,6 +5705,7 @@ class _OriginalFileAsFileObj(object):
     Based on
     https://docs.python.org/2/library/stdtypes.html#file-objects
     """
+
     def __init__(self, originalfile, buf=2621440):
         self.originalfile = originalfile
         self.bufsize = buf
@@ -5312,13 +5723,13 @@ class _OriginalFileAsFileObj(object):
         elif mode == os.SEEK_END:
             self.pos = self.rfs.size() + n
         else:
-            raise ValueError('Invalid mode: %s' % mode)
+            raise ValueError("Invalid mode: %s" % mode)
 
     def tell(self):
         return self.pos
 
     def read(self, n=-1):
-        buf = b''
+        buf = b""
         if n < 0:
             endpos = self.rfs.size()
         else:
@@ -5343,12 +5754,12 @@ class _OriginalFileAsFileObj(object):
         self.close()
 
 
-class _OriginalFileWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
+class _OriginalFileWrapper(BlitzObjectWrapper, OmeroRestrictionWrapper):
     """
     omero_model_OriginalFileI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'OriginalFile'
+    OMERO_CLASS = "OriginalFile"
 
     def getFileInChunks(self, buf=2621440):
         """
@@ -5384,7 +5795,7 @@ OriginalFileWrapper = _OriginalFileWrapper
 from omero_model_TimestampAnnotationI import TimestampAnnotationI
 
 
-class TimestampAnnotationWrapper (AnnotationWrapper):
+class TimestampAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_TimestampAnnotationI class wrapper extends AnnotationWrapper.
     """
@@ -5402,9 +5813,11 @@ class TimestampAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from TimestampAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from TimestampAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5428,18 +5841,20 @@ class TimestampAnnotationWrapper (AnnotationWrapper):
 
         if isinstance(val, datetime):
             self._obj.timeValue = rtime(
-                int(time.mktime(val.timetuple())*1000))
+                int(time.mktime(val.timetuple()) * 1000)
+            )
         elif isinstance(val, omero.RTime):
             self._obj.timeValue = val
         else:
             self._obj.timeValue = rtime(int(val * 1000))
+
 
 AnnotationWrapper._register(TimestampAnnotationWrapper)
 
 from omero_model_BooleanAnnotationI import BooleanAnnotationI
 
 
-class BooleanAnnotationWrapper (AnnotationWrapper):
+class BooleanAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_BooleanAnnotationI class wrapper extends AnnotationWrapper.
     """
@@ -5457,9 +5872,11 @@ class BooleanAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from BooleanAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from BooleanAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5481,12 +5898,13 @@ class BooleanAnnotationWrapper (AnnotationWrapper):
 
         self._obj.boolValue = rbool(not not val)
 
+
 AnnotationWrapper._register(BooleanAnnotationWrapper)
 
 from omero_model_TagAnnotationI import TagAnnotationI
 
 
-class TagAnnotationWrapper (AnnotationWrapper):
+class TagAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_BooleanAnnotationI class wrapper extends AnnotationWrapper.
     """
@@ -5498,13 +5916,16 @@ class TagAnnotationWrapper (AnnotationWrapper):
         if self.ns in (omero.constants.metadata.NSINSIGHTTAGSET):
             params = omero.sys.Parameters()
             params.map = {}
-            params.map['tid'] = self._obj.id
-            sql = ("select tg from TagAnnotation tg where exists "
-                   "( select aal from AnnotationAnnotationLink as aal where "
-                   "aal.child=tg.id and aal.parent.id=:tid) ")
+            params.map["tid"] = self._obj.id
+            sql = (
+                "select tg from TagAnnotation tg where exists "
+                "( select aal from AnnotationAnnotationLink as aal where "
+                "aal.child=tg.id and aal.parent.id=:tid) "
+            )
 
             res = self._conn.getQueryService().findAllByQuery(
-                sql, params, self._conn.SERVICE_OPTS)
+                sql, params, self._conn.SERVICE_OPTS
+            )
             return res is not None and len(res) or 0
 
     def listTagsInTagset(self):
@@ -5514,9 +5935,11 @@ class TagAnnotationWrapper (AnnotationWrapper):
             params.map = {}
             params.map["tid"] = rlong(self._obj.id)
 
-            sql = ("select tg from TagAnnotation tg where exists "
-                   "( select aal from AnnotationAnnotationLink as aal where "
-                   "aal.child.id=tg.id and aal.parent.id=:tid) ")
+            sql = (
+                "select tg from TagAnnotation tg where exists "
+                "( select aal from AnnotationAnnotationLink as aal where "
+                "aal.child.id=tg.id and aal.parent.id=:tid) "
+            )
 
             q = self._conn.getQueryService()
             for ann in q.findAllByQuery(sql, params, self._conn.SERVICE_OPTS):
@@ -5529,13 +5952,14 @@ class TagAnnotationWrapper (AnnotationWrapper):
         # In this case, the Tag is the 'child' - 'Tag-Group' (parent) has
         # specified ns
         links = self._conn.getAnnotationLinks(
-            "TagAnnotation", ann_ids=[self.getId()])
+            "TagAnnotation", ann_ids=[self.getId()]
+        )
         rv = []
         for l in links:
             if l.parent.ns.val == omero.constants.metadata.NSINSIGHTTAGSET:
                 rv.append(
-                    omero.gateway.TagAnnotationWrapper(
-                        self._conn, l.parent, l))
+                    omero.gateway.TagAnnotationWrapper(self._conn, l.parent, l)
+                )
         return rv
 
     @classmethod
@@ -5549,9 +5973,11 @@ class TagAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from TagAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from TagAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5574,12 +6000,13 @@ class TagAnnotationWrapper (AnnotationWrapper):
 
         self._obj.textValue = omero_type(val)
 
+
 AnnotationWrapper._register(TagAnnotationWrapper)
 
 from omero_model_CommentAnnotationI import CommentAnnotationI
 
 
-class CommentAnnotationWrapper (AnnotationWrapper):
+class CommentAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_CommentAnnotationI class wrapper extends AnnotationWrapper.
     """
@@ -5597,9 +6024,11 @@ class CommentAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from CommentAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from CommentAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5621,15 +6050,17 @@ class CommentAnnotationWrapper (AnnotationWrapper):
 
         self._obj.textValue = omero_type(val)
 
+
 AnnotationWrapper._register(CommentAnnotationWrapper)
 
 from omero_model_LongAnnotationI import LongAnnotationI
 
 
-class LongAnnotationWrapper (AnnotationWrapper):
+class LongAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_LongAnnotationI class wrapper extends AnnotationWrapper.
     """
+
     OMERO_TYPE = LongAnnotationI
 
     @classmethod
@@ -5643,9 +6074,11 @@ class LongAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from LongAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from LongAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5668,15 +6101,17 @@ class LongAnnotationWrapper (AnnotationWrapper):
 
         self._obj.longValue = rlong(val)
 
+
 AnnotationWrapper._register(LongAnnotationWrapper)
 
 from omero_model_DoubleAnnotationI import DoubleAnnotationI
 
 
-class DoubleAnnotationWrapper (AnnotationWrapper):
+class DoubleAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_DoubleAnnotationI class wrapper extends AnnotationWrapper.
     """
+
     OMERO_TYPE = DoubleAnnotationI
 
     @classmethod
@@ -5690,9 +6125,11 @@ class DoubleAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from DoubleAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from DoubleAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5714,17 +6151,19 @@ class DoubleAnnotationWrapper (AnnotationWrapper):
 
         self._obj.doubleValue = rdouble(val)
 
+
 AnnotationWrapper._register(DoubleAnnotationWrapper)
 
 from omero_model_TermAnnotationI import TermAnnotationI
 
 
-class TermAnnotationWrapper (AnnotationWrapper):
+class TermAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_TermAnnotationI class wrapper extends AnnotationWrapper.
 
     only in 4.2+
     """
+
     OMERO_TYPE = TermAnnotationI
 
     @classmethod
@@ -5738,9 +6177,11 @@ class TermAnnotationWrapper (AnnotationWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from TermAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
+        query = (
+            "select obj from TermAnnotation obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getValue(self):
@@ -5763,16 +6204,19 @@ class TermAnnotationWrapper (AnnotationWrapper):
 
         self._obj.termValue = rstring(val)
 
+
 AnnotationWrapper._register(TermAnnotationWrapper)
 
 from omero_model_XmlAnnotationI import XmlAnnotationI
 
 
-class XmlAnnotationWrapper (CommentAnnotationWrapper):
+class XmlAnnotationWrapper(CommentAnnotationWrapper):
     """
     omero_model_XmlAnnotationI class wrapper extends CommentAnnotationWrapper.
     """
+
     OMERO_TYPE = XmlAnnotationI
+
 
 AnnotationWrapper._register(XmlAnnotationWrapper)
 
@@ -5780,10 +6224,11 @@ AnnotationWrapper._register(XmlAnnotationWrapper)
 from omero_model_MapAnnotationI import MapAnnotationI
 
 
-class MapAnnotationWrapper (AnnotationWrapper):
+class MapAnnotationWrapper(AnnotationWrapper):
     """
     omero_model_MapAnnotationI class wrapper.
     """
+
     OMERO_TYPE = MapAnnotationI
 
     def getValue(self):
@@ -5809,16 +6254,18 @@ class MapAnnotationWrapper (AnnotationWrapper):
         data = [omero.model.NamedValue(d[0], d[1]) for d in val]
         self._obj.setMapValue(data)
 
+
 AnnotationWrapper._register(MapAnnotationWrapper)
 
 
-class _RoiWrapper (BlitzObjectWrapper):
+class _RoiWrapper(BlitzObjectWrapper):
     """
     omero_model_ExperimenterI class wrapper extends BlitzObjectWrapper.
     """
-    OMERO_CLASS = 'Roi'
+
+    OMERO_CLASS = "Roi"
     # TODO: test listChildren() to use ShapeWrapper? or remove?
-    CHILD_WRAPPER_CLASS = 'ShapeWrapper'
+    CHILD_WRAPPER_CLASS = "ShapeWrapper"
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -5831,15 +6278,14 @@ class _RoiWrapper (BlitzObjectWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _RoiWrapper, cls)._getQueryString(opts)
+        query, clauses, params = super(_RoiWrapper, cls)._getQueryString(opts)
         if opts is None:
             opts = {}
-        if opts.get('load_shapes'):
-            query += ' left outer join fetch obj.shapes'
-        if 'image' in opts:
-            clauses.append('obj.image.id = :image_id')
-            params.add('image_id', rlong(opts['image']))
+        if opts.get("load_shapes"):
+            query += " left outer join fetch obj.shapes"
+        if "image" in opts:
+            clauses.append("obj.image.id = :image_id")
+            params.add("image_id", rlong(opts["image"]))
         return (query, clauses, params)
 
     def getImage(self):
@@ -5853,20 +6299,22 @@ class _RoiWrapper (BlitzObjectWrapper):
         if self._obj.image is not None:
             return ImageWrapper(self._conn, self._obj.image)
 
+
 RoiWrapper = _RoiWrapper
 
 
-class _ShapeWrapper (BlitzObjectWrapper):
+class _ShapeWrapper(BlitzObjectWrapper):
     """
     omero_model_ShapeI class wrapper extends BlitzObjectWrapper.
     """
-    OMERO_CLASS = 'Shape'
+
+    OMERO_CLASS = "Shape"
+
 
 ShapeWrapper = _ShapeWrapper
 
 
-class _EnumerationWrapper (BlitzObjectWrapper):
-
+class _EnumerationWrapper(BlitzObjectWrapper):
     def getType(self):
         """
         Gets the type (class) of the Enumeration
@@ -5877,29 +6325,45 @@ class _EnumerationWrapper (BlitzObjectWrapper):
 
         return self._obj.__class__
 
+
 EnumerationWrapper = _EnumerationWrapper
 
 
-class _ExperimenterWrapper (BlitzObjectWrapper):
+class _ExperimenterWrapper(BlitzObjectWrapper):
     """
     omero_model_ExperimenterI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Experimenter'
+    OMERO_CLASS = "Experimenter"
     LINK_CLASS = "GroupExperimenterMap"
     CHILD_WRAPPER_CLASS = None
-    PARENT_WRAPPER_CLASS = 'ExperimenterGroupWrapper'
+    PARENT_WRAPPER_CLASS = "ExperimenterGroupWrapper"
 
     def simpleMarshal(self, xtra=None, parents=False):
         rv = super(_ExperimenterWrapper, self).simpleMarshal(
-            xtra=xtra, parents=parents)
-        isAdmin = (len([x for x in self._conn.getAdminService().containedGroups(self.getId()) if x.name.val == 'system']) == 1)
+            xtra=xtra, parents=parents
+        )
+        isAdmin = (
+            len(
+                [
+                    x
+                    for x in self._conn.getAdminService().containedGroups(
+                        self.getId()
+                    )
+                    if x.name.val == "system"
+                ]
+            )
+            == 1
+        )
         rv.update(
-            {'firstName': self.firstName,
-             'middleName': self.middleName,
-             'lastName': self.lastName,
-             'email': self.email,
-             'isAdmin': isAdmin, })
+            {
+                "firstName": self.firstName,
+                "middleName": self.middleName,
+                "lastName": self.lastName,
+                "email": self.email,
+                "isAdmin": isAdmin,
+            }
+        )
         return rv
 
     @classmethod
@@ -5913,9 +6377,11 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select distinct obj from Experimenter as obj "
-                 "left outer join fetch obj.groupExperimenterMap as map "
-                 "left outer join fetch map.parent g")
+        query = (
+            "select distinct obj from Experimenter as obj "
+            "left outer join fetch obj.groupExperimenterMap as map "
+            "left outer join fetch map.parent g"
+        )
         return query, [], omero.sys.ParametersI()
 
     def getRawPreferences(self):
@@ -5929,7 +6395,7 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
 
         self._obj.unloadAnnotationLinks()
         cp = configparser.SafeConfigParser()
-        prefs = self.getAnnotation('TODO.changeme.preferences')
+        prefs = self.getAnnotation("TODO.changeme.preferences")
         if prefs is not None:
             prefs = prefs.getValue()
             if prefs is not None:
@@ -5945,12 +6411,12 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
         :type prefs:        ConfigParser
         """
 
-        ann = self.getAnnotation('TODO.changeme.preferences')
+        ann = self.getAnnotation("TODO.changeme.preferences")
         t = StringIO()
         prefs.write(t)
         if ann is None:
             ann = CommentAnnotationWrapper()
-            ann.setNs('TODO.changeme.preferences')
+            ann.setNs("TODO.changeme.preferences")
             ann.setValue(t.getvalue())
             self.linkAnnotation(ann)
         else:
@@ -5958,7 +6424,7 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
             ann.save()
             self._obj.unloadAnnotationLinks()
 
-    def getPreference(self, key, default='', section=None):
+    def getPreference(self, key, default="", section=None):
         """
         Gets a preference for the experimenter
 
@@ -5969,7 +6435,7 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
         """
 
         if section is None:
-            section = 'DEFAULT'
+            section = "DEFAULT"
         try:
             return self.getRawPreferences().get(section, key)
         except configparser.Error:
@@ -5985,9 +6451,9 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
         """
 
         if section is None:
-            section = 'DEFAULT'
+            section = "DEFAULT"
         prefs = self.getRawPreferences()
-        if prefs.has_section(section) or section == 'DEFAULT':
+        if prefs.has_section(section) or section == "DEFAULT":
             return dict(prefs.items(section))
         return {}
 
@@ -6001,7 +6467,7 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
         """
 
         if section is None:
-            section = 'DEFAULT'
+            section = "DEFAULT"
         prefs = self.getRawPreferences()
         if section not in prefs.sections():
             prefs.add_section(section)
@@ -6042,7 +6508,7 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
             firstName = self.firstName
             middleName = self.middleName
 
-            if middleName is not None and middleName != '':
+            if middleName is not None and middleName != "":
                 name = "%s %s %s" % (firstName, middleName, lastName)
             else:
                 if firstName == "" and lastName == "":
@@ -6124,17 +6590,18 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
         """ Returns True if this Experimenter is the current user """
         return self.getId() == self._conn.getUserId()
 
+
 ExperimenterWrapper = _ExperimenterWrapper
 
 
-class _ExperimenterGroupWrapper (BlitzObjectWrapper):
+class _ExperimenterGroupWrapper(BlitzObjectWrapper):
     """
     omero_model_ExperimenterGroupI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'ExperimenterGroup'
+    OMERO_CLASS = "ExperimenterGroup"
     LINK_CLASS = "GroupExperimenterMap"
-    CHILD_WRAPPER_CLASS = 'ExperimenterWrapper'
+    CHILD_WRAPPER_CLASS = "ExperimenterWrapper"
     PARENT_WRAPPER_CLASS = None
 
     @classmethod
@@ -6148,9 +6615,11 @@ class _ExperimenterGroupWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select distinct obj from ExperimenterGroup as obj "
-                 "left outer join fetch obj.groupExperimenterMap as map "
-                 "left outer join fetch map.child e")
+        query = (
+            "select distinct obj from ExperimenterGroup as obj "
+            "left outer join fetch obj.groupExperimenterMap as map "
+            "left outer join fetch map.child e"
+        )
         return query, [], omero.sys.ParametersI()
 
     def groupSummary(self, exclude_self=False):
@@ -6168,8 +6637,11 @@ class _ExperimenterGroupWrapper (BlitzObjectWrapper):
             userId = self._conn.getUserId()
         colleagues = []
         leaders = []
-        if (not self.isPrivate() or self._conn.isLeader(self.id) or
-                self._conn.isAdmin()):
+        if (
+            not self.isPrivate()
+            or self._conn.isLeader(self.id)
+            or self._conn.isAdmin()
+        ):
             for d in self.copyGroupExperimenterMap():
                 if d is None or d.child.id.val == userId:
                     continue
@@ -6185,10 +6657,11 @@ class _ExperimenterGroupWrapper (BlitzObjectWrapper):
 
         return (leaders, colleagues)
 
+
 ExperimenterGroupWrapper = _ExperimenterGroupWrapper
 
 
-class DetailsWrapper (BlitzObjectWrapper):
+class DetailsWrapper(BlitzObjectWrapper):
     """
     omero_model_DetailsI class wrapper extends BlitzObjectWrapper.
     """
@@ -6207,8 +6680,11 @@ class DetailsWrapper (BlitzObjectWrapper):
         """
         if self._owner is None:
             owner = self._obj.getOwner()
-            self._owner = owner and ExperimenterWrapper(
-                self._conn, self._obj.getOwner()) or None
+            self._owner = (
+                owner
+                and ExperimenterWrapper(self._conn, self._obj.getOwner())
+                or None
+            )
         return self._owner
 
     def getGroup(self):
@@ -6220,20 +6696,23 @@ class DetailsWrapper (BlitzObjectWrapper):
         """
         if self._group is None:
             group = self._obj.getGroup()
-            self._group = group and ExperimenterGroupWrapper(
-                self._conn, self._obj.getGroup()) or None
+            self._group = (
+                group
+                and ExperimenterGroupWrapper(self._conn, self._obj.getGroup())
+                or None
+            )
         return self._group
 
 
-class _DatasetWrapper (BlitzObjectWrapper):
+class _DatasetWrapper(BlitzObjectWrapper):
     """
     omero_model_DatasetI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Dataset'
+    OMERO_CLASS = "Dataset"
     LINK_CLASS = "DatasetImageLink"
-    CHILD_WRAPPER_CLASS = 'ImageWrapper'
-    PARENT_WRAPPER_CLASS = 'ProjectWrapper'
+    CHILD_WRAPPER_CLASS = "ImageWrapper"
+    PARENT_WRAPPER_CLASS = "ProjectWrapper"
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -6247,19 +6726,20 @@ class _DatasetWrapper (BlitzObjectWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _DatasetWrapper, cls)._getQueryString(opts)
+        query, clauses, params = super(_DatasetWrapper, cls)._getQueryString(
+            opts
+        )
         if opts is None:
             opts = {}
-        if 'project' in opts:
-            query += ' join obj.projectLinks projectLinks'
-            clauses.append('projectLinks.parent.id = :pid')
-            params.add('pid', rlong(opts['project']))
-        if 'image' in opts:
-            query += ' join obj.imageLinks imagelinks'
-            clauses.append('imagelinks.child.id = :iid')
-            params.add('iid', rlong(opts['image']))
-        if opts.get('orphaned'):
+        if "project" in opts:
+            query += " join obj.projectLinks projectLinks"
+            clauses.append("projectLinks.parent.id = :pid")
+            params.add("pid", rlong(opts["project"]))
+        if "image" in opts:
+            query += " join obj.imageLinks imagelinks"
+            clauses.append("imagelinks.child.id = :iid")
+            params.add("iid", rlong(opts["image"]))
+        if opts.get("orphaned"):
             clauses.append(
                 """
                 not exists (
@@ -6279,22 +6759,25 @@ class _DatasetWrapper (BlitzObjectWrapper):
         if not self._obj.isImageLinksLoaded():
             links = self._conn.getQueryService().findAllByQuery(
                 "select l from DatasetImageLink as l join fetch l.child as a "
-                "where l.parent.id=%i"
-                % (self._oid), None, self._conn.SERVICE_OPTS)
+                "where l.parent.id=%i" % (self._oid),
+                None,
+                self._conn.SERVICE_OPTS,
+            )
             self._obj._imageLinksLoaded = True
             self._obj._imageLinksSeq = links
+
 
 DatasetWrapper = _DatasetWrapper
 
 
-class _ProjectWrapper (BlitzObjectWrapper):
+class _ProjectWrapper(BlitzObjectWrapper):
     """
     omero_model_ProjectI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Project'
+    OMERO_CLASS = "Project"
     LINK_CLASS = "ProjectDatasetLink"
-    CHILD_WRAPPER_CLASS = 'DatasetWrapper'
+    CHILD_WRAPPER_CLASS = "DatasetWrapper"
     PARENT_WRAPPER_CLASS = None
 
     @classmethod
@@ -6307,27 +6790,29 @@ class _ProjectWrapper (BlitzObjectWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _ProjectWrapper, cls)._getQueryString(opts)
+        query, clauses, params = super(_ProjectWrapper, cls)._getQueryString(
+            opts
+        )
         if opts is None:
             opts = {}
-        if 'dataset' in opts:
-            query += ' join obj.datasetLinks datasetLinks'
-            clauses.append('datasetLinks.child.id = :dataset_id')
-            params.add('dataset_id', rlong(opts['dataset']))
+        if "dataset" in opts:
+            query += " join obj.datasetLinks datasetLinks"
+            clauses.append("datasetLinks.child.id = :dataset_id")
+            params.add("dataset_id", rlong(opts["dataset"]))
         return (query, clauses, params)
+
 
 ProjectWrapper = _ProjectWrapper
 
 
-class _ScreenWrapper (BlitzObjectWrapper):
+class _ScreenWrapper(BlitzObjectWrapper):
     """
     omero_model_ScreenI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Screen'
+    OMERO_CLASS = "Screen"
     LINK_CLASS = "ScreenPlateLink"
-    CHILD_WRAPPER_CLASS = 'PlateWrapper'
+    CHILD_WRAPPER_CLASS = "PlateWrapper"
     PARENT_WRAPPER_CLASS = None
 
     @classmethod
@@ -6340,39 +6825,41 @@ class _ScreenWrapper (BlitzObjectWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _ScreenWrapper, cls)._getQueryString(opts)
+        query, clauses, params = super(_ScreenWrapper, cls)._getQueryString(
+            opts
+        )
         if opts is None:
             opts = {}
-        if 'plate' in opts:
-            query += ' join obj.plateLinks plateLinks'
-            clauses.append('plateLinks.child.id = :plate_id')
-            params.add('plate_id', rlong(opts['plate']))
+        if "plate" in opts:
+            query += " join obj.plateLinks plateLinks"
+            clauses.append("plateLinks.child.id = :plate_id")
+            params.add("plate_id", rlong(opts["plate"]))
         return (query, clauses, params)
+
 
 ScreenWrapper = _ScreenWrapper
 
 
 def _letterGridLabel(i):
     """  Convert number to letter label. E.g. 0 -> 'A' and 100 -> 'CW'  """
-    r = chr(ord('A') + i % 26)
-    i = old_div(i,26)
+    r = chr(ord("A") + i % 26)
+    i = old_div(i, 26)
     while i > 0:
         i -= 1
-        r = chr(ord('A') + i % 26) + r
-        i = old_div(i,26)
+        r = chr(ord("A") + i % 26) + r
+        i = old_div(i, 26)
     return r
 
 
-class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
+class _PlateWrapper(BlitzObjectWrapper, OmeroRestrictionWrapper):
     """
     omero_model_PlateI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Plate'
+    OMERO_CLASS = "Plate"
     LINK_CLASS = None
-    CHILD_WRAPPER_CLASS = 'WellWrapper'
-    PARENT_WRAPPER_CLASS = 'ScreenWrapper'
+    CHILD_WRAPPER_CLASS = "WellWrapper"
+    PARENT_WRAPPER_CLASS = "ScreenWrapper"
 
     def __prepare__(self):
         self.__reset__()
@@ -6388,10 +6875,13 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         p = omero.sys.Parameters()
         p.map = {}
         p.map["pid"] = self._obj.id
-        sql = ("select pa from PlateAcquisition as pa "
-               "join fetch pa.plate as p where p.id=:pid")
-        self._obj._plateAcquisitionsSeq = self._conn.getQueryService(
-            ).findAllByQuery(sql, p, self._conn.SERVICE_OPTS)
+        sql = (
+            "select pa from PlateAcquisition as pa "
+            "join fetch pa.plate as p where p.id=:pid"
+        )
+        self._obj._plateAcquisitionsSeq = self._conn.getQueryService().findAllByQuery(
+            sql, p, self._conn.SERVICE_OPTS
+        )
         self._obj._plateAcquisitionsLoaded = True
 
     def countPlateAcquisitions(self):
@@ -6413,8 +6903,10 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         q = self._conn.getQueryService()
-        sql = "select minIndex(ws), maxIndex(ws) from Well w " \
+        sql = (
+            "select minIndex(ws), maxIndex(ws) from Well w "
             "join w.wellSamples ws where w.plate.id=:oid"
+        )
 
         p = omero.sys.Parameters()
         p.map = {}
@@ -6425,9 +6917,13 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         fields = None
         try:
-            res = [r for r in unwrap(
-                q.projection(
-                    sql, p, self._conn.SERVICE_OPTS))[0] if r is not None]
+            res = [
+                r
+                for r in unwrap(q.projection(sql, p, self._conn.SERVICE_OPTS))[
+                    0
+                ]
+                if r is not None
+            ]
             if len(res) == 2:
                 fields = tuple(res)
         except:
@@ -6447,18 +6943,21 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             params = omero.sys.Parameters()
             params.map = {}
             params.map["oid"] = rlong(self.getId())
-            query = ("select well from Well as well "
-                     "join fetch well.details.creationEvent "
-                     "join fetch well.details.owner "
-                     "join fetch well.details.group "
-                     "left outer join fetch well.plate as pt "
-                     "left outer join fetch well.wellSamples as ws "
-                     "left outer join fetch ws.image as img "
-                     "where well.plate.id = :oid")
+            query = (
+                "select well from Well as well "
+                "join fetch well.details.creationEvent "
+                "join fetch well.details.owner "
+                "join fetch well.details.group "
+                "left outer join fetch well.plate as pt "
+                "left outer join fetch well.wellSamples as ws "
+                "left outer join fetch ws.image as img "
+                "where well.plate.id = :oid"
+            )
 
             self._childcache = {}
             for well in q.findAllByQuery(
-                    query, params, self._conn.SERVICE_OPTS):
+                query, params, self._conn.SERVICE_OPTS
+            ):
                 self._childcache[(well.row.val, well.column.val)] = well
         return list(self._childcache.values())
 
@@ -6472,10 +6971,12 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         gs = self.getGridSize()
         mul = 0
-        while gs['rows'] > (row*(2**mul)) or gs['columns'] > (col*(2**mul)):
+        while gs["rows"] > (row * (2 ** mul)) or gs["columns"] > (
+            col * (2 ** mul)
+        ):
             mul += 1
-        self._gridSize['rows'] = row * (2**mul)
-        self._gridSize['columns'] = col * (2**mul)
+        self._gridSize["rows"] = row * (2 ** mul)
+        self._gridSize["columns"] = col * (2 ** mul)
 
     def getGridSize(self):
         """
@@ -6488,11 +6989,12 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             q = self._conn.getQueryService()
             params = omero.sys.ParametersI()
             params.addId(self.getId())
-            query = "select max(row), max(column) from Well "\
-                    "where plate.id = :id"
+            query = (
+                "select max(row), max(column) from Well " "where plate.id = :id"
+            )
             res = q.projection(query, params, self._conn.SERVICE_OPTS)
             (row, col) = res[0]
-            self._gridSize = {'rows': row.val+1, 'columns': col.val+1}
+            self._gridSize = {"rows": row.val + 1, "columns": col.val + 1}
         return self._gridSize
 
     def getWellGrid(self, index=0):
@@ -6504,10 +7006,11 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         grid = self.getGridSize()
         childw = self._getChildWrapper()
-        rv = [[None]*grid['columns'] for x in range(grid['rows'])]
+        rv = [[None] * grid["columns"] for x in range(grid["rows"])]
         for child in self._listChildren():
             rv[child.row.val][child.column.val] = childw(
-                self._conn, child, index=index)
+                self._conn, child, index=index
+            )
         return rv
 
     def getColumnLabels(self):
@@ -6515,42 +7018,49 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Returns a list of labels for the columns on this plate.
         E.g. [1, 2, 3...] or ['A', 'B', 'C'...] etc
         """
-        if (self.columnNamingConvention and
-                self.columnNamingConvention.lower() == 'letter'):
+        if (
+            self.columnNamingConvention
+            and self.columnNamingConvention.lower() == "letter"
+        ):
             # this should simply be precalculated!
-            return [_letterGridLabel(x)
-                    for x in range(self.getGridSize()['columns'])]
+            return [
+                _letterGridLabel(x)
+                for x in range(self.getGridSize()["columns"])
+            ]
         else:
-            return list(range(1, self.getGridSize()['columns']+1))
+            return list(range(1, self.getGridSize()["columns"] + 1))
 
     def getRowLabels(self):
         """
         Returns a list of labels for the rows on this plate.
         E.g. [1, 2, 3...] or ['A', 'B', 'C'...] etc
         """
-        if (self.rowNamingConvention and
-                self.rowNamingConvention.lower() == 'number'):
-            return list(range(1, self.getGridSize()['rows']+1))
+        if (
+            self.rowNamingConvention
+            and self.rowNamingConvention.lower() == "number"
+        ):
+            return list(range(1, self.getGridSize()["rows"] + 1))
         else:
             # this should simply be precalculated!
-            return [_letterGridLabel(x)
-                    for x in range(self.getGridSize()['rows'])]
+            return [
+                _letterGridLabel(x) for x in range(self.getGridSize()["rows"])
+            ]
 
-#        if self._childcache is None:
-#            q = self._conn.getQueryService()
-#            params = omero.sys.Parameters()
-#            params.map = {}
-#            params.map["oid"] = omero_type(self.getId())
-#            query = "select well from Well as well "\
-#                    "left outer join fetch well.wellSamples as ws " \
-#                    "where well.plate.id = :oid"
-#            children = q.findAllByQuery(query, params)
-#        else:
-#            children = self._listChildren()
-#        f = 0
-#        for child in children:
-#            f = max(len(child._wellSamplesSeq), f)
-#        return f
+    #        if self._childcache is None:
+    #            q = self._conn.getQueryService()
+    #            params = omero.sys.Parameters()
+    #            params.map = {}
+    #            params.map["oid"] = omero_type(self.getId())
+    #            query = "select well from Well as well "\
+    #                    "left outer join fetch well.wellSamples as ws " \
+    #                    "where well.plate.id = :oid"
+    #            children = q.findAllByQuery(query, params)
+    #        else:
+    #            children = self._listChildren()
+    #        f = 0
+    #        for child in children:
+    #            f = max(len(child._wellSamplesSeq), f)
+    #        return f
 
     def exportOmeTiff(self):
         """
@@ -6573,24 +7083,26 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select obj from Plate as obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent "
-                 "left outer join fetch obj.screenLinks spl "
-                 "left outer join fetch spl.parent sc")
+        query = (
+            "select obj from Plate as obj "
+            "join fetch obj.details.owner as owner "
+            "join fetch obj.details.creationEvent "
+            "left outer join fetch obj.screenLinks spl "
+            "left outer join fetch spl.parent sc"
+        )
         # NB: we don't use base _getQueryString.
         clauses = []
         params = omero.sys.ParametersI()
         if opts is None:
             opts = {}
-        if 'screen' in opts:
-            clauses.append('spl.parent.id = :sid')
-            params.add('sid', rlong(opts['screen']))
-        if 'well' in opts:
-            query += ' join obj.wells wells'
-            clauses.append('wells.id = :well_id')
-            params.add('well_id', rlong(opts['well']))
-        if opts.get('orphaned'):
+        if "screen" in opts:
+            clauses.append("spl.parent.id = :sid")
+            params.add("sid", rlong(opts["screen"]))
+        if "well" in opts:
+            query += " join obj.wells wells"
+            clauses.append("wells.id = :well_id")
+            params.add("well_id", rlong(opts["well"]))
+        if opts.get("orphaned"):
             clauses.append(
                 """
                 not exists (
@@ -6601,12 +7113,13 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             )
         return (query, clauses, params)
 
+
 PlateWrapper = _PlateWrapper
 
 
-class _PlateAcquisitionWrapper (BlitzObjectWrapper):
+class _PlateAcquisitionWrapper(BlitzObjectWrapper):
 
-    OMERO_CLASS = 'PlateAcquisition'
+    OMERO_CLASS = "PlateAcquisition"
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -6619,7 +7132,8 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
         :return:            Tuple of string, list, ParametersI
         """
         query, clauses, params = super(
-            _PlateAcquisitionWrapper, cls)._getQueryString(opts)
+            _PlateAcquisitionWrapper, cls
+        )._getQueryString(opts)
         add_plate_filter(clauses, params, opts)
         return (query, clauses, params)
 
@@ -6628,11 +7142,13 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
         if name is None:
             if self.startTime is not None and self.endTime is not None:
                 name = "%s - %s" % (
-                    datetime.fromtimestamp(old_div(self.startTime,1000)),
-                    datetime.fromtimestamp(old_div(self.endTime,1000)))
+                    datetime.fromtimestamp(old_div(self.startTime, 1000)),
+                    datetime.fromtimestamp(old_div(self.endTime, 1000)),
+                )
             else:
                 name = "Run %i" % self.id
         return name
+
     name = property(getName)
 
     def listParents(self, withlinks=False):
@@ -6640,7 +7156,7 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
         Because PlateAcquisitions are direct children of plates, with no links
         in between, a special listParents is needed
         """
-        rv = self._conn.getObject('Plate', self.plate.id.val)
+        rv = self._conn.getObject("Plate", self.plate.id.val)
         if withlinks:
             return [(rv, None)]
         return [rv]
@@ -6648,29 +7164,30 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
     def getStartTime(self):
         """Get the StartTime as a datetime object or None if not set."""
         if self.startTime:
-            return datetime.fromtimestamp(old_div(self.startTime,1000))
+            return datetime.fromtimestamp(old_div(self.startTime, 1000))
 
     def getEndTime(self):
         """Get the EndTime as a datetime object or None if not set."""
         if self.endTime:
-            return datetime.fromtimestamp(old_div(self.endTime,1000))
+            return datetime.fromtimestamp(old_div(self.endTime, 1000))
+
 
 PlateAcquisitionWrapper = _PlateAcquisitionWrapper
 
 
-class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
+class _WellWrapper(BlitzObjectWrapper, OmeroRestrictionWrapper):
     """
     omero_model_WellI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Well'
+    OMERO_CLASS = "Well"
     LINK_CLASS = None
-    CHILD_WRAPPER_CLASS = 'WellSampleWrapper'
-    PARENT_WRAPPER_CLASS = 'PlateWrapper'
+    CHILD_WRAPPER_CLASS = "WellSampleWrapper"
+    PARENT_WRAPPER_CLASS = "PlateWrapper"
 
     def __prepare__(self, **kwargs):
         try:
-            self.index = int(kwargs['index'])
+            self.index = int(kwargs["index"])
         except:
             self.index = 0
         self.__reset__()
@@ -6694,27 +7211,28 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _WellWrapper, cls)._getQueryString(opts)
+        query, clauses, params = super(_WellWrapper, cls)._getQueryString(opts)
         if opts is None:
             opts = {}
         add_plate_filter(clauses, params, opts)
-        load_images = opts.get('load_images')
-        load_pixels = opts.get('load_pixels')
-        load_channels = opts.get('load_channels')
-        if 'plateacquisition' in opts:
-            clauses.append('plateAcquisition.id = :plateAcq')
-            params.add('plateAcq', rlong(opts['plateacquisition']))
+        load_images = opts.get("load_images")
+        load_pixels = opts.get("load_pixels")
+        load_channels = opts.get("load_channels")
+        if "plateacquisition" in opts:
+            clauses.append("plateAcquisition.id = :plateAcq")
+            params.add("plateAcq", rlong(opts["plateacquisition"]))
             load_images = True
-        if 'wellsample_index' in opts:
-            clauses.append('index(wellSamples) = :wellsample_index')
-            params.add('wellsample_index', rint(opts['wellsample_index']))
+        if "wellsample_index" in opts:
+            clauses.append("index(wellSamples) = :wellsample_index")
+            params.add("wellsample_index", rint(opts["wellsample_index"]))
         if load_images or load_pixels or load_channels:
             # NB: Using left outer join, we may get Wells with no Images
-            query += " left outer join fetch obj.wellSamples as wellSamples"\
-                     " left outer join fetch wellSamples.image as image"\
-                     " left outer join fetch wellSamples.plateAcquisition"\
-                     " as plateAcquisition"
+            query += (
+                " left outer join fetch obj.wellSamples as wellSamples"
+                " left outer join fetch wellSamples.image as image"
+                " left outer join fetch wellSamples.plateAcquisition"
+                " as plateAcquisition"
+            )
         if load_pixels or load_channels:
             query += getPixelsQuery("image")
         if load_channels:
@@ -6723,16 +7241,19 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return (query, clauses, params)
 
     def __loadedHotSwap__(self):
-        query = ("select well from Well as well "
-                 "join fetch well.details.creationEvent "
-                 "join fetch well.details.owner "
-                 "join fetch well.details.group "
-                 "left outer join fetch well.wellSamples as ws "
-                 "left outer join fetch ws.image as img "
-                 "where well.id = %d" % self.getId())
+        query = (
+            "select well from Well as well "
+            "join fetch well.details.creationEvent "
+            "join fetch well.details.owner "
+            "join fetch well.details.group "
+            "left outer join fetch well.wellSamples as ws "
+            "left outer join fetch ws.image as img "
+            "where well.id = %d" % self.getId()
+        )
 
         self._obj = self._conn.getQueryService().findByQuery(
-            query, None, self._conn.SERVICE_OPTS)
+            query, None, self._conn.SERVICE_OPTS
+        )
 
     def _listChildren(self, **kwargs):
         if self._childcache is None:
@@ -6748,9 +7269,9 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         simple Marshal of the first image in the Well.
         """
         rv = self.getImage().simpleMarshal(xtra=xtra)
-        rv['wellPos'] = self.getWellPos()
-        rv['plateId'] = self._obj.plate.id.val
-        rv['wellId'] = self.getId()
+        rv["wellPos"] = self.getWellPos()
+        rv["plateId"] = self._obj.plate.id.val
+        rv["wellId"] = self.getId()
         return rv
 
     def getWellPos(self):
@@ -6761,7 +7282,8 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         plate = self.getParent()
         rv = "%s%s" % (
             plate.getRowLabels()[self.row],
-            plate.getColumnLabels()[self.column])
+            plate.getColumnLabels()[self.column],
+        )
         return rv
 
     def listParents(self, withlinks=False):
@@ -6780,16 +7302,19 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     def getScreens(self):
         """ returns the screens that link to plates that link to this well """
         params = omero.sys.Parameters()
-        params.map = {'id': omero_type(self.getId())}
+        params.map = {"id": omero_type(self.getId())}
         query = """select s from Well w
         left outer join w.plate p
         left outer join p.screenLinks spl
         left outer join spl.parent s
         where spl.parent.id=s.id and spl.child.id=p.id and w.plate.id=p.id
         and w.id=:id"""
-        return [omero.gateway.ScreenWrapper(self._conn, x) for x in
-                self._conn.getQueryService().findAllByQuery(
-                    query, params, self._conn.SERVICE_OPTS)]
+        return [
+            omero.gateway.ScreenWrapper(self._conn, x)
+            for x in self._conn.getQueryService().findAllByQuery(
+                query, params, self._conn.SERVICE_OPTS
+            )
+        ]
 
     def isWellSample(self):
         """
@@ -6802,8 +7327,9 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if self.isWellSamplesLoaded():
             childnodes = self.copyWellSamples()
             logger.debug(
-                'listChildren for %s %d: already loaded, %d samples'
-                % (self.OMERO_CLASS, self.getId(), len(childnodes)))
+                "listChildren for %s %d: already loaded, %d samples"
+                % (self.OMERO_CLASS, self.getId(), len(childnodes))
+            )
             if len(childnodes) > 0:
                 return True
         return False
@@ -6864,6 +7390,7 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         return self.getWellSample()
 
+
 #    def loadWellSamples (self):
 #        """
 #        Return a generator yielding child objects
@@ -6893,16 +7420,16 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 WellWrapper = _WellWrapper
 
 
-class _WellSampleWrapper (BlitzObjectWrapper):
+class _WellSampleWrapper(BlitzObjectWrapper):
     """
     omero_model_WellSampleI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'WellSample'
-    CHILD_WRAPPER_CLASS = 'ImageWrapper'
-    PARENT_WRAPPER_CLASS = 'WellWrapper'
-    LINK_CLASS = 'WellSample'
-    LINK_CHILD = 'image'
+    OMERO_CLASS = "WellSample"
+    CHILD_WRAPPER_CLASS = "ImageWrapper"
+    PARENT_WRAPPER_CLASS = "WellWrapper"
+    LINK_CLASS = "WellSample"
+    LINK_CHILD = "image"
 
     @staticmethod
     def LINK_PARENT(link):
@@ -6915,10 +7442,14 @@ class _WellSampleWrapper (BlitzObjectWrapper):
         between, a special listParents is needed
         """
         rv = self._conn.getQueryService().findAllByQuery(
-            ("select w from Well w "
-             "left outer join fetch w.wellSamples as ws "
-             "where ws.id=%d" % self.getId()),
-            None, self._conn.SERVICE_OPTS)
+            (
+                "select w from Well w "
+                "left outer join fetch w.wellSamples as ws "
+                "where ws.id=%d" % self.getId()
+            ),
+            None,
+            self._conn.SERVICE_OPTS,
+        )
         if not len(rv):
             rv = [None]
         # rv = self._conn.getObject('Plate', self.plate.id.val)
@@ -6957,19 +7488,20 @@ class _WellSampleWrapper (BlitzObjectWrapper):
             return None
         return PlateAcquisitionWrapper(self._conn, aquisition)
 
+
 WellSampleWrapper = _WellSampleWrapper
 
 
 # IMAGE #
 
 
-class ColorHolder (object):
+class ColorHolder(object):
     """
     Stores color internally as (R,G,B,A) and allows setting and getting in
     multiple formats
     """
 
-    _color = {'red': 0, 'green': 0, 'blue': 0, 'alpha': 255}
+    _color = {"red": 0, "green": 0, "blue": 0, "alpha": 255}
 
     def __init__(self, colorname=None):
         """
@@ -6980,7 +7512,7 @@ class ColorHolder (object):
         :type colorname:    String
         """
 
-        self._color = {'red': 0, 'green': 0, 'blue': 0, 'alpha': 255}
+        self._color = {"red": 0, "green": 0, "blue": 0, "alpha": 255}
         if colorname and colorname.lower() in list(self._color.keys()):
             self._color[colorname.lower()] = 255
 
@@ -7016,7 +7548,7 @@ class ColorHolder (object):
         :rtype:     int
         """
 
-        return self._color['red']
+        return self._color["red"]
 
     def setRed(self, val):
         """
@@ -7026,7 +7558,7 @@ class ColorHolder (object):
         :type val:  Int
         """
 
-        self._color['red'] = max(min(255, int(val)), 0)
+        self._color["red"] = max(min(255, int(val)), 0)
 
     def getGreen(self):
         """
@@ -7036,7 +7568,7 @@ class ColorHolder (object):
         :rtype:     int
         """
 
-        return self._color['green']
+        return self._color["green"]
 
     def setGreen(self, val):
         """
@@ -7046,7 +7578,7 @@ class ColorHolder (object):
         :type val:  Int
         """
 
-        self._color['green'] = max(min(255, int(val)), 0)
+        self._color["green"] = max(min(255, int(val)), 0)
 
     def getBlue(self):
         """
@@ -7056,7 +7588,7 @@ class ColorHolder (object):
         :rtype:     int
         """
 
-        return self._color['blue']
+        return self._color["blue"]
 
     def setBlue(self, val):
         """
@@ -7066,7 +7598,7 @@ class ColorHolder (object):
         :type val:  Int
         """
 
-        self._color['blue'] = max(min(255, int(val)), 0)
+        self._color["blue"] = max(min(255, int(val)), 0)
 
     def getAlpha(self):
         """
@@ -7076,7 +7608,7 @@ class ColorHolder (object):
         :rtype:     int
         """
 
-        return self._color['alpha']
+        return self._color["alpha"]
 
     def setAlpha(self, val):
         """
@@ -7085,7 +7617,7 @@ class ColorHolder (object):
         :param val: value of alpha.
         """
 
-        self._color['alpha'] = max(min(255, int(val)), 0)
+        self._color["alpha"] = max(min(255, int(val)), 0)
 
     def getHtml(self):
         """
@@ -7106,7 +7638,7 @@ class ColorHolder (object):
         """
 
         c = self._color.copy()
-        c['alpha'] /= 255.0
+        c["alpha"] /= 255.0
         return "rgba(%(red)i,%(green)i,%(blue)i,%(alpha)0.3f)" % (c)
 
     def getRGB(self):
@@ -7117,7 +7649,7 @@ class ColorHolder (object):
         :rtype:     tuple of ints
         """
 
-        return (self._color['red'], self._color['green'], self._color['blue'])
+        return (self._color["red"], self._color["green"], self._color["blue"])
 
     def getInt(self):
         """
@@ -7131,35 +7663,38 @@ class ColorHolder (object):
         g = self.getGreen() << 16
         b = self.getBlue() << 8
         a = self.getAlpha()
-        rgba_int = r+g+b+a
-        if (rgba_int > (2**31-1)):       # convert to signed 32-bit int
-            rgba_int = rgba_int - 2**32
+        rgba_int = r + g + b + a
+        if rgba_int > (2 ** 31 - 1):  # convert to signed 32-bit int
+            rgba_int = rgba_int - 2 ** 32
         return int(rgba_int)
 
 
-class _LogicalChannelWrapper (BlitzObjectWrapper):
+class _LogicalChannelWrapper(BlitzObjectWrapper):
     """
     omero_model_LogicalChannelI class wrapper extends BlitzObjectWrapper.
     Specifies a number of _attrs for the channel metadata.
     """
-    _attrs = ('name',
-              'pinHoleSize',
-              '#illumination',
-              'contrastMethod',
-              'excitationWave',
-              'emissionWave',
-              'fluor',
-              'ndFilter',
-              'otf',
-              'detectorSettings|DetectorSettingsWrapper',
-              'lightSourceSettings|LightSettingsWrapper',
-              'filterSet|FilterSetWrapper',
-              'samplesPerPixel',
-              '#photometricInterpretation',
-              'mode',
-              'pockelCellSetting',
-              '()lightPath|',
-              'version')
+
+    _attrs = (
+        "name",
+        "pinHoleSize",
+        "#illumination",
+        "contrastMethod",
+        "excitationWave",
+        "emissionWave",
+        "fluor",
+        "ndFilter",
+        "otf",
+        "detectorSettings|DetectorSettingsWrapper",
+        "lightSourceSettings|LightSettingsWrapper",
+        "filterSet|FilterSetWrapper",
+        "samplesPerPixel",
+        "#photometricInterpretation",
+        "mode",
+        "pockelCellSetting",
+        "()lightPath|",
+        "version",
+    )
 
     def __loadedHotSwap__(self):
         """ Loads the logical channel using the metadata service """
@@ -7167,8 +7702,11 @@ class _LogicalChannelWrapper (BlitzObjectWrapper):
             ctx = self._conn.SERVICE_OPTS.copy()
             if ctx.getOmeroGroup() is None:
                 ctx.setOmeroGroup(-1)
-            self._obj = self._conn.getMetadataService(
-                ).loadChannelAcquisitionData([self._obj.id.val], ctx)[0]
+            self._obj = self._conn.getMetadataService().loadChannelAcquisitionData(
+                [self._obj.id.val], ctx
+            )[
+                0
+            ]
 
     def getLightPath(self):
         """
@@ -7179,35 +7717,44 @@ class _LogicalChannelWrapper (BlitzObjectWrapper):
         if self._obj.lightPath is not None:
             return LightPathWrapper(self._conn, self._obj.lightPath)
 
+
 LogicalChannelWrapper = _LogicalChannelWrapper
 
 
-class _LightPathWrapper (BlitzObjectWrapper):
+class _LightPathWrapper(BlitzObjectWrapper):
     """
     base Light Source class wrapper, extends BlitzObjectWrapper.
     """
-    _attrs = ('dichroic|DichroicWrapper',
-              '()emissionFilters|',
-              '()excitationFilters|')
 
-    OMERO_CLASS = 'LightPath'
+    _attrs = (
+        "dichroic|DichroicWrapper",
+        "()emissionFilters|",
+        "()excitationFilters|",
+    )
+
+    OMERO_CLASS = "LightPath"
 
     def getExcitationFilters(self):
         """ Returns list of excitation :class:`FilterWrapper`. Ordered
         collections can contain nulls"""
-        return [FilterWrapper(self._conn, link.child)
-                for link in self.copyExcitationFilterLink()
-                if link is not None]
+        return [
+            FilterWrapper(self._conn, link.child)
+            for link in self.copyExcitationFilterLink()
+            if link is not None
+        ]
 
     def getEmissionFilters(self):
         """ Returns list of emission :class:`FilterWrapper` """
-        return [FilterWrapper(self._conn, link.child)
-                for link in self.copyEmissionFilterLink()]
+        return [
+            FilterWrapper(self._conn, link.child)
+            for link in self.copyEmissionFilterLink()
+        ]
+
 
 LightPathWrapper = _LightPathWrapper
 
 
-class _PlaneInfoWrapper (BlitzObjectWrapper):
+class _PlaneInfoWrapper(BlitzObjectWrapper):
     """
     omero_model_PlaneInfo class wrapper extends BlitzObjectWrapper.
     """
@@ -7240,15 +7787,16 @@ class _PlaneInfoWrapper (BlitzObjectWrapper):
         """
         return self._unwrapunits(self._obj.getExposureTime(), units=units)
 
+
 PlaneInfoWrapper = _PlaneInfoWrapper
 
 
-class _PixelsWrapper (BlitzObjectWrapper):
+class _PixelsWrapper(BlitzObjectWrapper):
     """
     omero_model_PixelsI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Pixels'
+    OMERO_CLASS = "Pixels"
 
     def _prepareRawPixelsStore(self):
         """
@@ -7287,10 +7835,12 @@ class _PixelsWrapper (BlitzObjectWrapper):
         params = omero.sys.Parameters()
         params.map = {}
         params.map["pid"] = rlong(self._obj.id)
-        query = "select info from PlaneInfo as info" \
-                " join fetch info.deltaT as dt" \
-                " join fetch info.exposureTime as et" \
-                " where info.pixels.id=:pid"
+        query = (
+            "select info from PlaneInfo as info"
+            " join fetch info.deltaT as dt"
+            " join fetch info.exposureTime as et"
+            " where info.pixels.id=:pid"
+        )
         if theC is not None:
             params.map["theC"] = rint(theC)
             query += " and info.theC=:theC"
@@ -7303,7 +7853,8 @@ class _PixelsWrapper (BlitzObjectWrapper):
         query += " order by info.deltaT"
         queryService = self._conn.getQueryService()
         result = queryService.findAllByQuery(
-            query, params, self._conn.SERVICE_OPTS)
+            query, params, self._conn.SERVICE_OPTS
+        )
         for pi in result:
             yield PlaneInfoWrapper(self._conn, pi)
 
@@ -7343,14 +7894,16 @@ class _PixelsWrapper (BlitzObjectWrapper):
         import numpy
         from struct import unpack
 
-        pixelTypes = {PixelsTypeint8: ['b', numpy.int8],
-                      PixelsTypeuint8: ['B', numpy.uint8],
-                      PixelsTypeint16: ['h', numpy.int16],
-                      PixelsTypeuint16: ['H', numpy.uint16],
-                      PixelsTypeint32: ['i', numpy.int32],
-                      PixelsTypeuint32: ['I', numpy.uint32],
-                      PixelsTypefloat: ['f', numpy.float32],
-                      PixelsTypedouble: ['d', numpy.float64]}
+        pixelTypes = {
+            PixelsTypeint8: ["b", numpy.int8],
+            PixelsTypeuint8: ["B", numpy.uint8],
+            PixelsTypeint16: ["h", numpy.int16],
+            PixelsTypeuint16: ["H", numpy.uint16],
+            PixelsTypeint32: ["i", numpy.int32],
+            PixelsTypeuint32: ["I", numpy.uint32],
+            PixelsTypefloat: ["f", numpy.float32],
+            PixelsTypedouble: ["d", numpy.float64],
+        }
         rawPixelsStore = None
         sizeX = self.sizeX
         sizeY = self.sizeY
@@ -7368,12 +7921,15 @@ class _PixelsWrapper (BlitzObjectWrapper):
                 else:
                     x, y, width, height = tile
                     rawPlane = rawPixelsStore.getTile(
-                        z, c, t, x, y, width, height)
+                        z, c, t, x, y, width, height
+                    )
                     planeY = height
                     planeX = width
                 # +str(sizeX*sizeY)+pythonTypes[pixelType]
-                convertType = '>%d%s' % (
-                    (planeY*planeX), pixelTypes[pixelType][0])
+                convertType = ">%d%s" % (
+                    (planeY * planeX),
+                    pixelTypes[pixelType][0],
+                )
                 if isinstance(rawPlane, bytes):
                     convertedPlane = unpack(convertType, rawPlane)
                 else:
@@ -7385,7 +7941,8 @@ class _PixelsWrapper (BlitzObjectWrapper):
         except Exception as e:
             logger.error(
                 "Failed to getPlane() or getTile() from rawPixelsStore",
-                exc_info=True)
+                exc_info=True,
+            )
             exc = e
         try:
             if rawPixelsStore is not None:
@@ -7407,15 +7964,16 @@ class _PixelsWrapper (BlitzObjectWrapper):
         tileList = list(self.getTiles([(theZ, theC, theT, tile)]))
         return tileList[0]
 
+
 PixelsWrapper = _PixelsWrapper
 
 
-class _FilesetWrapper (BlitzObjectWrapper):
+class _FilesetWrapper(BlitzObjectWrapper):
     """
     omero_model_FilesetI class wrapper extends BlitzObjectWrapper
     """
 
-    OMERO_CLASS = 'Fileset'
+    OMERO_CLASS = "Fileset"
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -7428,10 +7986,12 @@ class _FilesetWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = "select obj from Fileset obj "\
-            "left outer join fetch obj.images as image "\
-            "left outer join fetch obj.usedFiles as usedFile " \
+        query = (
+            "select obj from Fileset obj "
+            "left outer join fetch obj.images as image "
+            "left outer join fetch obj.usedFiles as usedFile "
             "join fetch usedFile.originalFile"
+        )
         return query, [], omero.sys.ParametersI()
 
     def copyImages(self):
@@ -7443,13 +8003,16 @@ class _FilesetWrapper (BlitzObjectWrapper):
         Returns a list of :class:`OriginalFileWrapper` linked to this Fileset
         via Fileset Entries
         """
-        return [OriginalFileWrapper(self._conn, f.originalFile)
-                for f in self._obj.copyUsedFiles()]
+        return [
+            OriginalFileWrapper(self._conn, f.originalFile)
+            for f in self._obj.copyUsedFiles()
+        ]
+
 
 FilesetWrapper = _FilesetWrapper
 
 
-class _ChannelWrapper (BlitzObjectWrapper):
+class _ChannelWrapper(BlitzObjectWrapper):
     """
     omero_model_ChannelI class wrapper extends BlitzObjectWrapper.
     """
@@ -7460,12 +8023,13 @@ class _ChannelWrapper (BlitzObjectWrapper):
     GREEN_MAX = 600
     RED_MIN = 601
     RED_MAX = 700
-    COLOR_MAP = ((BLUE_MIN, BLUE_MAX, ColorHolder('Blue')),
-                 (GREEN_MIN, GREEN_MAX, ColorHolder('Green')),
-                 (RED_MIN, RED_MAX, ColorHolder('Red')),
-                 )
+    COLOR_MAP = (
+        (BLUE_MIN, BLUE_MAX, ColorHolder("Blue")),
+        (GREEN_MIN, GREEN_MAX, ColorHolder("Green")),
+        (RED_MIN, RED_MAX, ColorHolder("Red")),
+    )
 
-    OMERO_CLASS = 'Channel'
+    OMERO_CLASS = "Channel"
 
     def __prepare__(self, idx=-1, re=None, img=None):
         """
@@ -7482,7 +8046,8 @@ class _ChannelWrapper (BlitzObjectWrapper):
         """
 
         self._obj.setPixels(
-            omero.model.PixelsI(self._obj.getPixels().getId(), False))
+            omero.model.PixelsI(self._obj.getPixels().getId(), False)
+        )
         return super(_ChannelWrapper, self).save()
 
     def isActive(self):
@@ -7580,7 +8145,8 @@ class _ChannelWrapper (BlitzObjectWrapper):
         if self._re is None:
             return None
         return ColorHolder.fromRGBA(
-            *self._re.getRGBA(self._idx, self._conn.SERVICE_OPTS))
+            *self._re.getRGBA(self._idx, self._conn.SERVICE_OPTS)
+        )
 
     def getLut(self):
         """
@@ -7609,7 +8175,8 @@ class _ChannelWrapper (BlitzObjectWrapper):
         if self._re is None:
             return None
         return self._re.getChannelWindowStart(
-            self._idx, self._conn.SERVICE_OPTS)
+            self._idx, self._conn.SERVICE_OPTS
+        )
 
     def setWindowStart(self, val):
         self.setWindow(val, self.getWindowEnd())
@@ -7624,15 +8191,15 @@ class _ChannelWrapper (BlitzObjectWrapper):
 
         if self._re is None:
             return None
-        return self._re.getChannelWindowEnd(
-            self._idx, self._conn.SERVICE_OPTS)
+        return self._re.getChannelWindowEnd(self._idx, self._conn.SERVICE_OPTS)
 
     def setWindowEnd(self, val):
         self.setWindow(self.getWindowStart(), val)
 
     def setWindow(self, minval, maxval):
         self._re.setChannelWindow(
-            self._idx, float(minval), float(maxval), self._conn.SERVICE_OPTS)
+            self._idx, float(minval), float(maxval), self._conn.SERVICE_OPTS
+        )
 
     def getWindowMin(self):
         """
@@ -7648,18 +8215,24 @@ class _ChannelWrapper (BlitzObjectWrapper):
                 if self._re is not None:
                     return self._re.getPixelsTypeLowerBound(0)
                 else:
-                    minVals = {PixelsTypeint8: -128,
-                               PixelsTypeuint8: 0,
-                               PixelsTypeint16: -32768,
-                               PixelsTypeuint16: 0,
-                               PixelsTypeint32: -2147483648,
-                               PixelsTypeuint32: 0,
-                               PixelsTypefloat: -2147483648,
-                               PixelsTypedouble: -2147483648}
-                    pixtype = self._obj.getPixels(
-                        ).getPixelsType().getValue().getValue()
+                    minVals = {
+                        PixelsTypeint8: -128,
+                        PixelsTypeuint8: 0,
+                        PixelsTypeint16: -32768,
+                        PixelsTypeuint16: 0,
+                        PixelsTypeint32: -2147483648,
+                        PixelsTypeuint32: 0,
+                        PixelsTypefloat: -2147483648,
+                        PixelsTypedouble: -2147483648,
+                    }
+                    pixtype = (
+                        self._obj.getPixels()
+                        .getPixelsType()
+                        .getValue()
+                        .getValue()
+                    )
                     return minVals[pixtype]
-            except:     # Just in case we don't support pixType above
+            except:  # Just in case we don't support pixType above
                 return None
         return si.getGlobalMin().val
 
@@ -7677,18 +8250,24 @@ class _ChannelWrapper (BlitzObjectWrapper):
                 if self._re is not None:
                     return self._re.getPixelsTypeUpperBound(0)
                 else:
-                    maxVals = {PixelsTypeint8: 127,
-                               PixelsTypeuint8: 255,
-                               PixelsTypeint16: 32767,
-                               PixelsTypeuint16: 65535,
-                               PixelsTypeint32: 2147483647,
-                               PixelsTypeuint32: 4294967295,
-                               PixelsTypefloat: 2147483647,
-                               PixelsTypedouble: 2147483647}
-                    pixtype = self._obj.getPixels(
-                        ).getPixelsType().getValue().getValue()
+                    maxVals = {
+                        PixelsTypeint8: 127,
+                        PixelsTypeuint8: 255,
+                        PixelsTypeint16: 32767,
+                        PixelsTypeuint16: 65535,
+                        PixelsTypeint32: 2147483647,
+                        PixelsTypeuint32: 4294967295,
+                        PixelsTypefloat: 2147483647,
+                        PixelsTypedouble: 2147483647,
+                    }
+                    pixtype = (
+                        self._obj.getPixels()
+                        .getPixelsType()
+                        .getValue()
+                        .getValue()
+                    )
                     return maxVals[pixtype]
-            except:     # Just in case we don't support pixType above
+            except:  # Just in case we don't support pixType above
                 return None
         return si.getGlobalMax().val
 
@@ -7742,10 +8321,11 @@ class _ChannelWrapper (BlitzObjectWrapper):
 
         return self._re.getChannelCurveCoefficient(self._idx)
 
+
 ChannelWrapper = _ChannelWrapper
 
 
-class assert_re (object):
+class assert_re(object):
     """
     Function decorator to make sure that rendering engine is prepared before
     call. Is configurable by various options.
@@ -7777,16 +8357,24 @@ class assert_re (object):
 
         def wrapped(self, *args, **kwargs):
             try:
-                if not self._prepareRenderingEngine() \
-                   and ctx.onPrepareFailureReturnNone:
-                    logger.debug('Preparation of rendering engine failed, '
-                                 'returning None for %r!' % f)
+                if (
+                    not self._prepareRenderingEngine()
+                    and ctx.onPrepareFailureReturnNone
+                ):
+                    logger.debug(
+                        "Preparation of rendering engine failed, "
+                        "returning None for %r!" % f
+                    )
                     return None
             except ctx.ignoreExceptions:
-                logger.debug('Ignoring exception thrown during preparation '
-                             'of rendering engine for %r!' % f, exc_info=True)
+                logger.debug(
+                    "Ignoring exception thrown during preparation "
+                    "of rendering engine for %r!" % f,
+                    exc_info=True,
+                )
                 pass
             return f(self, *args, **kwargs)
+
         return wrapped
 
 
@@ -7806,10 +8394,11 @@ def assert_pixels(func):
         if not self._loadPixels():
             return None
         return func(self, *args, **kwargs)
+
     return wrapped
 
 
-class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
+class _ImageWrapper(BlitzObjectWrapper, OmeroRestrictionWrapper):
     """
     omero_model_ImageI class wrapper extends BlitzObjectWrapper.
     """
@@ -7830,11 +8419,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     _invertedAxis = False
 
     PROJECTIONS = {
-        'normal': -1,
-        'intmax': omero.constants.projection.ProjectionType.MAXIMUMINTENSITY,
-        'intmean': omero.constants.projection.ProjectionType.MEANINTENSITY,
-        'intsum': omero.constants.projection.ProjectionType.SUMINTENSITY,
-        }
+        "normal": -1,
+        "intmax": omero.constants.projection.ProjectionType.MAXIMUMINTENSITY,
+        "intmean": omero.constants.projection.ProjectionType.MEANINTENSITY,
+        "intsum": omero.constants.projection.ProjectionType.SUMINTENSITY,
+    }
 
     PLANEDEF = omero.romio.XY
 
@@ -7852,19 +8441,18 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
         """
-        query, clauses, params = super(
-            _ImageWrapper, cls)._getQueryString(opts)
-        if opts is not None and 'dataset' in opts:
-            query += ' join obj.datasetLinks dlink'
-            clauses.append('dlink.parent.id = :did')
-            params.add('did', rlong(opts['dataset']))
+        query, clauses, params = super(_ImageWrapper, cls)._getQueryString(opts)
+        if opts is not None and "dataset" in opts:
+            query += " join obj.datasetLinks dlink"
+            clauses.append("dlink.parent.id = :did")
+            params.add("did", rlong(opts["dataset"]))
         load_pixels = False
         load_channels = False
         orphaned = False
         if opts is not None:
-            load_pixels = opts.get('load_pixels')
-            load_channels = opts.get('load_channels')
-            orphaned = opts.get('orphaned')
+            load_pixels = opts.get("load_pixels")
+            load_channels = opts.get("load_channels")
+            orphaned = opts.get("orphaned")
         if load_pixels or load_channels:
             # We use 'left outer join', since we still want images if no pixels
             query += getPixelsQuery("obj")
@@ -7903,22 +8491,23 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         q = conn.getQueryService()
-        p = q.find('Pixels', pid, conn.SERVICE_OPTS)
+        p = q.find("Pixels", pid, conn.SERVICE_OPTS)
         if p is None:
             return None
         return ImageWrapper(conn, p.image)
 
-    OMERO_CLASS = 'Image'
+    OMERO_CLASS = "Image"
     LINK_CLASS = None
     CHILD_WRAPPER_CLASS = None
-    PARENT_WRAPPER_CLASS = ['DatasetWrapper', 'WellSampleWrapper']
+    PARENT_WRAPPER_CLASS = ["DatasetWrapper", "WellSampleWrapper"]
     _thumbInProgress = False
 
     def __loadedHotSwap__(self):
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.getDetails().group.id.val)
         self._obj = self._conn.getContainerService().getImages(
-            self.OMERO_CLASS, (self._oid,), None, ctx)[0]
+            self.OMERO_CLASS, (self._oid,), None, ctx
+        )[0]
 
     def getAcquisitionDate(self):
         """
@@ -7931,7 +8520,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         t = unwrap(self._obj.acquisitionDate)
         if t is not None and t > 0:
             try:
-                return datetime.fromtimestamp(old_div(t,1000))
+                return datetime.fromtimestamp(old_div(t, 1000))
             except ValueError:
                 return None
 
@@ -7982,9 +8571,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         rdid = ann and ann.getValue() or None
         if rdid is None:
             return
-        logger.debug('_getRDef: %s, annid=%d' % (str(rdid), ann.getId()))
-        logger.debug('now load render options: %s' %
-                     str(self._loadRenderOptions()))
+        logger.debug("_getRDef: %s, annid=%d" % (str(rdid), ann.getId()))
+        logger.debug(
+            "now load render options: %s" % str(self._loadRenderOptions())
+        )
         self.loadRenderOptions()
         return rdid
 
@@ -8055,12 +8645,12 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             try:
                 self._re = self._prepareRE(rdid=rdid)
             except omero.ValidationException:
-                logger.debug('on _prepareRE()', exc_info=True)
+                logger.debug("on _prepareRE()", exc_info=True)
                 self._closeRE()
         return self._re is not None
 
     def resetRDefs(self):
-        logger.debug('resetRDefs')
+        logger.debug("resetRDefs")
         if self.canAnnotate():
             self._deleteSettings()
             rdefns = self._conn.CONFIG.IMG_RDEFNS
@@ -8068,8 +8658,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             if rdefns:
                 # Use the same group as the image in the context
                 ctx = self._conn.SERVICE_OPTS.copy()
-                self._conn.SERVICE_OPTS.setOmeroGroup(
-                    self.details.group.id.val)
+                self._conn.SERVICE_OPTS.setOmeroGroup(self.details.group.id.val)
                 try:
                     self.removeAnnotations(rdefns)
                 finally:
@@ -8095,29 +8684,36 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         rv = super(_ImageWrapper, self).simpleMarshal(
-            xtra=xtra, parents=parents)
-        rv.update({'author': self.getAuthor(),
-                   'date': time.mktime(self.getDate().timetuple()), })
+            xtra=xtra, parents=parents
+        )
+        rv.update(
+            {
+                "author": self.getAuthor(),
+                "date": time.mktime(self.getDate().timetuple()),
+            }
+        )
         if xtra:
-            if 'thumbUrlPrefix' in xtra:
-                if callable(xtra['thumbUrlPrefix']):
-                    rv['thumb_url'] = xtra['thumbUrlPrefix'](str(self.id))
+            if "thumbUrlPrefix" in xtra:
+                if callable(xtra["thumbUrlPrefix"]):
+                    rv["thumb_url"] = xtra["thumbUrlPrefix"](str(self.id))
                 else:
-                    rv['thumb_url'] = xtra[
-                        'thumbUrlPrefix'] + str(self.id) + '/'
-            if xtra.get('tiled', False):
+                    rv["thumb_url"] = (
+                        xtra["thumbUrlPrefix"] + str(self.id) + "/"
+                    )
+            if xtra.get("tiled", False):
                 # Since we need to calculate sizes, store them too in the
                 # marshaled value
                 maxplanesize = self._conn.getMaxPlaneSize()
-                rv['size'] = {'width': self.getSizeX(),
-                              'height': self.getSizeY(),
-                              }
-                if rv['size']['height'] and rv['size']['width']:
-                    rv['tiled'] = ((rv['size']['height'] *
-                                    rv['size']['width']) >
-                                   (maxplanesize[0] * maxplanesize[1]))
+                rv["size"] = {
+                    "width": self.getSizeX(),
+                    "height": self.getSizeY(),
+                }
+                if rv["size"]["height"] and rv["size"]["width"]:
+                    rv["tiled"] = (
+                        rv["size"]["height"] * rv["size"]["width"]
+                    ) > (maxplanesize[0] * maxplanesize[1])
                 else:
-                    rv['tiled'] = False
+                    rv["tiled"] = False
 
         return rv
 
@@ -8153,9 +8749,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if not name:
             return ""
         l = len(name)
-        if l < length+hist:
+        if l < length + hist:
             return name
-        return "..." + name[l - length:]
+        return "..." + name[l - length :]
 
     def getAuthor(self):
         """
@@ -8168,7 +8764,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         q = self._conn.getQueryService()
         e = q.findByQuery(
             "select e from Experimenter e where e.id = %i"
-            % self._obj.details.owner.id.val, None, self._conn.SERVICE_OPTS)
+            % self._obj.details.owner.id.val,
+            None,
+            self._conn.SERVICE_OPTS,
+        )
         self._author = e.firstName.val + " " + e.lastName.val
         return self._author
 
@@ -8184,16 +8783,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         try:
-            q = ("select p from Image i join i.datasetLinks dl "
-                 "join dl.parent ds join ds.projectLinks pl "
-                 "join pl.parent p where i.id = %i"
-                 % self._obj.id.val)
+            q = (
+                "select p from Image i join i.datasetLinks dl "
+                "join dl.parent ds join ds.projectLinks pl "
+                "join pl.parent p where i.id = %i" % self._obj.id.val
+            )
             query = self._conn.getQueryService()
             prj = query.findAllByQuery(q, None, self._conn.SERVICE_OPTS)
             if prj and len(prj) == 1:
                 return ProjectWrapper(self._conn, prj[0])
         except:  # pragma: no cover
-            logger.debug('on getProject')
+            logger.debug("on getProject")
             logger.debug(traceback.format_exc())
             return None
 
@@ -8209,14 +8809,16 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         params = omero.sys.Parameters()
         params.map = {}
         params.map["oid"] = omero.rtypes.rlong(self.getId())
-        query = ("select well from Well as well "
-                 "join fetch well.details.creationEvent "
-                 "join fetch well.details.owner "
-                 "join fetch well.details.group "
-                 "join fetch well.plate as pt "
-                 "left outer join fetch well.wellSamples as ws "
-                 "left outer join fetch ws.image as img "
-                 "where ws.image.id = :oid")
+        query = (
+            "select well from Well as well "
+            "join fetch well.details.creationEvent "
+            "join fetch well.details.owner "
+            "join fetch well.details.group "
+            "join fetch well.plate as pt "
+            "left outer join fetch well.wellSamples as ws "
+            "left outer join fetch ws.image as img "
+            "where ws.image.id = :oid"
+        )
         q = self._conn.getQueryService()
         for well in q.findAllByQuery(query, params):
             return PlateWrapper(self._conn, well.plate)
@@ -8284,16 +8886,18 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
         has_rendering_settings = tb.setPixelsId(pid, ctx)
-        logger.debug("tb.setPixelsId(%d) = %s " %
-                     (pid, str(has_rendering_settings)))
+        logger.debug(
+            "tb.setPixelsId(%d) = %s " % (pid, str(has_rendering_settings))
+        )
         if rdefId is not None:
             try:
                 tb.setRenderingDefId(rdefId, ctx)
             except omero.ValidationException:
                 # The annotation exists, but not the rendering def?
                 logger.error(
-                    'IMG %d, defrdef == %d but object does not exist?'
-                    % (self.getId(), rdefId))
+                    "IMG %d, defrdef == %d but object does not exist?"
+                    % (self.getId(), rdefId)
+                )
                 rdefId = None
         if rdefId is None:
             if not has_rendering_settings:
@@ -8305,7 +8909,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.ConcurrencyException as ce:
                     logger.info(
                         "ConcurrencyException: resetDefaults() failed "
-                        "in _prepareTB with backOff: %s" % ce.backOff)
+                        "in _prepareTB with backOff: %s" % ce.backOff
+                    )
                     return tb
                 tb.setPixelsId(pid, ctx)
                 try:
@@ -8314,7 +8919,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.ApiUsageException:
                     logger.info(
                         "ApiUsageException: getRenderingDefId() failed "
-                        "in _prepareTB")
+                        "in _prepareTB"
+                    )
                     return tb
                 self._onResetDefaults(rdefId)
         return tb
@@ -8344,8 +8950,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         global_metadata = list()
         series_metadata = list()
 
-        for l, m in ((global_metadata, rsp.globalMetadata),
-                     (series_metadata, rsp.seriesMetadata)):
+        for l, m in (
+            (global_metadata, rsp.globalMetadata),
+            (series_metadata, rsp.seriesMetadata),
+        ):
 
             for k, v in list(m.items()):
                 l.append((k, unwrap(v)))  # was RType!
@@ -8391,12 +8999,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             w, h = size
         img = img.resize((w, h), Image.NEAREST)
         rv = BytesIO()
-        img.save(rv, 'jpeg', quality=70)
+        img.save(rv, "jpeg", quality=70)
         return rv.getvalue()
 
     # @setsessiongroup
-    def getThumbnail(self, size=(64, 64), z=None, t=None, direct=True,
-                     rdefId=None):
+    def getThumbnail(
+        self, size=(64, 64), z=None, t=None, direct=True, rdefId=None
+    ):
         """
         Returns a string holding a rendered JPEG of the thumbnail.
 
@@ -8450,7 +9059,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 #     pos = z,t
                 # else:
                 #     pos = None
-            if self.getProjection() != 'normal':
+            if self.getProjection() != "normal":
                 return self._getProjectedThumbnail(size, pos)
             if len(size) == 1:
                 if pos is None:
@@ -8501,7 +9110,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             if rp.isSigned():
                 return (-(old_div(pmax, 2)), old_div(pmax, 2) - 1)
             else:
-                return (0, pmax-1)
+                return (0, pmax - 1)
         finally:
             rp.close()
 
@@ -8522,19 +9131,24 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         eid = self._conn.getUserId()
         if self._obj.getPrimaryPixels()._thumbnailsLoaded:
-            tvs = [t.version.val
-                   for t in self._obj.getPrimaryPixels().copyThumbnails()
-                   if t.getDetails().owner.id.val == eid]
+            tvs = [
+                t.version.val
+                for t in self._obj.getPrimaryPixels().copyThumbnails()
+                if t.getDetails().owner.id.val == eid
+            ]
         else:
             pid = self.getPixelsId()
             params = omero.sys.ParametersI()
-            params.addLong('pid', pid)
-            params.addLong('ownerId', eid)
-            query = ("select t.version from Thumbnail t "
-                     "where t.pixels.id = :pid "
-                     "and t.details.owner.id = :ownerId")
+            params.addLong("pid", pid)
+            params.addLong("ownerId", eid)
+            query = (
+                "select t.version from Thumbnail t "
+                "where t.pixels.id = :pid "
+                "and t.details.owner.id = :ownerId"
+            )
             tbs = self._conn.getQueryService().projection(
-                query, params, self._conn.SERVICE_OPTS)
+                query, params, self._conn.SERVICE_OPTS
+            )
             tvs = [t[0].val for t in tbs]
         if len(tvs) > 0:
             return max(tvs)
@@ -8555,16 +9169,22 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 if not self._prepareRenderingEngine():
                     return None
             except omero.ConcurrencyException:
-                logger.debug('Ignoring exception thrown during '
-                             '_prepareRenderingEngine '
-                             'for getChannels()', exc_info=True)
+                logger.debug(
+                    "Ignoring exception thrown during "
+                    "_prepareRenderingEngine "
+                    "for getChannels()",
+                    exc_info=True,
+                )
 
             if self._re is not None:
-                return [ChannelWrapper(self._conn, c, idx=n,
-                                       re=self._re, img=self)
-                        for n, c in enumerate(
-                            self._re.getPixels(
-                                self._conn.SERVICE_OPTS).iterateChannels())]
+                return [
+                    ChannelWrapper(self._conn, c, idx=n, re=self._re, img=self)
+                    for n, c in enumerate(
+                        self._re.getPixels(
+                            self._conn.SERVICE_OPTS
+                        ).iterateChannels()
+                    )
+                ]
 
         # If we have silently failed to load rendering engine
         # E.g. ConcurrencyException OR noRE is True,
@@ -8572,12 +9192,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         pid = self.getPixelsId()
         params = omero.sys.Parameters()
         params.map = {"pid": rlong(pid)}
-        query = ("select p from Pixels p join fetch p.channels as c "
-                 "join fetch c.logicalChannel as lc where p.id=:pid")
+        query = (
+            "select p from Pixels p join fetch p.channels as c "
+            "join fetch c.logicalChannel as lc where p.id=:pid"
+        )
         pixels = self._conn.getQueryService().findByQuery(
-            query, params, self._conn.SERVICE_OPTS)
-        return [ChannelWrapper(self._conn, c, idx=n, re=self._re, img=self)
-                for n, c in enumerate(pixels.iterateChannels())]
+            query, params, self._conn.SERVICE_OPTS
+        )
+        return [
+            ChannelWrapper(self._conn, c, idx=n, re=self._re, img=self)
+            for n, c in enumerate(pixels.iterateChannels())
+        ]
 
     def getChannelLabels(self):
         """
@@ -8586,19 +9211,23 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         q = self._conn.getQueryService()
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = "select lc.name, lc.emissionWave.value, index(chan) "\
-                "from Pixels p "\
-                "join p.image as img "\
-                "join p.channels as chan "\
-                "join chan.logicalChannel as lc "\
-                "where img.id = :id order by index(chan)"
+        query = (
+            "select lc.name, lc.emissionWave.value, index(chan) "
+            "from Pixels p "
+            "join p.image as img "
+            "join p.channels as chan "
+            "join chan.logicalChannel as lc "
+            "where img.id = :id order by index(chan)"
+        )
         res = q.projection(query, params, self._conn.SERVICE_OPTS)
         ret = []
         for name, emissionWave, idx in res:
             if name is not None and len(name.val.strip()) > 0:
                 ret.append(name.val)
-            elif emissionWave is not None and\
-                    len(str(emissionWave.val).strip()) > 0:
+            elif (
+                emissionWave is not None
+                and len(str(emissionWave.val).strip()) > 0
+            ):
                 # FIXME: units ignored for wavelength
                 rv = emissionWave.getValue()
                 # Don't show as double if it's really an int
@@ -8622,13 +9251,20 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         rv = {}
         sizeXList = [level.sizeX for level in levels]
         for i, level in enumerate(sizeXList):
-            rv[i] = old_div(float(level),sizeXList[0])
+            rv[i] = old_div(float(level), sizeXList[0])
         return rv
 
     @assert_re()
-    def set_active_channels(self, channels, windows=None, colors=None,
-                            invertMaps=None, reverseMaps=None, noRE=False,
-                            set_inactive=False):
+    def set_active_channels(
+        self,
+        channels,
+        windows=None,
+        colors=None,
+        invertMaps=None,
+        reverseMaps=None,
+        noRE=False,
+        set_inactive=False,
+    ):
         """
         Sets the active channels on the rendering engine. Also sets rendering
         windows and channel colors
@@ -8664,48 +9300,64 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             warnings.warn(
                 "setActiveChannels() reverseMaps parameter"
                 "deprecated in OMERO 5.4.0. Use invertMaps",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
             if invertMaps is None:
                 invertMaps = reverseMaps
         abs_channels = [abs(c) for c in channels]
-        idx = 0     # index of windows/colors args above
+        idx = 0  # index of windows/colors args above
         for c in range(len(self.getChannels(noRE=noRE))):
-            self._re.setActive(c, (c+1) in channels, self._conn.SERVICE_OPTS)
+            self._re.setActive(c, (c + 1) in channels, self._conn.SERVICE_OPTS)
             if set_inactive:
-                update_channel = ((c + 1) in abs_channels)
+                update_channel = (c + 1) in abs_channels
             else:
-                update_channel = ((c + 1) in channels)
+                update_channel = (c + 1) in channels
             if update_channel:
-                if (invertMaps is not None and
-                        invertMaps[idx] is not None):
+                if invertMaps is not None and invertMaps[idx] is not None:
                     self.setReverseIntensity(c, invertMaps[idx])
-                if (windows is not None and
-                        windows[idx][0] is not None and
-                        windows[idx][1] is not None):
+                if (
+                    windows is not None
+                    and windows[idx][0] is not None
+                    and windows[idx][1] is not None
+                ):
                     self._re.setChannelWindow(
-                        c, float(windows[idx][0]), float(windows[idx][1]),
-                        self._conn.SERVICE_OPTS)
+                        c,
+                        float(windows[idx][0]),
+                        float(windows[idx][1]),
+                        self._conn.SERVICE_OPTS,
+                    )
                 if colors is not None and colors[idx]:
-                    if colors[idx].endswith('.lut'):
+                    if colors[idx].endswith(".lut"):
                         self._re.setChannelLookupTable(c, colors[idx])
                     else:
                         rgba = splitHTMLColor(colors[idx])
                         if rgba:
                             self._re.setRGBA(
-                                c, *(rgba + [self._conn.SERVICE_OPTS]))
+                                c, *(rgba + [self._conn.SERVICE_OPTS])
+                            )
                             # disable LUT
                             self._re.setChannelLookupTable(c, None)
-            if (c+1 in abs_channels):
+            if c + 1 in abs_channels:
                 idx += 1
         return True
 
     @assert_re()
-    def setActiveChannels(self, channels, windows=None, colors=None,
-                          invertMaps=None, reverseMaps=None):
-        warnings.warn("setActiveChannels() is deprecated in OMERO 5.4.0."
-                      "Use set_active_channels", DeprecationWarning)
-        return self.set_active_channels(channels, windows, colors,
-                                        invertMaps, reverseMaps, False)
+    def setActiveChannels(
+        self,
+        channels,
+        windows=None,
+        colors=None,
+        invertMaps=None,
+        reverseMaps=None,
+    ):
+        warnings.warn(
+            "setActiveChannels() is deprecated in OMERO 5.4.0."
+            "Use set_active_channels",
+            DeprecationWarning,
+        )
+        return self.set_active_channels(
+            channels, windows, colors, invertMaps, reverseMaps, False
+        )
 
     def getProjections(self):
         """
@@ -8728,7 +9380,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         if self._pr in list(self.PROJECTIONS.keys()):
             return self._pr
-        return 'normal'
+        return "normal"
 
     def setProjection(self, proj):
         """
@@ -8754,7 +9406,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if projStart is not None:
             projStart = max(0, int(projStart))
         if projEnd is not None:
-            projEnd = min(int(projEnd), self.getSizeZ()-1)
+            projEnd = min(int(projEnd), self.getSizeZ() - 1)
         self._prStart = projStart
         self._prEnd = projEnd
 
@@ -8779,16 +9431,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         self._invertedAxis = inverted
 
     LINE_PLOT_DTYPES = {
-        (4, True, True): 'f',  # signed float
-        (2, False, False): 'H',  # unsigned short
-        (2, False, True): 'h',  # signed short
-        (1, False, False): 'B',  # unsigned char
-        (1, False, True): 'b',  # signed char
-        }
+        (4, True, True): "f",  # signed float
+        (2, False, False): "H",  # unsigned short
+        (2, False, True): "h",  # signed short
+        (1, False, False): "B",  # unsigned char
+        (1, False, True): "b",  # signed char
+    }
 
     @assert_pixels
-    def getHistogram(self, channels, binCount, globalRange=True,
-                     theZ=0, theT=0):
+    def getHistogram(
+        self, channels, binCount, globalRange=True, theZ=0, theT=0
+    ):
         """
         Get pixel intensity histogram of a single plane for specified channels.
 
@@ -8839,9 +9492,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             return None
         axis = axis.lower()[:1]
         if channels is None:
-            channels = [x._idx for x in [x for x in self.getChannels() if x.isActive()]]
+            channels = [
+                x._idx for x in [x for x in self.getChannels() if x.isActive()]
+            ]
         if range is None:
-            range = axis == 'h' and self.getSizeY() or self.getSizeX()
+            range = axis == "h" and self.getSizeY() or self.getSizeX()
         if not isinstance(channels, (TupleType, ListType)):
             channels = (channels,)
         chw = [(x.getWindowMin(), x.getWindowMax()) for x in self.getChannels()]
@@ -8853,26 +9508,33 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             for c in channels:
                 bw = rp.getByteWidth()
                 key = self.LINE_PLOT_DTYPES.get(
-                    (bw, rp.isFloat(), rp.isSigned()), None)
+                    (bw, rp.isFloat(), rp.isSigned()), None
+                )
                 if key is None:
                     logger.error(
-                        "Unknown data type: " +
-                        str((bw, rp.isFloat(), rp.isSigned())))
-                plot = array.array(key, (axis == 'h' and
-                                   rp.getRow(pos, z, c, t) or
-                                   rp.getCol(pos, z, c, t)))
+                        "Unknown data type: "
+                        + str((bw, rp.isFloat(), rp.isSigned()))
+                    )
+                plot = array.array(
+                    key,
+                    (
+                        axis == "h"
+                        and rp.getRow(pos, z, c, t)
+                        or rp.getCol(pos, z, c, t)
+                    ),
+                )
                 plot.byteswap()  # TODO: Assuming ours is a little endian
                 # system now move data into the windowMin..windowMax range
                 offset = -chw[c][0]
                 if offset != 0:
-                    plot = [x+offset for x in plot]
+                    plot = [x + offset for x in plot]
                 try:
-                    normalize = 1.0/chw[c][1]*(range-1)
+                    normalize = 1.0 / chw[c][1] * (range - 1)
                 except ZeroDivisionError:
                     # This channel has zero sized window, no plot here
                     continue
                 if normalize != 1.0:
-                    plot = [x*normalize for x in plot]
+                    plot = [x * normalize for x in plot]
                 if isinstance(plot, array.array):
                     plot = plot.tolist()
                 rv.append(plot)
@@ -8893,7 +9555,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :return: rv         List of lists (one per channel)
         """
 
-        return self.getPixelLine(z, t, y, 'h', channels, range)
+        return self.getPixelLine(z, t, y, "h", channels, range)
 
     def getCol(self, z, t, x, channels=None, range=None):
         """
@@ -8908,7 +9570,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :return: rv         List of lists (one per channel)
         """
 
-        return self.getPixelLine(z, t, x, 'v', channels, range)
+        return self.getPixelLine(z, t, x, "v", channels, range)
 
     def getRenderingModels(self):
         """
@@ -8919,7 +9581,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         if not len(self._rm):
-            for m in self._conn.getEnumerationEntries('RenderingModel'):
+            for m in self._conn.getEnumerationEntries("RenderingModel"):
                 self._rm[m.value] = m
         return list(self._rm.values())
 
@@ -8941,7 +9603,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         rm = self.getRenderingModels()
-        self._re.setModel(self._rm.get('greyscale', rm[0])._obj)
+        self._re.setModel(self._rm.get("greyscale", rm[0])._obj)
 
     @assert_re()
     def setColorRenderingModel(self):
@@ -8950,7 +9612,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         rm = self.getRenderingModels()
-        self._re.setModel(self._rm.get('rgb', rm[0])._obj)
+        self._re.setModel(self._rm.get("rgb", rm[0])._obj)
 
     def isGreyscaleRenderingModel(self):
         """
@@ -8959,13 +9621,14 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :return:    isGreyscale
         :rtype:     Boolean
         """
-        return self.getRenderingModel().value.lower() == 'greyscale'
+        return self.getRenderingModel().value.lower() == "greyscale"
 
     @assert_re()
     def setReverseIntensity(self, channelIndex, reverse=True):
         """Deprecated in 5.4.0. Use setChannelInverted()."""
-        warnings.warn("Deprecated in 5.4.0. Use setChannelInverted()",
-                      DeprecationWarning)
+        warnings.warn(
+            "Deprecated in 5.4.0. Use setChannelInverted()", DeprecationWarning
+        )
         self.setChannelInverted(channelIndex, reverse)
 
     @assert_re()
@@ -8994,7 +9657,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     Dict
         """
         if not len(self._qf):
-            for f in self._conn.getEnumerationEntries('Family'):
+            for f in self._conn.getEnumerationEntries("Family"):
                 self._qf[f.value] = f
         return self._qf
 
@@ -9025,8 +9688,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         for i, m in enumerate(maps):
             if isinstance(m, dict):
-                family = m.get('family', None)
-                coefficient = m.get('coefficient', 1.0)
+                family = m.get("family", None)
+                coefficient = m.get("coefficient", 1.0)
                 self.setQuantizationMap(i, family, coefficient)
 
     @assert_re(ignoreExceptions=(omero.ConcurrencyException))
@@ -9058,45 +9721,51 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             return rv
         pixelsService = self._conn.getPixelsService()
         rdefs = pixelsService.retrieveAllRndSettings(
-            pixelsId, eid, self._conn.SERVICE_OPTS)
+            pixelsId, eid, self._conn.SERVICE_OPTS
+        )
         for rdef in rdefs:
             d = {}
             owner = rdef.getDetails().owner
-            d['id'] = rdef.getId().val
-            d['owner'] = {'id': owner.id.val,
-                          'firstName': owner.getFirstName().val,
-                          'lastName': owner.getLastName().val}
-            d['z'] = rdef.getDefaultZ().val
-            d['t'] = rdef.getDefaultT().val
+            d["id"] = rdef.getId().val
+            d["owner"] = {
+                "id": owner.id.val,
+                "firstName": owner.getFirstName().val,
+                "lastName": owner.getLastName().val,
+            }
+            d["z"] = rdef.getDefaultZ().val
+            d["t"] = rdef.getDefaultT().val
             # greyscale / rgb
-            d['model'] = rdef.getModel().getValue().val
+            d["model"] = rdef.getModel().getValue().val
             waves = rdef.iterateWaveRendering()
-            d['c'] = []
+            d["c"] = []
             for w in waves:
                 reverse = False
                 for c in w.copySpatialDomainEnhancement():
                     if isinstance(c, omero.model.ReverseIntensityContext):
                         reverse = True
                 color = ColorHolder.fromRGBA(
-                    w.getRed().val, w.getGreen().val, w.getBlue().val, 255)
+                    w.getRed().val, w.getGreen().val, w.getBlue().val, 255
+                )
                 r = {
-                    'active': w.getActive().val,
-                    'start': w.getInputStart().val,
-                    'end': w.getInputEnd().val,
-                    'color': color.getHtml(),
+                    "active": w.getActive().val,
+                    "start": w.getInputStart().val,
+                    "end": w.getInputEnd().val,
+                    "color": color.getHtml(),
                     # 'reverseIntensity' is deprecated. Use 'inverted'
-                    'inverted': reverse,
-                    'reverseIntensity': reverse,
-                    'family': unwrap(w.getFamily().getValue()),
-                    'coefficient': unwrap(w.getCoefficient()),
-                    'rgb': {'red': w.getRed().val,
-                            'green': w.getGreen().val,
-                            'blue': w.getBlue().val}
-                    }
+                    "inverted": reverse,
+                    "reverseIntensity": reverse,
+                    "family": unwrap(w.getFamily().getValue()),
+                    "coefficient": unwrap(w.getCoefficient()),
+                    "rgb": {
+                        "red": w.getRed().val,
+                        "green": w.getGreen().val,
+                        "blue": w.getBlue().val,
+                    },
+                }
                 lut = unwrap(w.getLookupTable())
                 if lut is not None and len(lut) > 0:
-                    r['lut'] = lut
-                d['c'].append(r)
+                    r["lut"] = lut
+                d["c"].append(r)
             rv.append(d)
         return rv
 
@@ -9132,7 +9801,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
             jpeg_data = self.renderJpegRegion(
-                z, t, x, y, width, height, level=0)
+                z, t, x, y, width, height, level=0
+            )
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -9154,8 +9824,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             re.close()
 
     @assert_re()
-    def renderJpegRegion(self, z, t, x, y, width, height, level=None,
-                         compression=0.9):
+    def renderJpegRegion(
+        self, z, t, x, y, width, height, level=None, compression=0.9
+    ):
         """
         Return the data from rendering a region of an image plane.
         NB. Projection not supported by the API currently.
@@ -9193,7 +9864,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             rv = self._re.renderCompressed(self._pd, self._conn.SERVICE_OPTS)
             return rv
         except (omero.ApiUsageException, omero.InternalException):
-            logger.debug('On renderJpegRegion', exc_info=True)
+            logger.debug("On renderJpegRegion", exc_info=True)
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
             # Make sure renderCompressed isn't called again on this re,
@@ -9244,21 +9915,28 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     return self.renderJpeg(z, t, None)
             projection = self.PROJECTIONS.get(self._pr, -1)
             if not isinstance(
-                    projection, omero.constants.projection.ProjectionType):
+                projection, omero.constants.projection.ProjectionType
+            ):
                 rv = self._re.renderCompressed(
-                    self._pd, self._conn.SERVICE_OPTS)
+                    self._pd, self._conn.SERVICE_OPTS
+                )
             else:
-                prStart, prEnd = 0, self.getSizeZ()-1
+                prStart, prEnd = 0, self.getSizeZ() - 1
                 if self._prStart is not None:
                     prStart = self._prStart
                 if self._prEnd is not None:
                     prEnd = self._prEnd
                 rv = self._re.renderProjectedCompressed(
-                    projection, self._pd.t, 1, prStart, prEnd,
-                    self._conn.SERVICE_OPTS)
+                    projection,
+                    self._pd.t,
+                    1,
+                    prStart,
+                    prEnd,
+                    self._conn.SERVICE_OPTS,
+                )
             return rv
         except omero.InternalException:  # pragma: no cover
-            logger.debug('On renderJpeg')
+            logger.debug("On renderJpeg")
             logger.debug(traceback.format_exc())
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
@@ -9309,17 +9987,19 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         rv = []
-        tokens = [_f for _f in text.split(' ') if _f]
+        tokens = [_f for _f in text.split(" ") if _f]
         while len(tokens) > 1:
             p1 = 0
             p2 = 1
-            while (p2 <= len(tokens) and
-                   font.getsize(' '.join(tokens[p1:p2]))[0] < width):
+            while (
+                p2 <= len(tokens)
+                and font.getsize(" ".join(tokens[p1:p2]))[0] < width
+            ):
                 p2 += 1
-            rv.append(' '.join(tokens[p1:p2-1]))
-            tokens = tokens[p2-1:]
+            rv.append(" ".join(tokens[p1 : p2 - 1]))
+            tokens = tokens[p2 - 1 :]
         if len(tokens):
-            rv.append(' '.join(tokens))
+            rv.append(" ".join(tokens))
         logger.debug(rv)
         return rv
 
@@ -9352,94 +10032,112 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         todel = []
         svc = self._conn.getScriptService()
-        mms = [x for x in svc.getScripts() if x.name.val == 'Make_Movie.py']
+        mms = [x for x in svc.getScripts() if x.name.val == "Make_Movie.py"]
         if not len(mms):
-            logger.error('No Make_Movie.py script found!')
+            logger.error("No Make_Movie.py script found!")
             return None, None
         mms = mms[0]
         params = svc.getParams(mms.id.val)
-        args = ['IDs=%d' % self.getId()]
-        args.append('Do_Link=False')
-        args.append('Z_Start=%d' % zstart)
-        args.append('Z_End=%d' % zend)
-        args.append('T_Start=%d' % tstart)
-        args.append('T_End=%d' % tend)
-        if 'fps' in opts:
-            args.append('FPS=%d' % opts['fps'])
-        if 'format' in opts:
-            if opts['format'] == 'video/mpeg':
-                args.append('Format=MPEG')
-            elif opts['format'] == 'video/wmv':
-                args.append('Format=WMV')
+        args = ["IDs=%d" % self.getId()]
+        args.append("Do_Link=False")
+        args.append("Z_Start=%d" % zstart)
+        args.append("Z_End=%d" % zend)
+        args.append("T_Start=%d" % tstart)
+        args.append("T_End=%d" % tend)
+        if "fps" in opts:
+            args.append("FPS=%d" % opts["fps"])
+        if "format" in opts:
+            if opts["format"] == "video/mpeg":
+                args.append("Format=MPEG")
+            elif opts["format"] == "video/wmv":
+                args.append("Format=WMV")
             else:
-                args.append('Format=Quicktime')
+                args.append("Format=Quicktime")
         rdid = self._getRDef()
         if rdid is not None:
-            args.append('RenderingDef_ID=%d' % rdid)
+            args.append("RenderingDef_ID=%d" % rdid)
 
         # Lets prepare the channel settings
         channels = self.getChannels()
         args.append(
-            'ChannelsExtended=%s'
-            % (','.join(
-                ["%d|%s:%s$%s"
-                 % (x._idx+1,
-                    Decimal(str(x.getWindowStart())),
-                    Decimal(str(x.getWindowEnd())),
-                    x.getColor().getHtml())
-                    for x in channels if x.isActive()])))
+            "ChannelsExtended=%s"
+            % (
+                ",".join(
+                    [
+                        "%d|%s:%s$%s"
+                        % (
+                            x._idx + 1,
+                            Decimal(str(x.getWindowStart())),
+                            Decimal(str(x.getWindowEnd())),
+                            x.getColor().getHtml(),
+                        )
+                        for x in channels
+                        if x.isActive()
+                    ]
+                )
+            )
+        )
 
-        watermark = opts.get('watermark', None)
-        logger.debug('watermark: %s' % watermark)
+        watermark = opts.get("watermark", None)
+        logger.debug("watermark: %s" % watermark)
         if watermark:
             origFile = self._conn.createOriginalFileFromLocalFile(watermark)
-            args.append('Watermark=OriginalFile:%d' % origFile.getId())
+            args.append("Watermark=OriginalFile:%d" % origFile.getId())
             todel.append(origFile.getId())
 
         w, h = self.getSizeX(), self.getSizeY()
-        if 'minsize' in opts:
-            args.append('Min_Width=%d' % opts['minsize'][0])
-            w = max(w, opts['minsize'][0])
-            args.append('Min_Height=%d' % opts['minsize'][1])
-            h = max(h, opts['minsize'][1])
-            args.append('Canvas_Colour=%s' % opts['minsize'][2])
+        if "minsize" in opts:
+            args.append("Min_Width=%d" % opts["minsize"][0])
+            w = max(w, opts["minsize"][0])
+            args.append("Min_Height=%d" % opts["minsize"][1])
+            h = max(h, opts["minsize"][1])
+            args.append("Canvas_Colour=%s" % opts["minsize"][2])
 
         scalebars = (1, 1, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10)
-        scalebar = scalebars[max(min(int(old_div(w, 256))-1, len(scalebars)), 1) - 1]
-        args.append('Scalebar=%d' % scalebar)
+        scalebar = scalebars[
+            max(min(int(old_div(w, 256)) - 1, len(scalebars)), 1) - 1
+        ]
+        args.append("Scalebar=%d" % scalebar)
         fsizes = (8, 8, 12, 18, 24, 32, 32, 40, 48, 56, 56, 64)
-        fsize = fsizes[max(min(int(old_div(w, 256))-1, len(fsizes)), 1) - 1]
-        font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (THISPATH, fsize))
-        slides = opts.get('slides', [])
+        fsize = fsizes[max(min(int(old_div(w, 256)) - 1, len(fsizes)), 1) - 1]
+        font = ImageFont.load("%s/pilfonts/B%0.2d.pil" % (THISPATH, fsize))
+        slides = opts.get("slides", [])
         for slidepos in range(min(2, len(slides))):
             t = slides[slidepos]
             slide = Image.new("RGBA", (w, h))
             for i, line in enumerate(t[1:4]):
-                line = line.decode('utf8').encode('iso8859-1')
+                line = line.decode("utf8").encode("iso8859-1")
                 wwline = self._wordwrap(w, line, font)
                 for j, line in enumerate(wwline):
                     tsize = font.getsize(line)
                     draw = ImageDraw.Draw(slide)
                     if i == 0:
-                        y = 10+j*tsize[1]
+                        y = 10 + j * tsize[1]
                     elif i == 1:
-                        y = old_div(h, 2) - \
-                            ((len(wwline)-j)*tsize[1]) + \
-                            old_div((len(wwline)*tsize[1]),2)
+                        y = (
+                            old_div(h, 2)
+                            - ((len(wwline) - j) * tsize[1])
+                            + old_div((len(wwline) * tsize[1]), 2)
+                        )
                     else:
-                        y = h - (len(wwline) - j)*tsize[1] - 10
-                    draw.text((old_div(w,2)-old_div(tsize[0],2), y), line, font=font)
+                        y = h - (len(wwline) - j) * tsize[1] - 10
+                    draw.text(
+                        (old_div(w, 2) - old_div(tsize[0], 2), y),
+                        line,
+                        font=font,
+                    )
             fp = StringIO()
             slide.save(fp, "JPEG")
             fileSize = len(fp.getvalue())
             origFile = self._conn.createOriginalFileFromFileObj(
-                fp, 'slide', '', fileSize)
+                fp, "slide", "", fileSize
+            )
             if slidepos == 0:
-                args.append('Intro_Slide=OriginalFile:%d' % origFile.getId())
-                args.append('Intro_Duration=%d' % t[0])
+                args.append("Intro_Slide=OriginalFile:%d" % origFile.getId())
+                args.append("Intro_Duration=%d" % t[0])
             else:
-                args.append('Ending_Slide=OriginalFile:%d' % origFile.getId())
-                args.append('Ending_Duration=%d' % t[0])
+                args.append("Ending_Slide=OriginalFile:%d" % origFile.getId())
+                args.append("Ending_Duration=%d" % t[0])
             todel.append(origFile.getId())
 
         m = scripts.parse_inputs(args, params)
@@ -9448,7 +10146,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             proc = svc.runScript(mms.id.val, m, None)
             proc.getJob()
         except omero.ValidationException as ve:
-            logger.error('Bad Parameters:\n%s' % ve)
+            logger.error("Bad Parameters:\n%s" % ve)
             return None, None
 
         # Adding notification to wait on result
@@ -9460,23 +10158,23 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         finally:
             cb.close()
 
-        if 'File_Annotation' not in rv:
-            logger.error('Error in createMovie:')
-            if 'stderr' in rv:
+        if "File_Annotation" not in rv:
+            logger.error("Error in createMovie:")
+            if "stderr" in rv:
                 x = StringIO()
-                self._conn.c.download(ofile=rv['stderr'].val, filehandle=x)
+                self._conn.c.download(ofile=rv["stderr"].val, filehandle=x)
                 logger.error(x.getvalue())
             return None, None
 
-        f = rv['File_Annotation'].val
+        f = rv["File_Annotation"].val
         ofw = OriginalFileWrapper(self._conn, f)
         todel.append(ofw.getId())
-        logger.debug('writing movie on %s' % (outpath,))
-        outfile = file(outpath, 'w')
+        logger.debug("writing movie on %s" % (outpath,))
+        outfile = file(outpath, "w")
         for chunk in ofw.getFileInChunks():
             outfile.write(chunk)
         outfile.close()
-        handle = self._conn.deleteObjects('OriginalFile', todel)
+        handle = self._conn.deleteObjects("OriginalFile", todel)
         try:
             self._conn._waitOnCmd(handle)
         finally:
@@ -9516,7 +10214,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         img = self.renderSplitChannelImage(z, t, compression, border)
         rv = BytesIO()
-        img.save(rv, 'jpeg', quality=int(compression*100))
+        img.save(rv, "jpeg", quality=int(compression * 100))
         return rv.getvalue()
 
     def splitChannelDims(self, border=2):
@@ -9535,28 +10233,33 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         x = sqrt(c)
         y = int(round(x))
         if x > y:
-            x = y+1
+            x = y + 1
         else:
             x = y
-        rv = {'g': {'width': self.getSizeX()*x + border*(x+1),
-                    'height': self.getSizeY()*y+border*(y+1),
-                    'border': border,
-                    'gridx': x,
-                    'gridy': y, }
-              }
+        rv = {
+            "g": {
+                "width": self.getSizeX() * x + border * (x + 1),
+                "height": self.getSizeY() * y + border * (y + 1),
+                "border": border,
+                "gridx": x,
+                "gridy": y,
+            }
+        }
         # Color, one extra image with all channels overlayed
         c += 1
         x = sqrt(c)
         y = int(round(x))
         if x > y:
-            x = y+1
+            x = y + 1
         else:
             x = y
-        rv['c'] = {'width': self.getSizeX()*x + border*(x+1),
-                   'height': self.getSizeY()*y+border*(y+1),
-                   'border': border,
-                   'gridx': x,
-                   'gridy': y, }
+        rv["c"] = {
+            "width": self.getSizeX() * x + border * (x + 1),
+            "height": self.getSizeY() * y + border * (y + 1),
+            "border": border,
+            "gridx": x,
+            "gridy": y,
+        }
         return rv
 
     def _renderSplit_channelLabel(self, channel):
@@ -9575,21 +10278,23 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:         PIL Image
         """
 
-        dims = self.splitChannelDims(
-            border=border)[self.isGreyscaleRenderingModel() and 'g' or 'c']
-        canvas = Image.new('RGB', (dims['width'], dims['height']), '#fff')
+        dims = self.splitChannelDims(border=border)[
+            self.isGreyscaleRenderingModel() and "g" or "c"
+        ]
+        canvas = Image.new("RGB", (dims["width"], dims["height"]), "#fff")
         cmap = [
-            ch.isActive() and i+1 or 0
-            for i, ch in enumerate(self.getChannels())]
+            ch.isActive() and i + 1 or 0
+            for i, ch in enumerate(self.getChannels())
+        ]
         c = self.getSizeC()
         pxc = 0
-        px = dims['border']
-        py = dims['border']
+        px = dims["border"]
+        py = dims["border"]
 
         # Font sizes depends on image width
         w = self.getSizeX()
         if w >= 640:
-            fsize = (int(old_div((w-640),128))*8) + 24
+            fsize = (int(old_div((w - 640), 128)) * 8) + 24
             if fsize > 64:
                 fsize = 64
         elif w >= 512:
@@ -9607,22 +10312,28 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         else:  # pragma: no cover
             fsize = 0
         if fsize > 0:
-            font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (THISPATH, fsize))
+            font = ImageFont.load("%s/pilfonts/B%0.2d.pil" % (THISPATH, fsize))
 
         for i in range(c):
             if cmap[i]:
-                self.setActiveChannels((i+1,))
+                self.setActiveChannels((i + 1,))
                 img = self.renderImage(z, t, compression)
                 if fsize > 0:
                     draw = ImageDraw.ImageDraw(img)
                     draw.text(
                         (2, 2),
-                        "%s" % (self._renderSplit_channelLabel(
-                            self.getChannels()[i])),
-                        font=font, fill="#fff")
+                        "%s"
+                        % (
+                            self._renderSplit_channelLabel(
+                                self.getChannels()[i]
+                            )
+                        ),
+                        font=font,
+                        fill="#fff",
+                    )
                 canvas.paste(img, (px, py))
             pxc += 1
-            if pxc < dims['gridx']:
+            if pxc < dims["gridx"]:
                 px += self.getSizeX() + border
             else:
                 pxc = 0
@@ -9659,7 +10370,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             pal.extend(channel.getColor().getRGB())
 
         # Prepare the PIL classes we'll be using
-        im = Image.new('P', (width, height))
+        im = Image.new("P", (width, height))
         im.putpalette(pal)
         return im, width, height
 
@@ -9685,8 +10396,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         draw = ImageDraw.ImageDraw(im)
         # On your marks, get set... go!
         draw.rectangle(
-            [0, 0, width-1, base], fill=self.LP_TRANSPARENT,
-            outline=self.LP_TRANSPARENT)
+            [0, 0, width - 1, base],
+            fill=self.LP_TRANSPARENT,
+            outline=self.LP_TRANSPARENT,
+        )
         draw.line(((0, y), (width, y)), fill=self.LP_FGCOLOR, width=linewidth)
 
         # Grab row data
@@ -9695,12 +10408,14 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         for r in range(len(rows)):
             chrow = rows[r]
             color = r + self.LP_FGCOLOR + 1
-            last_point = base-chrow[0]
+            last_point = base - chrow[0]
             for i in range(len(chrow)):
                 draw.line(
-                    ((i, last_point), (i, base-chrow[i])), fill=color,
-                    width=linewidth)
-                last_point = base-chrow[i]
+                    ((i, last_point), (i, base - chrow[i])),
+                    fill=color,
+                    width=linewidth,
+                )
+                last_point = base - chrow[i]
         del draw
         out = BytesIO()
         im.save(out, format="gif", transparency=0)
@@ -9726,8 +10441,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         draw = ImageDraw.ImageDraw(im)
         # On your marks, get set... go!
-        draw.rectangle([0, 0, width-1, height-1],
-                       fill=self.LP_TRANSPARENT, outline=self.LP_TRANSPARENT)
+        draw.rectangle(
+            [0, 0, width - 1, height - 1],
+            fill=self.LP_TRANSPARENT,
+            outline=self.LP_TRANSPARENT,
+        )
         draw.line(((x, 0), (x, height)), fill=self.LP_FGCOLOR, width=linewidth)
 
         # Grab col data
@@ -9739,8 +10457,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             last_point = chcol[0]
             for i in range(len(chcol)):
                 draw.line(
-                    ((last_point, i), (chcol[i], i)), fill=color,
-                    width=linewidth)
+                    ((last_point, i), (chcol[i], i)),
+                    fill=color,
+                    width=linewidth,
+                )
                 last_point = chcol[i]
         del draw
         out = BytesIO()
@@ -9810,7 +10530,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     String
         """
         rv = self._obj.getPrimaryPixels().getPixelsType().value
-        return rv is not None and rv.val or 'unknown'
+        return rv is not None and rv.val or "unknown"
 
     @assert_pixels
     def getPixelSizeX(self, units=None):
@@ -9823,7 +10543,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     float or omero.model.LengthI
         """
         return self._unwrapunits(
-            self._obj.getPrimaryPixels().getPhysicalSizeX(), units)
+            self._obj.getPrimaryPixels().getPhysicalSizeX(), units
+        )
 
     @assert_pixels
     def getPixelSizeY(self, units=None):
@@ -9836,7 +10557,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     float or omero.model.LengthI
         """
         return self._unwrapunits(
-            self._obj.getPrimaryPixels().getPhysicalSizeY(), units)
+            self._obj.getPrimaryPixels().getPhysicalSizeY(), units
+        )
 
     @assert_pixels
     def getPixelSizeZ(self, units=None):
@@ -9849,7 +10571,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     float or omero.model.LengthI
         """
         return self._unwrapunits(
-            self._obj.getPrimaryPixels().getPhysicalSizeZ(), units)
+            self._obj.getPrimaryPixels().getPhysicalSizeZ(), units
+        )
 
     @assert_pixels
     def getSizeX(self):
@@ -9954,8 +10677,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         rv = {}
-        rv['p'] = self.getProjection()
-        rv['ia'] = self.isInvertedAxis() and "1" or "0"
+        rv["p"] = self.getProjection()
+        rv["ia"] = self.isInvertedAxis() and "1" or "0"
         return rv
 
     def _loadRenderOptions(self):
@@ -9969,7 +10692,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if ns:
             ann = self.getAnnotation(ns)
             if ann is not None:
-                opts = dict([x.split('=') for x in ann.getValue().split('&')])
+                opts = dict([x.split("=") for x in ann.getValue().split("&")])
                 return opts
         return {}
 
@@ -9981,8 +10704,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :return:    True!    TODO: Always True??
         """
         opts = self._loadRenderOptions()
-        self.setProjection(opts.get('p', None))
-        self.setInvertedAxis(opts.get('ia', "0") == "1")
+        self.setProjection(opts.get("p", None))
+        self.setInvertedAxis(opts.get("ia", "0") == "1")
         return True
 
     @assert_re()
@@ -10003,7 +10726,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             ann = omero.gateway.CommentAnnotationWrapper()
             ann.setNs(ns)
             ann.setValue(
-                '&'.join(['='.join(map(str, x)) for x in list(opts.items())]))
+                "&".join(["=".join(map(str, x)) for x in list(opts.items())])
+            )
             self.linkAnnotation(ann)
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
@@ -10019,7 +10743,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             ann = omero.gateway.CommentAnnotationWrapper()
             ann.setNs(ns)
             ann.setValue(
-                '&'.join(['='.join(map(str, x)) for x in list(opts.items())]))
+                "&".join(["=".join(map(str, x)) for x in list(opts.items())])
+            )
             self.linkAnnotation(ann)
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
@@ -10034,8 +10759,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         pixels.
         """
         fsInfo = self.getImportedFilesInfo()
-        if not fsInfo['fileset']:
-            return fsInfo['count']
+        if not fsInfo["fileset"]:
+            return fsInfo["count"]
         return 0
 
     def countFilesetFiles(self):
@@ -10045,8 +10770,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         fsInfo = self.getImportedFilesInfo()
-        if fsInfo['fileset']:
-            return fsInfo['count']
+        if fsInfo["fileset"]:
+            return fsInfo["count"]
         return 0
 
     def getImportedFilesInfo(self):
@@ -10059,11 +10784,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if self._importedFilesInfo is None:
             # Check for Filesets first...
             self._importedFilesInfo = self._conn.getFilesetFilesInfo(
-                [self.getId()])
-            if (self._importedFilesInfo['count'] == 0):
+                [self.getId()]
+            )
+            if self._importedFilesInfo["count"] == 0:
                 # If none, check Archived files
                 self._importedFilesInfo = self._conn.getArchivedFilesInfo(
-                    [self.getId()])
+                    [self.getId()]
+                )
         return self._importedFilesInfo
 
     def countImportedImageFiles(self):
@@ -10073,7 +10800,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         This will only be 0 if the image was imported pre-FS
         and original files NOT archived
         """
-        return self.getImportedFilesInfo()['count']
+        return self.getImportedFilesInfo()["count"]
 
     def getArchivedFiles(self):
         """
@@ -10082,7 +10809,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         ** Deprecated ** Use :meth:`getImportedImageFiles`.
         """
         warnings.warn(
-            "Deprecated. Use getImportedImageFiles()", DeprecationWarning)
+            "Deprecated. Use getImportedImageFiles()", DeprecationWarning
+        )
         return self.getImportedImageFiles()
 
     def getImportedImageFiles(self):
@@ -10095,11 +10823,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         # If we have an FS image, return Fileset files.
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = 'select ofile from FilesetEntry as fse '\
-                'join fse.fileset as fileset '\
-                'join fse.originalFile as ofile '\
-                'join fileset.images as image '\
-                'where image.id in (:id)'
+        query = (
+            "select ofile from FilesetEntry as fse "
+            "join fse.fileset as fileset "
+            "join fse.originalFile as ofile "
+            "join fileset.images as image "
+            "where image.id in (:id)"
+        )
         original_files = query_service.findAllByQuery(
             query, params, self._conn.SERVICE_OPTS
         )
@@ -10108,9 +10838,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # Otherwise, return Original Archived Files
             params = omero.sys.ParametersI()
             params.addId(self.getPixelsId())
-            query = 'select ofile from PixelsOriginalFileMap as link '\
-                    'join link.parent as ofile ' \
-                    'where link.child.id = :id'
+            query = (
+                "select ofile from PixelsOriginalFileMap as link "
+                "join link.parent as ofile "
+                "where link.child.id = :id"
+            )
             original_files = query_service.findAllByQuery(
                 query, params, self._conn.SERVICE_OPTS
             )
@@ -10130,36 +10862,38 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         # If we have an FS image, return Fileset files.
         params = omero.sys.ParametersI()
         params.addId(self.getId())
-        query = 'select ofile.path, ofile.name, fse.clientPath '\
-                'from FilesetEntry as fse '\
-                'join fse.fileset as fileset '\
-                'join fse.originalFile as ofile '\
-                'join fileset.images as image '\
-                'where image.id in (:id)'
-        rows = query_service.projection(
-            query, params, self._conn.SERVICE_OPTS
+        query = (
+            "select ofile.path, ofile.name, fse.clientPath "
+            "from FilesetEntry as fse "
+            "join fse.fileset as fileset "
+            "join fse.originalFile as ofile "
+            "join fileset.images as image "
+            "where image.id in (:id)"
         )
+        rows = query_service.projection(query, params, self._conn.SERVICE_OPTS)
         for row in rows:
             path, name, clientPath = row
-            server_paths.append('%s%s' % (unwrap(path), unwrap(name)))
+            server_paths.append("%s%s" % (unwrap(path), unwrap(name)))
             client_paths.append(unwrap(clientPath))
 
         if len(rows) == 0:
             # Otherwise, return Original Archived Files
             params = omero.sys.ParametersI()
             params.addId(self.getPixelsId())
-            query = 'select ofile.path, ofile.name '\
-                    '    from PixelsOriginalFileMap as link '\
-                    'join link.parent as ofile ' \
-                    'where link.child.id = :id'
+            query = (
+                "select ofile.path, ofile.name "
+                "    from PixelsOriginalFileMap as link "
+                "join link.parent as ofile "
+                "where link.child.id = :id"
+            )
             rows = query_service.projection(
                 query, params, self._conn.SERVICE_OPTS
             )
             for row in rows:
                 path, name = row
-                server_paths.append('%s%s' % (unwrap(path), unwrap(name)))
+                server_paths.append("%s%s" % (unwrap(path), unwrap(name)))
 
-        return {'server_paths': server_paths, 'client_paths': client_paths}
+        return {"server_paths": server_paths, "client_paths": client_paths}
 
     def getFileset(self):
         """
@@ -10185,10 +10919,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         ns = omero.constants.namespaces.NSFILETRANSFER
         fsInfo = self.getImportedFilesInfo()
-        if 'annotations' in fsInfo:
-            for a in fsInfo['annotations']:
-                if ns == a['ns']:
-                    return a['value']
+        if "annotations" in fsInfo:
+            for a in fsInfo["annotations"]:
+                if ns == a["ns"]:
+                    return a["value"]
 
     def getROICount(self, shapeType=None, filterByCurrentUser=False):
         """
@@ -10225,14 +10959,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         # for the current user.
         if shapeType is None:
             params = omero.sys.ParametersI()
-            params.addLong('imageId', self.id)
-            query = 'select count(*) from Roi as roi ' \
-                    'where roi.image.id = :imageId'
+            params.addLong("imageId", self.id)
+            query = (
+                "select count(*) from Roi as roi "
+                "where roi.image.id = :imageId"
+            )
             if filterByCurrentUser:
-                query += ' and roi.details.owner.id = :ownerId'
-                params.addLong('ownerId', self._conn.getUserId())
+                query += " and roi.details.owner.id = :ownerId"
+                params.addLong("ownerId", self._conn.getUserId())
             count = self._conn.getQueryService().projection(
-                query, params, self._conn.SERVICE_OPTS)
+                query, params, self._conn.SERVICE_OPTS
+            )
             # Projection returns a two dimensional array of RType wrapped
             # return values so we want the value of row one, column one.
             return count[0][0].getValue()
@@ -10245,16 +10982,19 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         count = sum(1 for roi in result.rois if isValidROI(roi))
         return count
 
+
 ImageWrapper = _ImageWrapper
 
 # INSTRUMENT AND ACQUISITION #
 
 
-class _ImageStageLabelWrapper (BlitzObjectWrapper):
+class _ImageStageLabelWrapper(BlitzObjectWrapper):
     """
     omero_model_StageLabelI class wrapper extends BlitzObjectWrapper.
     """
+
     pass
+
 
 ImageStageLabelWrapper = _ImageStageLabelWrapper
 
@@ -10263,85 +11003,97 @@ class _ImagingEnvironmentWrapper(BlitzObjectWrapper):
     """
     omero_model_ImagingEnvironment class wrapper extends BlitzObjectWrapper.
     """
+
     pass
+
 
 ImagingEnvironmentWrapper = _ImagingEnvironmentWrapper
 
 
-class _ImagingEnviromentWrapper (BlitzObjectWrapper):
+class _ImagingEnviromentWrapper(BlitzObjectWrapper):
     """
     omero_model_ImagingEnvironmentI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('temperature',
-              'airPressure',
-              'humidity',
-              'co2percent',
-              'version')
 
-    OMERO_CLASS = 'ImagingEnvironment'
+    _attrs = ("temperature", "airPressure", "humidity", "co2percent", "version")
+
+    OMERO_CLASS = "ImagingEnvironment"
+
 
 ImagingEnviromentWrapper = _ImagingEnviromentWrapper
 
 
-class _TransmittanceRangeWrapper (BlitzObjectWrapper):
+class _TransmittanceRangeWrapper(BlitzObjectWrapper):
     """
     omero_model_TransmittanceRangeI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('cutIn',
-              'cutOut',
-              'cutInTolerance',
-              'cutOutTolerance',
-              'transmittance',
-              'version')
 
-    OMERO_CLASS = 'TransmittanceRange'
+    _attrs = (
+        "cutIn",
+        "cutOut",
+        "cutInTolerance",
+        "cutOutTolerance",
+        "transmittance",
+        "version",
+    )
+
+    OMERO_CLASS = "TransmittanceRange"
+
 
 TransmittanceRangeWrapper = _TransmittanceRangeWrapper
 
 
-class _DetectorSettingsWrapper (BlitzObjectWrapper):
+class _DetectorSettingsWrapper(BlitzObjectWrapper):
     """
     omero_model_DetectorSettingsI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('voltage',
-              'gain',
-              'offsetValue',
-              'readOutRate',
-              'binning|BinningWrapper',
-              'detector|DetectorWrapper',
-              'version')
 
-    OMERO_CLASS = 'DetectorSettings'
+    _attrs = (
+        "voltage",
+        "gain",
+        "offsetValue",
+        "readOutRate",
+        "binning|BinningWrapper",
+        "detector|DetectorWrapper",
+        "version",
+    )
+
+    OMERO_CLASS = "DetectorSettings"
+
 
 DetectorSettingsWrapper = _DetectorSettingsWrapper
 
 
-class _BinningWrapper (BlitzObjectWrapper):
+class _BinningWrapper(BlitzObjectWrapper):
     """
     omero_model_BinningI class wrapper extends BlitzObjectWrapper.
     """
 
-    OMERO_CLASS = 'Binning'
+    OMERO_CLASS = "Binning"
+
 
 BinningWrapper = _BinningWrapper
 
 
-class _DetectorWrapper (BlitzObjectWrapper):
+class _DetectorWrapper(BlitzObjectWrapper):
     """
     omero_model_DetectorI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'serialNumber',
-              'voltage',
-              'gain',
-              'offsetValue',
-              'zoom',
-              'amplificationGain',
-              '#type;detectorType',
-              'version')
 
-    OMERO_CLASS = 'Detector'
+    _attrs = (
+        "manufacturer",
+        "model",
+        "serialNumber",
+        "voltage",
+        "gain",
+        "offsetValue",
+        "zoom",
+        "amplificationGain",
+        "#type;detectorType",
+        "version",
+    )
+
+    OMERO_CLASS = "Detector"
 
     def getDetectorType(self):
         """
@@ -10358,26 +11110,30 @@ class _DetectorWrapper (BlitzObjectWrapper):
                 self.type = rv._obj
             return rv
 
+
 DetectorWrapper = _DetectorWrapper
 
 
-class _ObjectiveWrapper (BlitzObjectWrapper):
+class _ObjectiveWrapper(BlitzObjectWrapper):
     """
     omero_model_ObjectiveI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'serialNumber',
-              'nominalMagnification',
-              'calibratedMagnification',
-              'lensNA',
-              '#immersion',
-              '#correction',
-              'workingDistance',
-              'iris',
-              'version')
 
-    OMERO_CLASS = 'Objective'
+    _attrs = (
+        "manufacturer",
+        "model",
+        "serialNumber",
+        "nominalMagnification",
+        "calibratedMagnification",
+        "lensNA",
+        "#immersion",
+        "#correction",
+        "workingDistance",
+        "iris",
+        "version",
+    )
+
+    OMERO_CLASS = "Objective"
 
     def getImmersion(self):
         """
@@ -10424,20 +11180,24 @@ class _ObjectiveWrapper (BlitzObjectWrapper):
                 self.iris = rv._obj
             return rv
 
+
 ObjectiveWrapper = _ObjectiveWrapper
 
 
-class _ObjectiveSettingsWrapper (BlitzObjectWrapper):
+class _ObjectiveSettingsWrapper(BlitzObjectWrapper):
     """
     omero_model_ObjectiveSettingsI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('correctionCollar',
-              '#medium',
-              'refractiveIndex',
-              'objective|ObjectiveWrapper',
-              'version')
 
-    OMERO_CLASS = 'ObjectiveSettings'
+    _attrs = (
+        "correctionCollar",
+        "#medium",
+        "refractiveIndex",
+        "objective|ObjectiveWrapper",
+        "version",
+    )
+
+    OMERO_CLASS = "ObjectiveSettings"
 
     def getObjective(self):
         """
@@ -10469,22 +11229,26 @@ class _ObjectiveSettingsWrapper (BlitzObjectWrapper):
                 self.medium = rv._obj
             return rv
 
+
 ObjectiveSettingsWrapper = _ObjectiveSettingsWrapper
 
 
-class _FilterWrapper (BlitzObjectWrapper):
+class _FilterWrapper(BlitzObjectWrapper):
     """
     omero_model_FilterI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'lotNumber',
-              'filterWheel',
-              '#type;filterType',
-              'transmittanceRange|TransmittanceRangeWrapper',
-              'version')
 
-    OMERO_CLASS = 'Filter'
+    _attrs = (
+        "manufacturer",
+        "model",
+        "lotNumber",
+        "filterWheel",
+        "#type;filterType",
+        "transmittanceRange|TransmittanceRangeWrapper",
+        "version",
+    )
+
+    OMERO_CLASS = "Filter"
 
     def getFilterType(self):
         """
@@ -10501,34 +11265,37 @@ class _FilterWrapper (BlitzObjectWrapper):
                 self.type = rv._obj
             return rv
 
+
 FilterWrapper = _FilterWrapper
 
 
-class _DichroicWrapper (BlitzObjectWrapper):
+class _DichroicWrapper(BlitzObjectWrapper):
     """
     omero_model_DichroicI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'lotNumber',
-              'version')
 
-    OMERO_CLASS = 'Dichroic'
+    _attrs = ("manufacturer", "model", "lotNumber", "version")
+
+    OMERO_CLASS = "Dichroic"
+
 
 DichroicWrapper = _DichroicWrapper
 
 
-class _FilterSetWrapper (BlitzObjectWrapper):
+class _FilterSetWrapper(BlitzObjectWrapper):
     """
     omero_model_FilterSetI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'lotNumber',
-              'dichroic|DichroicWrapper',
-              'version')
 
-    OMERO_CLASS = 'FilterSet'
+    _attrs = (
+        "manufacturer",
+        "model",
+        "lotNumber",
+        "dichroic|DichroicWrapper",
+        "version",
+    )
+
+    OMERO_CLASS = "FilterSet"
 
     def copyEmissionFilters(self):
         """ TODO: not implemented """
@@ -10538,69 +11305,83 @@ class _FilterSetWrapper (BlitzObjectWrapper):
         """ TODO: not implemented """
         pass
 
+
 FilterSetWrapper = _FilterSetWrapper
 
 
-class _OTFWrapper (BlitzObjectWrapper):
+class _OTFWrapper(BlitzObjectWrapper):
     """
     omero_model_OTFI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('sizeX',
-              'sizeY',
-              'opticalAxisAveraged'
-              'pixelsType',
-              'path',
-              'filterSet|FilterSetWrapper',
-              'objective|ObjectiveWrapper',
-              'version')
 
-    OMERO_CLASS = 'OTF'
+    _attrs = (
+        "sizeX",
+        "sizeY",
+        "opticalAxisAveraged" "pixelsType",
+        "path",
+        "filterSet|FilterSetWrapper",
+        "objective|ObjectiveWrapper",
+        "version",
+    )
+
+    OMERO_CLASS = "OTF"
+
 
 OTFWrapper = _OTFWrapper
 
 
-class _LightSettingsWrapper (BlitzObjectWrapper):
+class _LightSettingsWrapper(BlitzObjectWrapper):
     """
     base Light Source class wrapper, extends BlitzObjectWrapper.
     """
-    _attrs = ('attenuation',
-              'wavelength',
-              # 'lightSource|LightSourceWrapper',
-              'microbeamManipulation',
-              'version')
 
-    OMERO_CLASS = 'LightSettings'
+    _attrs = (
+        "attenuation",
+        "wavelength",
+        # 'lightSource|LightSourceWrapper',
+        "microbeamManipulation",
+        "version",
+    )
+
+    OMERO_CLASS = "LightSettings"
 
     def getLightSource(self):
         if self._obj.lightSource is None:
             return None
-        if not self._obj.lightSource.isLoaded():    # see #5742
+        if not self._obj.lightSource.isLoaded():  # see #5742
             lid = self._obj.lightSource.id.val
             params = omero.sys.Parameters()
             params.map = {"id": rlong(lid)}
-            query = ("select l from Laser as l left outer join fetch l.type "
-                     "left outer join fetch l.laserMedium "
-                     "left outer join fetch l.pulse as pulse "
-                     "left outer join fetch l.pump as pump "
-                     "left outer join fetch pump.type as pt "
-                     "where l.id = :id")
+            query = (
+                "select l from Laser as l left outer join fetch l.type "
+                "left outer join fetch l.laserMedium "
+                "left outer join fetch l.pulse as pulse "
+                "left outer join fetch l.pump as pump "
+                "left outer join fetch pump.type as pt "
+                "where l.id = :id"
+            )
             self._obj.lightSource = self._conn.getQueryService().findByQuery(
-                query, params, self._conn.SERVICE_OPTS)
+                query, params, self._conn.SERVICE_OPTS
+            )
         return LightSourceWrapper(self._conn, self._obj.lightSource)
+
 
 LightSettingsWrapper = _LightSettingsWrapper
 
 
-class _LightSourceWrapper (BlitzObjectWrapper):
+class _LightSourceWrapper(BlitzObjectWrapper):
     """
     base Light Source class wrapper, extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'power',
-              'serialNumber',
-              '#type;lightSourceType',
-              'version')
+
+    _attrs = (
+        "manufacturer",
+        "model",
+        "power",
+        "serialNumber",
+        "#type;lightSourceType",
+        "version",
+    )
 
     def getLightSourceType(self):
         """
@@ -10616,6 +11397,7 @@ class _LightSourceWrapper (BlitzObjectWrapper):
             if not self.type.loaded:
                 self.type = rv._obj
             return rv
+
 
 # map of light source gateway classes to omero model objects. E.g.
 # omero.model.Arc : 'ArcWrapper'
@@ -10636,46 +11418,49 @@ def LightSourceWrapper(conn, obj, **kwargs):
     return None
 
 
-class _FilamentWrapper (_LightSourceWrapper):
+class _FilamentWrapper(_LightSourceWrapper):
     """
     omero_model_FilamentI class wrapper extends LightSourceWrapper.
     """
 
-    OMERO_CLASS = 'Filament'
+    OMERO_CLASS = "Filament"
+
 
 FilamentWrapper = _FilamentWrapper
-_LightSourceClasses[omero.model.FilamentI] = 'FilamentWrapper'
+_LightSourceClasses[omero.model.FilamentI] = "FilamentWrapper"
 
 
-class _ArcWrapper (_FilamentWrapper):
+class _ArcWrapper(_FilamentWrapper):
     """
     omero_model_ArcI class wrapper extends FilamentWrapper.
     """
 
-    OMERO_CLASS = 'Arc'
+    OMERO_CLASS = "Arc"
+
 
 ArcWrapper = _ArcWrapper
-_LightSourceClasses[omero.model.ArcI] = 'ArcWrapper'
+_LightSourceClasses[omero.model.ArcI] = "ArcWrapper"
 
 
-class _LaserWrapper (_LightSourceWrapper):
+class _LaserWrapper(_LightSourceWrapper):
     """
     omero_model_LaserI class wrapper extends LightSourceWrapper.
     """
 
-    OMERO_CLASS = 'Laser'
+    OMERO_CLASS = "Laser"
 
     def __bstrap__(self):
         super(_LaserWrapper, self).__bstrap__()
         self._attrs += (
-            '#laserMedium',
-            'frequencyMultiplication',
-            'tuneable',
-            'pulse',
-            'wavelength',
-            'pockelCell',
-            'pump',
-            'repetitionRate')
+            "#laserMedium",
+            "frequencyMultiplication",
+            "tuneable",
+            "pulse",
+            "wavelength",
+            "pockelCell",
+            "pump",
+            "repetitionRate",
+        )
 
     def getLaserMedium(self):
         """
@@ -10703,33 +11488,39 @@ class _LaserWrapper (_LightSourceWrapper):
         if rv is not None:
             return LightSourceWrapper(self._conn, rv)
 
+
 LaserWrapper = _LaserWrapper
-_LightSourceClasses[omero.model.LaserI] = 'LaserWrapper'
+_LightSourceClasses[omero.model.LaserI] = "LaserWrapper"
 
 
-class _LightEmittingDiodeWrapper (_LightSourceWrapper):
+class _LightEmittingDiodeWrapper(_LightSourceWrapper):
     """
     omero_model_LightEmittingDiodeI class wrapper extends LightSourceWrapper.
     """
 
-    OMERO_CLASS = 'LightEmittingDiode'
+    OMERO_CLASS = "LightEmittingDiode"
+
 
 LightEmittingDiodeWrapper = _LightEmittingDiodeWrapper
 _LightSourceClasses[
-    omero.model.LightEmittingDiodeI] = 'LightEmittingDiodeWrapper'
+    omero.model.LightEmittingDiodeI
+] = "LightEmittingDiodeWrapper"
 
 
-class _MicroscopeWrapper (BlitzObjectWrapper):
+class _MicroscopeWrapper(BlitzObjectWrapper):
     """
     omero_model_MicroscopeI class wrapper extends BlitzObjectWrapper.
     """
-    _attrs = ('manufacturer',
-              'model',
-              'serialNumber',
-              '#type;microscopeType',
-              'version')
 
-    OMERO_CLASS = 'Microscope'
+    _attrs = (
+        "manufacturer",
+        "model",
+        "serialNumber",
+        "#type;microscopeType",
+        "version",
+    )
+
+    OMERO_CLASS = "Microscope"
 
     def getMicroscopeType(self):
         """
@@ -10746,19 +11537,20 @@ class _MicroscopeWrapper (BlitzObjectWrapper):
                 self.type = rv._obj
             return rv
 
+
 MicroscopeWrapper = _MicroscopeWrapper
 
 
-class _InstrumentWrapper (BlitzObjectWrapper):
+class _InstrumentWrapper(BlitzObjectWrapper):
     """
     omero_model_InstrumentI class wrapper extends BlitzObjectWrapper.
     """
 
     # TODO: wrap version
 
-    _attrs = ('microscope|MicroscopeWrapper',)
+    _attrs = ("microscope|MicroscopeWrapper",)
 
-    OMERO_CLASS = 'Instrument'
+    OMERO_CLASS = "Instrument"
 
     def getMicroscope(self):
         """
@@ -10840,25 +11632,24 @@ class _InstrumentWrapper (BlitzObjectWrapper):
         :rtype:     :class:`LightSourceWrapper` list
         """
 
-        return [LightSourceWrapper(self._conn, x)
-                for x in self._lightSourceSeq]
+        return [LightSourceWrapper(self._conn, x) for x in self._lightSourceSeq]
 
     def simpleMarshal(self):
         if self._obj:
             rv = super(_InstrumentWrapper, self).simpleMarshal(parents=False)
-            rv['detectors'] = [x.simpleMarshal() for x in self.getDetectors()]
-            rv['objectives'] = [x.simpleMarshal()
-                                for x in self.getObjectives()]
-            rv['filters'] = [x.simpleMarshal() for x in self.getFilters()]
-            rv['dichroics'] = [x.simpleMarshal() for x in self.getDichroics()]
-            rv['filterSets'] = [x.simpleMarshal()
-                                for x in self.getFilterSets()]
-            rv['otfs'] = [x.simpleMarshal() for x in self.getOTFs()]
-            rv['lightsources'] = [x.simpleMarshal()
-                                  for x in self.getLightSources()]
+            rv["detectors"] = [x.simpleMarshal() for x in self.getDetectors()]
+            rv["objectives"] = [x.simpleMarshal() for x in self.getObjectives()]
+            rv["filters"] = [x.simpleMarshal() for x in self.getFilters()]
+            rv["dichroics"] = [x.simpleMarshal() for x in self.getDichroics()]
+            rv["filterSets"] = [x.simpleMarshal() for x in self.getFilterSets()]
+            rv["otfs"] = [x.simpleMarshal() for x in self.getOTFs()]
+            rv["lightsources"] = [
+                x.simpleMarshal() for x in self.getLightSources()
+            ]
         else:
             rv = {}
         return rv
+
 
 InstrumentWrapper = _InstrumentWrapper
 
@@ -10869,30 +11660,35 @@ def refreshWrappers():
     """
     this needs to be called by modules that extend the base wrappers
     """
-    KNOWN_WRAPPERS.update({"project": ProjectWrapper,
-                           "dataset": DatasetWrapper,
-                           "image": ImageWrapper,
-                           "screen": ScreenWrapper,
-                           "plate": PlateWrapper,
-                           "plateacquisition": PlateAcquisitionWrapper,
-                           "acquisition": PlateAcquisitionWrapper,
-                           "well": WellWrapper,
-                           "roi": RoiWrapper,
-                           "shape": ShapeWrapper,
-                           "experimenter": ExperimenterWrapper,
-                           "experimentergroup": ExperimenterGroupWrapper,
-                           "originalfile": OriginalFileWrapper,
-                           "fileset": FilesetWrapper,
-                           "commentannotation": CommentAnnotationWrapper,
-                           "tagannotation": TagAnnotationWrapper,
-                           "longannotation": LongAnnotationWrapper,
-                           "booleanannotation": BooleanAnnotationWrapper,
-                           "fileannotation": FileAnnotationWrapper,
-                           "doubleannotation": DoubleAnnotationWrapper,
-                           "termannotation": TermAnnotationWrapper,
-                           "timestampannotation": TimestampAnnotationWrapper,
-                           "mapannotation": MapAnnotationWrapper,
-                           # allows for getObjects("Annotation", ids)
-                           "annotation": AnnotationWrapper._wrap})
+    KNOWN_WRAPPERS.update(
+        {
+            "project": ProjectWrapper,
+            "dataset": DatasetWrapper,
+            "image": ImageWrapper,
+            "screen": ScreenWrapper,
+            "plate": PlateWrapper,
+            "plateacquisition": PlateAcquisitionWrapper,
+            "acquisition": PlateAcquisitionWrapper,
+            "well": WellWrapper,
+            "roi": RoiWrapper,
+            "shape": ShapeWrapper,
+            "experimenter": ExperimenterWrapper,
+            "experimentergroup": ExperimenterGroupWrapper,
+            "originalfile": OriginalFileWrapper,
+            "fileset": FilesetWrapper,
+            "commentannotation": CommentAnnotationWrapper,
+            "tagannotation": TagAnnotationWrapper,
+            "longannotation": LongAnnotationWrapper,
+            "booleanannotation": BooleanAnnotationWrapper,
+            "fileannotation": FileAnnotationWrapper,
+            "doubleannotation": DoubleAnnotationWrapper,
+            "termannotation": TermAnnotationWrapper,
+            "timestampannotation": TimestampAnnotationWrapper,
+            "mapannotation": MapAnnotationWrapper,
+            # allows for getObjects("Annotation", ids)
+            "annotation": AnnotationWrapper._wrap,
+        }
+    )
+
 
 refreshWrappers()

--- a/src/omero/gateway/pytest_fixtures.py
+++ b/src/omero/gateway/pytest_fixtures.py
@@ -15,8 +15,7 @@ from omero.gateway.scripts.testdb_create import TestDBHelper, dbhelpers
 import pytest
 
 
-class GatewayWrapper (TestDBHelper):
-
+class GatewayWrapper(TestDBHelper):
     def __init__(self):
         super(GatewayWrapper, self).__init__()
         self.setUp(skipTestDB=False, skipTestImages=True)
@@ -28,7 +27,7 @@ class GatewayWrapper (TestDBHelper):
         return testimg
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def gatewaywrapper(request):
     """
     Returns a test helper gateway object.
@@ -38,11 +37,12 @@ def gatewaywrapper(request):
     def fin():
         g.tearDown()
         dbhelpers.cleanup()
+
     request.addfinalizer(fin)
     return g
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_generated(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -52,7 +52,7 @@ def author_testimg_generated(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_tiny(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -62,7 +62,7 @@ def author_testimg_tiny(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_tiny2(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -72,7 +72,7 @@ def author_testimg_tiny2(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -82,7 +82,7 @@ def author_testimg(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_bad(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -92,7 +92,7 @@ def author_testimg_bad(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_big(request, gatewaywrapper):
     """
     logs in as Author and returns the test image, creating it first if needed.
@@ -102,7 +102,7 @@ def author_testimg_big(request, gatewaywrapper):
     return rv
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def author_testimg_32float(request, gatewaywrapper):
     """
     logs in as Author and returns the float image, creating it first if needed.

--- a/src/omero/gateway/scripts/testdb_create.py
+++ b/src/omero/gateway/scripts/testdb_create.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
@@ -23,57 +24,67 @@ from omero.rtypes import rstring
 from omero.gateway.scripts import dbhelpers
 
 dbhelpers.USERS = {
-    'user': dbhelpers.UserEntry(
-        'weblitz_test_user', 'foobar', 'User', 'Weblitz'),
-    'author': dbhelpers.UserEntry(
-        'weblitz_test_author', 'foobar', 'Author', 'Weblitz'),
+    "user": dbhelpers.UserEntry(
+        "weblitz_test_user", "foobar", "User", "Weblitz"
+    ),
+    "author": dbhelpers.UserEntry(
+        "weblitz_test_author", "foobar", "Author", "Weblitz"
+    ),
 }
 
 dbhelpers.PROJECTS = {
-    'testpr1': dbhelpers.ProjectEntry('weblitz_test_priv_project', 'author'),
-    'testpr2': dbhelpers.ProjectEntry('weblitz_test_priv_project2', 'author'),
+    "testpr1": dbhelpers.ProjectEntry("weblitz_test_priv_project", "author"),
+    "testpr2": dbhelpers.ProjectEntry("weblitz_test_priv_project2", "author"),
 }
 
 dbhelpers.DATASETS = {
-    'testds1': dbhelpers.DatasetEntry('weblitz_test_priv_dataset', 'testpr1'),
-    'testds2': dbhelpers.DatasetEntry('weblitz_test_priv_dataset2', 'testpr1'),
-    'testds3': dbhelpers.DatasetEntry('weblitz_test_priv_dataset3', 'testpr2'),
+    "testds1": dbhelpers.DatasetEntry("weblitz_test_priv_dataset", "testpr1"),
+    "testds2": dbhelpers.DatasetEntry("weblitz_test_priv_dataset2", "testpr1"),
+    "testds3": dbhelpers.DatasetEntry("weblitz_test_priv_dataset3", "testpr2"),
 }
 
 dbhelpers.IMAGES = {
-    'testimg1': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image', 'CHOBI_d3d.dv', 'testds1'),
-    'testimg2': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image2', 'CHOBI_d3d.dv', 'testds1'),
-    'tinyimg': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_tiny', 'tinyTest.d3d.dv', 'testds1'),
-    'badimg': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_bad', False, 'testds1'),
-    'tinyimg2': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_tiny2', 'tinyTest.d3d.dv', 'testds2'),
-    'tinyimg3': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_tiny3', 'tinyTest.d3d.dv', 'testds3'),
-    'bigimg': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_big', 'big.tiff', 'testds3'),
-    '32float': dbhelpers.ImageEntry(
-        'weblitz_test_priv_image_32float',
-        '32bitfloat&pixelType=float&sizeX=8192&sizeY=8192.fake', 'testds3'),
+    "testimg1": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image", "CHOBI_d3d.dv", "testds1"
+    ),
+    "testimg2": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image2", "CHOBI_d3d.dv", "testds1"
+    ),
+    "tinyimg": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_tiny", "tinyTest.d3d.dv", "testds1"
+    ),
+    "badimg": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_bad", False, "testds1"
+    ),
+    "tinyimg2": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_tiny2", "tinyTest.d3d.dv", "testds2"
+    ),
+    "tinyimg3": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_tiny3", "tinyTest.d3d.dv", "testds3"
+    ),
+    "bigimg": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_big", "big.tiff", "testds3"
+    ),
+    "32float": dbhelpers.ImageEntry(
+        "weblitz_test_priv_image_32float",
+        "32bitfloat&pixelType=float&sizeX=8192&sizeY=8192.fake",
+        "testds3",
+    ),
 }
 
 
 class TestDBHelper(object):
-
     def setUp(self, skipTestDB=False, skipTestImages=True):
         self.tmpfiles = []
         self._has_connected = False
         self._last_login = None
         self.doDisconnect()
-        self.USER = dbhelpers.USERS['user']
-        self.AUTHOR = dbhelpers.USERS['author']
+        self.USER = dbhelpers.USERS["user"]
+        self.AUTHOR = dbhelpers.USERS["author"]
         self.ADMIN = dbhelpers.ROOT
         gateway = omero.client_wrapper()
         try:
-            rp = gateway.getProperty('omero.rootpass')
+            rp = gateway.getProperty("omero.rootpass")
             if rp:
                 dbhelpers.ROOT.passwd = rp
         finally:
@@ -86,17 +97,19 @@ class TestDBHelper(object):
         if not self._has_connected:
             self.gateway.connect()
             self._has_connected = True
-        assert self.gateway.isConnected(), 'Can not connect'
-        assert self.gateway.keepAlive(
-        ), 'Could not send keepAlive to connection'
+        assert self.gateway.isConnected(), "Can not connect"
+        assert (
+            self.gateway.keepAlive()
+        ), "Could not send keepAlive to connection"
         self.gateway.setGroupForSession(
-            self.gateway.getEventContext().memberOfGroups[0])
+            self.gateway.getEventContext().memberOfGroups[0]
+        )
 
     def doDisconnect(self):
         if self._has_connected and self.gateway:
             self.doConnect()
             self.gateway.close()
-            assert not self.gateway.isConnected(), 'Can not disconnect'
+            assert not self.gateway.isConnected(), "Can not disconnect"
         self.gateway = None
         self._has_connected = False
         self._last_login = None
@@ -141,47 +154,54 @@ class TestDBHelper(object):
             raise Exception("Exception on client.closeSession")
 
     def getTestProject(self):
-        return dbhelpers.getProject(self.gateway, 'testpr1')
+        return dbhelpers.getProject(self.gateway, "testpr1")
 
     def getTestProject2(self):
-        return dbhelpers.getProject(self.gateway, 'testpr2')
+        return dbhelpers.getProject(self.gateway, "testpr2")
 
     def getTestDataset(self, project=None):
-        return dbhelpers.getDataset(self.gateway, 'testds1', project)
+        return dbhelpers.getDataset(self.gateway, "testds1", project)
 
     def getTestDataset2(self, project=None):
-        return dbhelpers.getDataset(self.gateway, 'testds2', project)
+        return dbhelpers.getDataset(self.gateway, "testds2", project)
 
     def getTestImage(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'testimg1', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "testimg1", forceds=dataset, autocreate=autocreate
+        )
 
     def getTestImage2(self, dataset=None):
-        return dbhelpers.getImage(self.gateway, 'testimg2', dataset)
+        return dbhelpers.getImage(self.gateway, "testimg2", dataset)
 
     def getBadTestImage(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'badimg', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "badimg", forceds=dataset, autocreate=autocreate
+        )
 
     def getTinyTestImage(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'tinyimg', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "tinyimg", forceds=dataset, autocreate=autocreate
+        )
 
     def getTinyTestImage2(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'tinyimg2', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "tinyimg2", forceds=dataset, autocreate=autocreate
+        )
 
     def getTinyTestImage3(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'tinyimg3', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "tinyimg3", forceds=dataset, autocreate=autocreate
+        )
 
     def getBigTestImage(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, 'bigimg', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "bigimg", forceds=dataset, autocreate=autocreate
+        )
 
     def get32FloatTestImage(self, dataset=None, autocreate=False):
-        return dbhelpers.getImage(self.gateway, '32float', forceds=dataset,
-                                  autocreate=autocreate)
+        return dbhelpers.getImage(
+            self.gateway, "32float", forceds=dataset, autocreate=autocreate
+        )
 
     def prepTestDB(self, onlyUsers=False, skipImages=True):
         dbhelpers.bootstrap(onlyUsers=onlyUsers, skipImages=skipImages)
@@ -242,8 +262,16 @@ class TestDBHelper(object):
 
         return returnVal
 
-    def createTestImage(self, imageName="testImage", dataset=None, sizeX=16,
-                        sizeY=16, sizeZ=1, sizeC=1, sizeT=1):
+    def createTestImage(
+        self,
+        imageName="testImage",
+        dataset=None,
+        sizeX=16,
+        sizeY=16,
+        sizeZ=1,
+        sizeC=1,
+        sizeT=1,
+    ):
         """
         Creates a test image of the required dimensions, where each pixel
         value is set to the average value of x & y. If dataset (obj or name)
@@ -277,8 +305,13 @@ class TestDBHelper(object):
                     pass
 
         image = self.gateway.createImageFromNumpySeq(
-            planeGen(), imageName, sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT,
-            dataset=ds)
+            planeGen(),
+            imageName,
+            sizeZ=sizeZ,
+            sizeC=sizeC,
+            sizeT=sizeT,
+            dataset=ds,
+        )
         return image
 
     def createTestFile(self, parentpath, filename, content):
@@ -292,5 +325,6 @@ class TestDBHelper(object):
         """
         sio = BytesIO(content.encode("utf-8"))
         f = self.gateway.createOriginalFileFromFileObj(
-            sio, parentpath, filename, len(content))
+            sio, parentpath, filename, len(content)
+        )
         return f

--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -57,7 +57,6 @@ class GatewayConfig(object):
 
 
 class ServiceOptsDict(dict):
-
     def __new__(cls, *args, **kwargs):
         return super(ServiceOptsDict, cls).__new__(cls, *args, **kwargs)
 
@@ -75,15 +74,19 @@ class ServiceOptsDict(dict):
                 else:
                     logger.debug(
                         "None or non- string, unicode or numeric type"
-                        "values are ignored, (%r, %r)" % (key, item))
+                        "values are ignored, (%r, %r)" % (key, item)
+                    )
         else:
             raise AttributeError(
                 "%s argument (%r:%s) must be a dictionary"
-                % (self.__class__.__name__, data, type(data)))
+                % (self.__class__.__name__, data, type(data))
+            )
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__,
-                             super(ServiceOptsDict, self).__repr__())
+        return "<%s: %s>" % (
+            self.__class__.__name__,
+            super(ServiceOptsDict, self).__repr__(),
+        )
 
     def __setitem__(self, key, item):
         """Set key to value as string."""
@@ -93,7 +96,8 @@ class ServiceOptsDict(dict):
         else:
             raise AttributeError(
                 "%s argument (%r:%s) must be a string, unicode or numeric type"
-                % (self.__class__.__name__, item, type(item)))
+                % (self.__class__.__name__, item, type(item))
+            )
 
     def __getitem__(self, key):
         """
@@ -137,47 +141,52 @@ class ServiceOptsDict(dict):
         return self.__setitem__(key, value)
 
     def getOmeroGroup(self):
-        return self.get('omero.group')
+        return self.get("omero.group")
 
     def setOmeroGroup(self, value=None):
         if value is not None:
-            self.set('omero.group', value)
+            self.set("omero.group", value)
         else:
             try:
-                del self['omero.group']
+                del self["omero.group"]
             except KeyError:
                 logger.debug("Key 'omero.group' not found in %r" % self)
 
     def getOmeroUser(self):
-        return self.get('omero.user')
+        return self.get("omero.user")
 
     def setOmeroUser(self, value=None):
         if value is not None:
-            self.set('omero.user', value)
+            self.set("omero.user", value)
         else:
             try:
-                del self['omero.user']
+                del self["omero.user"]
             except KeyError:
                 logger.debug("Key 'omero.user' not found in %r" % self)
 
     def getOmeroShare(self):
-        return self.get('omero.share')
+        return self.get("omero.share")
 
     def setOmeroShare(self, value=None):
         if value is not None:
-            self.set('omero.share', value)
+            self.set("omero.share", value)
         else:
             try:
-                del self['omero.share']
+                del self["omero.share"]
             except KeyError:  # pragma: no cover
                 logger.debug("Key 'omero.share' not found in %r" % self)
 
     def _testItem(self, item):
-        if item is not None and not isinstance(item, bool) and \
-            (isinstance(item, basestring) or
-             isinstance(item, int) or
-             isinstance(item, long) or
-             isinstance(item, float)):
+        if (
+            item is not None
+            and not isinstance(item, bool)
+            and (
+                isinstance(item, basestring)
+                or isinstance(item, int)
+                or isinstance(item, long)
+                or isinstance(item, float)
+            )
+        ):
             return True
         return False
 
@@ -210,11 +219,11 @@ def propertiesToDict(m, prefix=None):
         d = nested_dict
         if prefix is not None:
             item = item.replace(prefix, "")
-        items = item.split('.')
+        items = item.split(".")
         for key in items[:-1]:
             d = d.setdefault(key, {})
         try:
-            if value.strip().lower() in ('true', 'false'):
+            if value.strip().lower() in ("true", "false"):
                 d[items[-1]] = toBoolean(value)
             else:
                 d[items[-1]] = json.loads(value)

--- a/src/omero/grid/__init__.py
+++ b/src/omero/grid/__init__.py
@@ -7,6 +7,7 @@
 """
 
 import IceImport
+
 IceImport.load("omero_FS_ice")
 IceImport.load("omero_Scripts_ice")
 IceImport.load("omero_SharedResources_ice")

--- a/src/omero/grid/monitors/__init__.py
+++ b/src/omero/grid/monitors/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import IceImport
+
 IceImport.load("omero_FS_ice")

--- a/src/omero/install/bzip2_tool.py
+++ b/src/omero/install/bzip2_tool.py
@@ -22,6 +22,7 @@ def bzip2_tool(disable=False):
     """
 
     import tables
+
     f = tables.__file__
     p = os.path.dirname(f)
     p = os.path.abspath(p)
@@ -38,6 +39,7 @@ def _swap(f, t):
         print("%s doesn't exist" % f)
         sys.exit(0)
     os.rename(f, t)
+
 
 if __name__ == "__main__":
     try:

--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -30,6 +30,8 @@ from future.utils import isbytes
 from past.builtins import cmp
 from builtins import str
 from builtins import object
+
+
 class Header(object):
     def __init__(self, name, reference=None, description=""):
         """Initialize new configuration property"""
@@ -43,6 +45,7 @@ class Header(object):
             return self.name.lower()
         else:
             return self.reference
+
 
 DB_HEADER = Header("Database", reference="db")
 FS_HEADER = Header("Binary repository", reference="fs")
@@ -78,8 +81,7 @@ HEADER_MAPPING = {
 }
 
 
-TOP = \
-    """.. This file is auto-generated from omero.properties. DO NOT EDIT IT
+TOP = """.. This file is auto-generated from omero.properties. DO NOT EDIT IT
 
 Configuration properties glossary
 =================================
@@ -161,8 +163,7 @@ OMERO.server. Depending on your set-up, default values may be sufficient.
 
 """
 
-HEADER = \
-    """.. _%(reference)s_configuration:
+HEADER = """.. _%(reference)s_configuration:
 
 %(header)s
 %(hline)s
@@ -184,6 +185,7 @@ from collections import defaultdict
 def fail(msg="", debug=0):
     if debug:
         import pdb
+
         pdb.set_trace()
     else:
         raise Exception(msg)
@@ -195,11 +197,10 @@ def dbg(msg):
 
 def underline(size):
     """Create underline for reStructuredText headings"""
-    return '^' * size
+    return "^" * size
 
 
 class Property(object):
-
     def __init__(self, key=None, val=None, txt=""):
         """Initialize new configuration property"""
         self.key = key
@@ -216,7 +217,7 @@ class Property(object):
         dbg("detect:" + line)
         idx = line.index("=")
         self.key = line[0:idx]
-        self.val = line[idx + 1:]
+        self.val = line[idx + 1 :]
 
     def cont(self, line):
         dbg("cont:  " + line)
@@ -225,8 +226,11 @@ class Property(object):
         self.val += line
 
     def __str__(self):
-        return ("Property(key='%s', val='%s', txt='%s')"
-                % (self.key, self.val, self.txt))
+        return "Property(key='%s', val='%s', txt='%s')" % (
+            self.key,
+            self.val,
+            self.txt,
+        )
 
 
 IN_PROGRESS = "in_progress_action"
@@ -234,7 +238,6 @@ ESCAPED = "escaped_action"
 
 
 class PropertyParser(object):
-
     def __init__(self):
         """Initialize a property set"""
         self.properties = []
@@ -335,20 +338,22 @@ class PropertyParser(object):
             data[parts[0]].append(".".join(parts[1:]))
         return data
 
-    def parse_module(self, module='omeroweb.settings'):
+    def parse_module(self, module="omeroweb.settings"):
         """Parse the properties from the setting module"""
 
-        os.environ['DJANGO_SETTINGS_MODULE'] = module
+        os.environ["DJANGO_SETTINGS_MODULE"] = module
 
         from django.conf import settings
 
         for key, values in sorted(
-                iter(list(settings.CUSTOM_SETTINGS_MAPPINGS.items())),
-                key=lambda k: k):
+            iter(list(settings.CUSTOM_SETTINGS_MAPPINGS.items())),
+            key=lambda k: k,
+        ):
 
             p = Property()
-            global_name, default_value, mapping, description, config = \
-                tuple(values)
+            global_name, default_value, mapping, description, config = tuple(
+                values
+            )
             p.val = str(default_value)
             p.key = key
             p.txt = (description or "") + "\n"
@@ -365,7 +370,7 @@ class PropertyParser(object):
                     found = True
                     break
 
-            if not found and x.key.startswith('omero.'):
+            if not found and x.key.startswith("omero."):
                 parts = x.key.split(".")
                 section = parts[1].title()
                 if section not in additional_headers:
@@ -403,8 +408,11 @@ class PropertyParser(object):
         for header in sorted(headers, key=lambda x: x.name):
             properties = ""
             # Filter properties marked as DEVELOPMENT
-            props = [p for p in headers[header] if
-                     not p.txt.startswith('DEVELOPMENT')]
+            props = [
+                p
+                for p in headers[header]
+                if not p.txt.startswith("DEVELOPMENT")
+            ]
             for p in props:
                 properties += ".. property:: %s\n" % (p.key)
                 properties += "\n"
@@ -421,18 +429,22 @@ class PropertyParser(object):
                 if not p.val:
                     v = "[empty]"
 
-                if ',' in v and ', ' not in v:
+                if "," in v and ", " not in v:
                     properties += "Default: `%s`\n\n" % (
-                        ",\n".join(v.split(',')))
+                        ",\n".join(v.split(","))
+                    )
                 else:
                     properties += "Default: `%s`\n\n" % v
 
             hline = "-" * len(header.name)
-            m = {"header": header.name,
-                 "hline": hline,
-                 "properties": properties,
-                 "reference": header.get_reference()}
+            m = {
+                "header": header.name,
+                "hline": hline,
+                "properties": properties,
+                "reference": header.get_reference(),
+            }
             print(HEADER % m)
+
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
@@ -451,7 +463,7 @@ if __name__ == "__main__":
 
     pp = PropertyParser()
     pp.parse_file(ns.files)
-    pp.parse_module('omeroweb.settings')
+    pp.parse_module("omeroweb.settings")
 
     if ns.dbg:
         print("Found:", len(list(pp)))

--- a/src/omero/install/jvmcfg.py
+++ b/src/omero/install/jvmcfg.py
@@ -62,8 +62,8 @@ def strip_dict(map, prefix=("omero", "jvmcfg"), suffix=(), limit=1):
         ssz = len(suffix)
         if ksz <= (psz + ssz):
             return  # No way to strip if smaller
-        if key[0:psz] == prefix and key[ksz-ssz:] == suffix:
-            newkey = key[psz:ksz-ssz]
+        if key[0:psz] == prefix and key[ksz - ssz :] == suffix:
+            newkey = key[psz : ksz - ssz]
             if len(newkey) == limit:
                 newkey = ".".join(newkey)
                 rv[newkey] = v
@@ -74,7 +74,6 @@ def strip_dict(map, prefix=("omero", "jvmcfg"), suffix=(), limit=1):
 
 
 class StrategyRegistry(dict):
-
     def __init__(self, *args, **kwargs):
         super(dict, self).__init__(*args, **kwargs)
 
@@ -142,7 +141,7 @@ class Settings(object):
         rv.update(self.__global)
         if not rv:
             rv = ""
-        return 'Settings(%s)' % rv
+        return "Settings(%s)" % rv
 
 
 class Strategy(object):
@@ -199,8 +198,9 @@ class Strategy(object):
     def _system_memory_mb_psutil(self):
         try:
             import psutil
+
             pymem = psutil.virtual_memory()
-            return (old_div(pymem.free,1000000), old_div(pymem.total,1000000))
+            return (old_div(pymem.free, 1000000), old_div(pymem.total, 1000000))
         except ImportError:
             LOGGER.debug("No psutil installed")
             return None
@@ -217,8 +217,7 @@ class Strategy(object):
         o, e = list(map(bytes_to_native_str, p.communicate()))
 
         if p.poll() != 0:
-            LOGGER.warn("Failed to invoke java:\nout:%s\nerr:%s",
-                        o, e)
+            LOGGER.warn("Failed to invoke java:\nout:%s\nerr:%s", o, e)
 
         rv = dict()
         for line in o.split("\n"):
@@ -279,6 +278,7 @@ class Strategy(object):
         values = []
         if self.settings.heap_dump == "tmp":
             import tempfile
+
             tmp = tempfile.gettempdir()
             values.append("-XX:HeapDumpPath=%s" % tmp)
         return values + split(self.settings.append)
@@ -368,7 +368,7 @@ class PercentStrategy(Strategy):
         return calculated
 
     def usage_table(self, min=10, max=20):
-        total_mb = [2**x for x in range(min, max)]
+        total_mb = [2 ** x for x in range(min, max)]
         for total in total_mb:
             method = lambda: (total, total, total)
             yield total, self.calculate_heap_size(method)
@@ -389,13 +389,18 @@ def read_settings(template_xml):
             for option in server.findall("option"):
                 o = option.text
                 if o.startswith("-Xmx") | o.startswith("-XX"):
-                    rv.setdefault(server.get('id'), []).append(o)
+                    rv.setdefault(server.get("id"), []).append(o)
     return rv
 
 
-def adjust_settings(config, template_xml,
-                    blitz=None, indexer=None,
-                    pixeldata=None, repository=None):
+def adjust_settings(
+    config,
+    template_xml,
+    blitz=None,
+    indexer=None,
+    pixeldata=None,
+    repository=None,
+):
     """
     Takes an omero.config.ConfigXml object and adjusts
     the memory settings. Primary entry point to the
@@ -421,14 +426,19 @@ def adjust_settings(config, template_xml,
 
     rv = defaultdict(list)
     m = config.as_map()
-    loop = (("blitz", blitz), ("indexer", indexer),
-            ("pixeldata", pixeldata), ("repository", repository))
+    loop = (
+        ("blitz", blitz),
+        ("indexer", indexer),
+        ("pixeldata", pixeldata),
+        ("repository", repository),
+    )
 
     for name, StrategyType in loop:
         if name not in options:
             raise Exception(
                 "Cannot find %s option. Make sure templates.xml was "
-                "not copied from an older server" % name)
+                "not copied from an older server" % name
+            )
 
     for name, StrategyType in loop:
         specific = strip_dict(m, suffix=name)
@@ -478,9 +488,7 @@ def adjust_settings(config, template_xml,
     return rv
 
 
-def usage_charts(path,
-                 min=0, max=20,
-                 Strategy=PercentStrategy, name="blitz"):
+def usage_charts(path, min=0, max=20, Strategy=PercentStrategy, name="blitz"):
     # See http://matplotlib.org/examples/pylab_examples/anscombe.html
 
     from pylab import array
@@ -493,13 +501,17 @@ def usage_charts(path,
     from pylab import text
 
     points = 200
-    x = array([old_div(2 ** (old_div(x, points)), 1000)
-               for x in range(min*points, max*points)])
+    x = array(
+        [
+            old_div(2 ** (old_div(x, points)), 1000)
+            for x in range(min * points, max * points)
+        ]
+    )
     y_configs = (
-        (Settings({}), 'A'),
-        (Settings({"percent": "20"}), 'B'),
-        (Settings({}), 'C'),
-        (Settings({"max_system_memory": "10000"}), 'D'),
+        (Settings({}), "A"),
+        (Settings({"percent": "20"}), "B"),
+        (Settings({}), "C"),
+        (Settings({"max_system_memory": "10000"}), "D"),
     )
 
     def f(cfg):

--- a/src/omero/install/logs_library.py
+++ b/src/omero/install/logs_library.py
@@ -53,6 +53,7 @@ class log_line(object):
     012345678901234567890123456789012345678901234567890123456789012345678901\
 23456789012345678901234567890123456789012345678901234567890123456789
     """
+
     def __init__(self, line):
         self.line = line
         line.strip()
@@ -74,7 +75,6 @@ class log_line(object):
 
 
 class log_watcher(object):
-
     def __init__(self, files, entries, exits, storeonce=None, storeall=None):
         if storeonce is None:
             storeonce = []
@@ -127,23 +127,28 @@ class log_watcher(object):
 
 class allthreads_watcher(log_watcher):
     def __init__(self, files):
-        log_watcher.__init__(self, files, ["Meth:", "Executor.doWork"],
-                             ["Rslt:", "Excp:"])
+        log_watcher.__init__(
+            self, files, ["Meth:", "Executor.doWork"], ["Rslt:", "Excp:"]
+        )
 
 
 class saveAndReturnObject_watcher(log_watcher):
     def __init__(self, files):
-        log_watcher.__init__(self, files, ["saveAndReturnObject"],
-                             ["Rslt:", "Excp:"], storeonce=["Args:"],
-                             storeall=["Adding log"])
+        log_watcher.__init__(
+            self,
+            files,
+            ["saveAndReturnObject"],
+            ["Rslt:", "Excp:"],
+            storeonce=["Args:"],
+            storeall=["Adding log"],
+        )
 
 
 # http://matplotlib.sourceforge.net/examples/api/line_with_text.html
 class MyLine(lines.Line2D):
-
     def __init__(self, *args, **kwargs):
         # we'll update the position when the line data is set
-        self.text = mtext.Text(0, 0, '')
+        self.text = mtext.Text(0, 0, "")
         lines.Line2D.__init__(self, *args, **kwargs)
 
         # we can't access the label attr until *after* the line is
@@ -176,8 +181,9 @@ class MyLine(lines.Line2D):
         self.text.draw(renderer)
 
 
-def plot_threads(watcher, all_colors=("blue", "red", "yellow", "green",
-                                      "pink", "purple")):
+def plot_threads(
+    watcher, all_colors=("blue", "red", "yellow", "green", "pink", "purple")
+):
     digit = re.compile(r".*(\d+).*")
 
     fig = plt.figure()
@@ -200,28 +206,31 @@ def plot_threads(watcher, all_colors=("blue", "red", "yellow", "green",
                 print("Error parsing thread:", ll.thread)
                 raise
         y = np.array([int(t), int(t)])
-        x = np.array([ll.start-first, ll.stop-first])
+        x = np.array([ll.start - first, ll.stop - first])
         c = colors.get(t, all_colors[0])
         i = all_colors.index(c)
-        colors[t] = all_colors[(i+1) % len(all_colors)]
+        colors[t] = all_colors[(i + 1) % len(all_colors)]
 
         if True:
             line = MyLine(x, y, c=c, lw=2, alpha=0.5)
             # , mfc='red')#, ms=12, label=str(len(ll.logs)))
             # line.text.set_text('line label')
-            line.text.set_color('red')
+            line.text.set_color("red")
             # line.text.set_fontsize(16)
             ax.add_line(line)
         else:
             # http://matplotlib.sourceforge.net/examples/pylab_examples/broken_barh.html
-            ax.broken_barh([(110, 30), (150, 10)], (10, 9), facecolors='blue')
+            ax.broken_barh([(110, 30), (150, 10)], (10, 9), facecolors="blue")
 
     ax.set_ylim(-2, 25)
-    ax.set_xlim(0, (last-first))
+    ax.set_xlim(0, (last - first))
     plt.show()
+
 
 if __name__ == "__main__":
     for g in allthreads_watcher(sys.argv).gen():
-        print("Date:%s\nElapsed:%s\nLevel:%s\nThread:%s\nMethod:%s\n" \
-            "Status:%s\n\n" % (g.date, g.took, g.level, g.thread, g.message,
-                               g.status))
+        print(
+            "Date:%s\nElapsed:%s\nLevel:%s\nThread:%s\nMethod:%s\n"
+            "Status:%s\n\n"
+            % (g.date, g.took, g.level, g.thread, g.message, g.status)
+        )

--- a/src/omero/install/python_warning.py
+++ b/src/omero/install/python_warning.py
@@ -11,8 +11,9 @@ import sys
 import platform
 
 
-PYTHON_WARNING = ("Python version %s is not "
-                  "supported!" % platform.python_version())
+PYTHON_WARNING = (
+    "Python version %s is not " "supported!" % platform.python_version()
+)
 
 
 def py27_only():

--- a/src/omero/install/versions.py
+++ b/src/omero/install/versions.py
@@ -46,21 +46,32 @@ def needs_upgrade(client_version, server_version, verbose=False):
         server_cleaned = REGEX.match(server_version).group(1)
         server_split = server_cleaned.split(".")
 
-        rv = (client_split < server_split)
+        rv = client_split < server_split
         if verbose:
-            LOG.info("Client=%20s (%-5s)  v.  Server=%20s (%-5s) Upgrade? %s",
-                     client_version, ".".join(client_split),
-                     server_version, ".".join(server_split), rv)
+            LOG.info(
+                "Client=%20s (%-5s)  v.  Server=%20s (%-5s) Upgrade? %s",
+                client_version,
+                ".".join(client_split),
+                server_version,
+                ".".join(server_split),
+                rv,
+            )
         return rv
 
     except:
-        LOG.warn("Bad versions: client=%s server=%s", client_version,
-                 server_version, exc_info=1)
+        LOG.warn(
+            "Bad versions: client=%s server=%s",
+            client_version,
+            server_version,
+            exc_info=1,
+        )
         return True
+
 
 if __name__ == "__main__":
 
     import sys
+
     args = list(sys.argv[1:])
 
     if "--quiet" in args:
@@ -70,7 +81,7 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.DEBUG)
 
     if "--test" in args:
-        print("="*10, "Test", "="*72)
+        print("=" * 10, "Test", "=" * 72)
         needs_upgrade("4.0", "4.1.1", True)
         needs_upgrade("4.1", "4.1.1", True)
         needs_upgrade("4.1.0", "4.1.1", True)
@@ -100,6 +111,9 @@ if __name__ == "__main__":
             rv = int(needs_upgrade(args[0], args[1], True))
         except:
             rv = 2
-            print("""    %s [--quiet] client_version server_version
-or: %s [--quiet] --test """ % (sys.argv[0], sys.argv[0]))
+            print(
+                """    %s [--quiet] client_version server_version
+or: %s [--quiet] --test """
+                % (sys.argv[0], sys.argv[0])
+            )
         sys.exit(rv)

--- a/src/omero/install/win_set_path.py
+++ b/src/omero/install/win_set_path.py
@@ -54,16 +54,17 @@ def win_set_path(new_name=dummy, old_name=r"c:\omero_dist", dir=path(".")):
     for line in fileinput.input([str(cfg), str(xml)], inplace=1):
         if line.find(old_name) >= 0:
             count += 1
-            print(line.replace(old_name, new_name), end=' ')
+            print(line.replace(old_name, new_name), end=" ")
         elif line.find(old_name2) >= 0:
             count += 1
-            print(line.replace(old_name2, new_name2), end=' ')
+            print(line.replace(old_name2, new_name2), end=" ")
         else:
-            print(line, end=' ')
+            print(line, end=" ")
 
     fileinput.close()
     print("Changes made: %s" % count)
     return count
+
 
 if __name__ == "__main__":
     try:
@@ -82,9 +83,12 @@ if __name__ == "__main__":
         print("Failed to set path: ", e)
         sys.exit(1)
 
-    print("""Usage: %s [oldname] newname
+    print(
+        """Usage: %s [oldname] newname
 
 Replaces the [oldname] entries in the Windows configuration files
 with [newname]. By default, [oldname] is set to "c:\omero_dist"
-        """ % sys.argv[0])
+        """
+        % sys.argv[0]
+    )
     sys.exit(2)

--- a/src/omero/install/windows_warning.py
+++ b/src/omero/install/windows_warning.py
@@ -9,20 +9,25 @@
 
 from functools import wraps
 
-WINDOWS_WARNING = ("ERROR: OMERO.server support for Windows was removed"
-                   " in OMERO 5.3, see http://blog.openmicroscopy.org/"
-                   "tech-issues/future-plans/deployment/2016/03/22/"
-                   "windows-support/")
+WINDOWS_WARNING = (
+    "ERROR: OMERO.server support for Windows was removed"
+    " in OMERO 5.3, see http://blog.openmicroscopy.org/"
+    "tech-issues/future-plans/deployment/2016/03/22/"
+    "windows-support/"
+)
 
 
 def windows_warning(func):
     """
     Support for Windows will be removed
     """
+
     def win_warn(func):
         def wrapper(self, *args, **kwargs):
             if self._isWindows():
                 self.ctx.die(20, WINDOWS_WARNING)
             return func(self, *args, **kwargs)
+
         return wrapper
+
     return wraps(func)(win_warn(func))

--- a/src/omero/java.py
+++ b/src/omero/java.py
@@ -19,8 +19,10 @@ DEFAULT_DEBUG = "-Xrunjdwp:server=y,transport=dt_socket,address=8787,suspend=n"
 def check_java(command):
     try:
         p = subprocess.Popen(
-            [command[0], "-version"], stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            [command[0], "-version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         p.communicate()
         rc = p.wait()
         if rc == 0:
@@ -36,12 +38,14 @@ def makeVar(key, env):
         env[key] = os.environ[key]
 
 
-def cmd(args,
-        java="java",
-        xargs=None,
-        chdir=None,
-        debug=None,
-        debug_string=DEFAULT_DEBUG):
+def cmd(
+    args,
+    java="java",
+    xargs=None,
+    chdir=None,
+    debug=None,
+    debug_string=DEFAULT_DEBUG,
+):
     """
     Defines the command to be used by run or popen.
     """
@@ -83,15 +87,17 @@ def cmd(args,
     return command
 
 
-def run(args,
-        use_exec=False,
-        java="java",
-        xargs=None,
-        chdir=None,
-        debug=None,
-        debug_string=DEFAULT_DEBUG,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE):
+def run(
+    args,
+    use_exec=False,
+    java="java",
+    xargs=None,
+    chdir=None,
+    debug=None,
+    debug_string=DEFAULT_DEBUG,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+):
     """
     Execute a Java process, either via subprocess waiting for the process
     to finish and returning the output or if use_exec is True, via os.execvpe
@@ -113,7 +119,7 @@ def run(args,
         if chdir:
             os.chdir(chdir)
         if platform.system() == "Windows":
-            command = ["\"%s\"" % i for i in command]
+            command = ['"%s"' % i for i in command]
             os.execvpe(command[0], command, env)
         else:
             os.execvpe(command[0], command, env)
@@ -123,14 +129,16 @@ def run(args,
         return output
 
 
-def popen(args,
-          java="java",
-          xargs=None,
-          chdir=None,
-          debug=None,
-          debug_string=DEFAULT_DEBUG,
-          stdout=subprocess.PIPE,
-          stderr=subprocess.PIPE):
+def popen(
+    args,
+    java="java",
+    xargs=None,
+    chdir=None,
+    debug=None,
+    debug_string=DEFAULT_DEBUG,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+):
     """
     Creates a subprocess.Popen object and returns it. Uses cmd() internally
     to create the Java command to be executed. This is the same logic as
@@ -140,5 +148,6 @@ def popen(args,
     check_java(command)
     if not chdir:
         chdir = os.getcwd()
-    return subprocess.Popen(command, stdout=stdout, stderr=stderr,
-                            cwd=chdir, env=os.environ)
+    return subprocess.Popen(
+        command, stdout=stdout, stderr=stderr, cwd=chdir, env=os.environ
+    )

--- a/src/omero/min.py
+++ b/src/omero/min.py
@@ -15,6 +15,7 @@
 
 import omero
 import IceImport
+
 if omero.__import_style__ is None:
     omero.__import_style__ = "min"
 

--- a/src/omero/plugins/_metadata_deprecated.py
+++ b/src/omero/plugins/_metadata_deprecated.py
@@ -43,15 +43,17 @@ GUI clients.
 DEPRECATION_MESSAGE = (
     "This plugin is deprecated as of OMERO 5.4.8. Use the plugin"
     " available from https://pypi.org/project/omero-metadata/"
-    " instead.")
+    " instead."
+)
 
-ANNOTATION_TYPES = [t for t in dir(omero.model)
-                    if re.match(r'[A-Za-z0-9]+Annotation$', t)]
+ANNOTATION_TYPES = [
+    t for t in dir(omero.model) if re.match(r"[A-Za-z0-9]+Annotation$", t)
+]
 
 
 def guess_mimetype(filename):
     mt = mimetypes.guess_type(filename, strict=False)[0]
-    if not mt and os.path.splitext(filename) in ('yml', 'yaml'):
+    if not mt and os.path.splitext(filename) in ("yml", "yaml"):
         mt = "application/x-yaml"
     if not mt:
         mt = "application/octet-stream"
@@ -62,11 +64,13 @@ class ObjectLoadException(Exception):
     """
     Raised when a requested object could not be loaded
     """
+
     def __init__(self, klass, oid):
         self.klass = klass
         self.oid = oid
         super(ObjectLoadException, self).__init__(
-            "Failed to get object %s:%s" % (klass, oid))
+            "Failed to get object %s:%s" % (klass, oid)
+        )
 
 
 class Metadata(object):
@@ -161,77 +165,123 @@ class MetadataControl(BaseControl):
         populateroi = parser.add(sub, self.populateroi)
         pixelsize = parser.add(sub, self.pixelsize)
 
-        populate.add_argument("--batch",
-                              type=int,
-                              default=1000,
-                              help="Number of objects to process at once")
+        populate.add_argument(
+            "--batch",
+            type=int,
+            default=1000,
+            help="Number of objects to process at once",
+        )
         self._add_wait(populate)
 
-        for x in (summary, original, bulkanns, measures, mapanns, allanns,
-                  rois, populate, populateroi, pixelsize):
-            x.add_argument("obj",
-                           type=ProxyStringType(),
-                           help="Object in Class:ID format")
+        for x in (
+            summary,
+            original,
+            bulkanns,
+            measures,
+            mapanns,
+            allanns,
+            rois,
+            populate,
+            populateroi,
+            pixelsize,
+        ):
+            x.add_argument(
+                "obj", type=ProxyStringType(), help="Object in Class:ID format"
+            )
 
-        for x in (bulkanns, measures, mapanns, allanns,
-                  rois, populate, populateroi):
-            x.add_argument("--report", action="store_true", help=(
-                "Show additional information"))
+        for x in (
+            bulkanns,
+            measures,
+            mapanns,
+            allanns,
+            rois,
+            populate,
+            populateroi,
+        ):
+            x.add_argument(
+                "--report",
+                action="store_true",
+                help=("Show additional information"),
+            )
 
         for x in (rois, populate, populateroi):
             dry_or_not = x.add_mutually_exclusive_group()
             dry_or_not.add_argument("-n", "--dry-run", action="store_true")
-            dry_or_not.add_argument("-f", "--force", action="store_false",
-                                    dest="dry_run")
+            dry_or_not.add_argument(
+                "-f", "--force", action="store_false", dest="dry_run"
+            )
 
         for x in (bulkanns, measures, mapanns, allanns):
             x.add_argument(
-                "--parents", action="store_true",
-                help="Also search parents for annotations")
+                "--parents",
+                action="store_true",
+                help="Also search parents for annotations",
+            )
 
         for x in (mapanns, allanns):
             x.add_argument(
-                "--ns", default=None, help="Restrict to this namespace")
+                "--ns", default=None, help="Restrict to this namespace"
+            )
             x.add_argument(
-                "--nsre",
-                help="Restrict to this namespace (regular expression)")
+                "--nsre", help="Restrict to this namespace (regular expression)"
+            )
 
         rois.add_argument(
-            "--delete", action="store_true", help="Delete all ROIs")
+            "--delete", action="store_true", help="Delete all ROIs"
+        )
 
         populate.add_argument(
-            "--context", default=self.POPULATE_CONTEXTS[0][0],
-            choices=[a[0] for a in self.POPULATE_CONTEXTS])
+            "--context",
+            default=self.POPULATE_CONTEXTS[0][0],
+            choices=[a[0] for a in self.POPULATE_CONTEXTS],
+        )
 
         datafile = populate.add_mutually_exclusive_group()
         datafile.add_argument("--file", help="Input file")
         datafile.add_argument(
-            "--fileid", type=int, help="Input OriginalFile ID")
+            "--fileid", type=int, help="Input OriginalFile ID"
+        )
 
         cfgfile = populate.add_mutually_exclusive_group()
         cfgfile.add_argument("--cfg", help="YAML configuration file")
         cfgfile.add_argument(
-            "--cfgid", type=int, help="YAML configuration OriginalFile ID")
+            "--cfgid", type=int, help="YAML configuration OriginalFile ID"
+        )
 
-        populate.add_argument("--attach", action="store_true", help=(
-            "Upload input or configuration files and attach to parent object"))
+        populate.add_argument(
+            "--attach",
+            action="store_true",
+            help=(
+                "Upload input or configuration files and attach to parent object"
+            ),
+        )
 
-        populate.add_argument("--localcfg", help=(
-            "Local configuration file or a JSON object string"))
+        populate.add_argument(
+            "--localcfg",
+            help=("Local configuration file or a JSON object string"),
+        )
 
         populateroi.add_argument(
-            "--measurement", type=int, default=None,
-            help="Index of the measurement to populate. By default, all")
+            "--measurement",
+            type=int,
+            default=None,
+            help="Index of the measurement to populate. By default, all",
+        )
 
         pixelsize.add_argument(
-            "--x", type=float, default=None, help="Physical pixel size X")
+            "--x", type=float, default=None, help="Physical pixel size X"
+        )
         pixelsize.add_argument(
-            "--y", type=float, default=None, help="Physical pixel size Y")
+            "--y", type=float, default=None, help="Physical pixel size Y"
+        )
         pixelsize.add_argument(
-            "--z", type=float, default=None, help="Physical pixel size Z")
+            "--z", type=float, default=None, help="Physical pixel size Z"
+        )
         pixelsize.add_argument(
-            "--unit", default="micrometer",
-            help="Unit (nanometer, micrometer, etc.) (default: micrometer)")
+            "--unit",
+            default="micrometer",
+            help="Unit (nanometer, micrometer, etc.) (default: micrometer)",
+        )
 
     def _clientconn(self, args):
         client = self.ctx.conn(args)
@@ -243,7 +293,7 @@ class MetadataControl(BaseControl):
         # loaded. To raise an exception instead pass die_on_failure=False
         # and catch ObjectLoadException
         client, conn = self._clientconn(args)
-        conn.SERVICE_OPTS.setOmeroGroup('-1')
+        conn.SERVICE_OPTS.setOmeroGroup("-1")
         klass = args.obj.ice_staticId().split("::")[-1]
         oid = args.obj.id.val
         wrapper = conn.getObject(klass, oid)
@@ -265,14 +315,14 @@ class MetadataControl(BaseControl):
             s += "%sdescription: %s" % (pre, obj.getDescription())
             s += "%sdate: %s" % (pre, obj.getDate().isoformat())
 
-            if obj.get_type() == 'FileAnnotation':
+            if obj.get_type() == "FileAnnotation":
                 f = md.wrap(obj.getFile())
                 s += "%sfile: %s" % (pre, f.get_name())
                 pre = "\n%s" % ("  " * (indent + 2))
                 s += "%sname: %s" % (pre, f.getName())
                 s += "%ssize: %s" % (pre, f.getSize())
 
-            elif obj.get_type() == 'MapAnnotation':
+            elif obj.get_type() == "MapAnnotation":
                 ma = obj.getValue()
                 s += "%svalue:" % pre
                 pre = "\n%s" % ("  " * (indent + 2))
@@ -303,10 +353,10 @@ class MetadataControl(BaseControl):
             self.ctx.out("Roi count: %s" % md.get_roi_count())
         except AttributeError:
             pass
-        self.ctx.out("Bulk annotations: %d" %
-                     sum(1 for a in md.get_bulkanns()))
-        self.ctx.out("Measurement tables: %d" %
-                     sum(1 for a in md.get_measures()))
+        self.ctx.out("Bulk annotations: %d" % sum(1 for a in md.get_bulkanns()))
+        self.ctx.out(
+            "Measurement tables: %d" % sum(1 for a in md.get_measures())
+        )
         try:
             parent = md.get_parent().get_name()
             self.ctx.out("Parent: %s" % parent)
@@ -342,11 +392,11 @@ class MetadataControl(BaseControl):
         try:
             source, global_om, series_om = md.get_original()
         except AttributeError:
-            self.ctx.die(100, 'Failed to get original metadata for %s' %
-                         md.get_name())
+            self.ctx.die(
+                100, "Failed to get original metadata for %s" % md.get_name()
+            )
 
-        om = (("Global", global_om),
-              ("Series", series_om))
+        om = (("Global", global_om), ("Series", series_om))
 
         for name, tuples in om:
             # Matches the OMERO4 original_metadata.txt format
@@ -360,12 +410,12 @@ class MetadataControl(BaseControl):
             # NotImplementedError
             anns = list(func(mdobj))
         except NotImplementedError:
-            self.ctx.err('WARNING: Failed to get annotations for %s' %
-                         mdobj.get_name())
+            self.ctx.err(
+                "WARNING: Failed to get annotations for %s" % mdobj.get_name()
+            )
             anns = []
         if indent is not None:
-            self.ctx.out("%s%s" % (
-                '  ' * indent, mdobj.get_name()))
+            self.ctx.out("%s%s" % ("  " * indent, mdobj.get_name()))
             indent += 1
         for a in anns:
             self.ctx.out(self._format_ann(mdobj, a, indent))
@@ -374,34 +424,38 @@ class MetadataControl(BaseControl):
                 self._output_ann(p, func, parents, indent)
 
     def bulkanns(self, args):
-        ("Provide a list of the NSBULKANNOTATION tables linked "
-         "to the given object")
+        (
+            "Provide a list of the NSBULKANNOTATION tables linked "
+            "to the given object"
+        )
         self.ctx.err(DEPRECATION_MESSAGE, DeprecationWarning)
         md = self._load(args)
         indent = None
         if args.report:
             indent = 0
-        self._output_ann(
-            md, lambda md: md.get_bulkanns(), args.parents, indent)
+        self._output_ann(md, lambda md: md.get_bulkanns(), args.parents, indent)
 
     def measures(self, args):
-        ("Provide a list of the NSMEASUREMENT tables linked "
-         "to the given object")
+        (
+            "Provide a list of the NSMEASUREMENT tables linked "
+            "to the given object"
+        )
         self.ctx.err(DEPRECATION_MESSAGE, DeprecationWarning)
         md = self._load(args)
         indent = None
         if args.report:
             indent = 0
-        self._output_ann(
-            md, lambda md: md.get_measures(), args.parents, indent)
+        self._output_ann(md, lambda md: md.get_measures(), args.parents, indent)
 
     def mapanns(self, args):
         "Provide a list of all MapAnnotations linked to the given object"
+
         def get_anns(md):
-            for a in md.get_allanns(args.ns, 'MapAnnotation'):
+            for a in md.get_allanns(args.ns, "MapAnnotation"):
                 if args.nsre and not re.match(args.nsre, a.get_ns()):
                     continue
                 yield a
+
         self.ctx.err(DEPRECATION_MESSAGE, DeprecationWarning)
         md = self._load(args)
         indent = None
@@ -411,11 +465,13 @@ class MetadataControl(BaseControl):
 
     def allanns(self, args):
         "Provide a list of all annotations linked to the given object"
+
         def get_anns(md):
             for a in md.get_allanns(args.ns):
                 if args.nsre and not re.match(args.nsre, a.get_ns()):
                     continue
                 yield a
+
         self.ctx.err(DEPRECATION_MESSAGE, DeprecationWarning)
         md = self._load(args)
         indent = None
@@ -430,14 +486,14 @@ class MetadataControl(BaseControl):
 
         sf = client.getSession()
         sr = sf.sharedResources()
-        table = sr.newTable(1, 'testtables')
+        table = sr.newTable(1, "testtables")
         if table is None:
             self.ctx.die(100, "Failed to create Table")
 
         # If we have a table...
         initialized = False
         try:
-            table.initialize([LongColumn('ID', '', [])])
+            table.initialize([LongColumn("ID", "", [])])
             initialized = True
         except:
             pass
@@ -471,7 +527,8 @@ class MetadataControl(BaseControl):
 
         if args.localcfg:
             localcfg = pydict_text_io.load(
-                args.localcfg, session=client.getSession())
+                args.localcfg, session=client.getSession()
+            )
         else:
             localcfg = {}
 
@@ -481,22 +538,33 @@ class MetadataControl(BaseControl):
         if args.attach and not args.dry_run:
             if args.file:
                 fileann = conn.createFileAnnfromLocalFile(
-                    args.file, mimetype=guess_mimetype(args.file),
-                    ns=NSBULKANNOTATIONSRAW)
+                    args.file,
+                    mimetype=guess_mimetype(args.file),
+                    ns=NSBULKANNOTATIONSRAW,
+                )
                 fileid = fileann.getFile().getId()
                 md.linkAnnotation(fileann)
 
             if args.cfg:
                 cfgann = conn.createFileAnnfromLocalFile(
-                    args.cfg, mimetype=guess_mimetype(args.cfg),
-                    ns=NSBULKANNOTATIONSCONFIG)
+                    args.cfg,
+                    mimetype=guess_mimetype(args.cfg),
+                    ns=NSBULKANNOTATIONSCONFIG,
+                )
                 cfgid = cfgann.getFile().getId()
                 md.linkAnnotation(cfgann)
 
         # Note some contexts only support a subset of these args
-        ctx = context_class(client, args.obj, file=args.file, fileid=fileid,
-                            cfg=args.cfg, cfgid=cfgid, attach=args.attach,
-                            options=localcfg)
+        ctx = context_class(
+            client,
+            args.obj,
+            file=args.file,
+            fileid=fileid,
+            cfg=args.cfg,
+            cfgid=cfgid,
+            attach=args.attach,
+            options=localcfg,
+        )
         ctx.parse()
         if not args.dry_run:
             wait = args.wait
@@ -552,7 +620,7 @@ class MetadataControl(BaseControl):
         roiids = client.getSession().getQueryService().projection(q, params)
         roiids = [r[0].val for r in roiids]
         if roiids:
-            self.ctx.out('\n'.join('Roi:%d' % rid for rid in roiids))
+            self.ctx.out("\n".join("Roi:%d" % rid for rid in roiids))
 
     def populateroi(self, args):
         "Add ROIs to an object"
@@ -571,12 +639,14 @@ class MetadataControl(BaseControl):
             self.ctx.die(100, "No measurements found")
         if args.measurement is not None and args.measurement >= count:
             self.ctx.die(
-                100, "Invalid measurement index: %d" % args.measurement)
+                100, "Invalid measurement index: %d" % args.measurement
+            )
         for i in range(count):
             if args.dry_run:
                 self.ctx.out(
-                    "Measurement %d has %s result files." % (
-                        i, ctx.get_result_file_count(i)))
+                    "Measurement %d has %s result files."
+                    % (i, ctx.get_result_file_count(i))
+                )
             else:
                 if args.measurement is not None:
                     if args.measurement != i:
@@ -592,8 +662,7 @@ class MetadataControl(BaseControl):
 
         unit = getattr(UnitsLength, args.unit.upper())
         if not unit:
-            self.ctx.die(100, "%s is not recognized as valid unit."
-                              % args.unit)
+            self.ctx.die(100, "%s is not recognized as valid unit." % args.unit)
 
         md = self._load(args)
         client, conn = self._clientconn(args)
@@ -624,7 +693,7 @@ class MetadataControl(BaseControl):
         else:
             raise Exception("Not implemented for type %s" % md.get_type())
 
-        ctx = {'omero.group': '-1'}
+        ctx = {"omero.group": "-1"}
 
         params = omero.sys.ParametersI()
         params.addId(md.get_id())
@@ -642,7 +711,7 @@ class MetadataControl(BaseControl):
                 pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit))
 
         groupId = pixels[0].getDetails().getGroup().getId().getValue()
-        ctx = {'omero.group': native_str(groupId)}
+        ctx = {"omero.group": native_str(groupId)}
         conn.getUpdateService().saveArray(pixels, ctx)
 
 

--- a/src/omero/plugins/_upload_deprecated.py
+++ b/src/omero/plugins/_upload_deprecated.py
@@ -22,18 +22,19 @@ import omero_ext.path as path
 
 try:
     import hashlib
+
     hash_sha1 = hashlib.sha1
 except:
     import sha
+
     hash_sha1 = sha.new
 
 HELP = """Upload local files to the OMERO server"""
 RE = re.compile(r"\s*upload\s*")
-UNKNOWN = 'type/unknown'
+UNKNOWN = "type/unknown"
 
 
 class UploadControl(BaseControl):
-
     def _complete(self, text, line, begidx, endidx):
         """
         Returns a file after "upload" and otherwise delegates to the
@@ -41,7 +42,7 @@ class UploadControl(BaseControl):
         """
         m = RE.match(line)
         if m:
-            return self._complete_file(RE.sub('', line))
+            return self._complete_file(RE.sub("", line))
         else:
             return BaseControl._complete(self, text, line, begidx, endidx)
 
@@ -54,7 +55,9 @@ class UploadControl(BaseControl):
         self.ctx.err(
             "This module is deprecated as of OMERO 5.5.0. Use the module"
             " available from https://pypi.org/project/omero-upload/"
-            " instead.", DeprecationWarning)
+            " instead.",
+            DeprecationWarning,
+        )
         client = self.ctx.conn(args)
         objIds = []
         for file in args.file:
@@ -62,7 +65,7 @@ class UploadControl(BaseControl):
                 self.ctx.die(500, "File: %s does not exist" % file)
         for file in args.file:
             omero_format = UNKNOWN
-            if(mimetypes.guess_type(file) != (None, None)):
+            if mimetypes.guess_type(file) != (None, None):
                 omero_format = mimetypes.guess_type(file)[0]
             obj = client.upload(file, type=omero_format)
             objIds.append(obj.id.val)
@@ -71,13 +74,15 @@ class UploadControl(BaseControl):
         objIds = self._order_and_range_ids(objIds)
         self.ctx.out("OriginalFile:%s" % objIds)
 
+
 try:
     if "OMERO_NO_DEPRECATED_PLUGINS" not in os.environ:
         warnings.warn(
             "This plugin is deprecated as of OMERO 5.5.0. Use the upload"
             " CLI plugin available from"
             " https://pypi.org/project/omero-upload/ instead.",
-            DeprecationWarning)
+            DeprecationWarning,
+        )
         register("upload", UploadControl, HELP)
 except NameError:
     if __name__ == "__main__":

--- a/src/omero/plugins/basics.py
+++ b/src/omero/plugins/basics.py
@@ -32,7 +32,6 @@ from omero.cli import OMERODIR
 
 
 class QuitControl(BaseControl):
-
     def _configure(self, parser):
         parser.set_defaults(func=self.__call__)
 
@@ -41,7 +40,6 @@ class QuitControl(BaseControl):
 
 
 class VersionControl(BaseControl):
-
     def _configure(self, parser):
         parser.set_defaults(func=self.__call__)
 
@@ -52,7 +50,7 @@ class VersionControl(BaseControl):
         for line in self.ctx.get_config_property_lines(OMERODIR):
             line = str(line).strip()
             if line.startswith("omero.version="):
-                server_version = line[len("omero.verison="):]
+                server_version = line[len("omero.verison=") :]
         if server_version:
             self.ctx.err("OMERO.server version:")
             self.ctx.err(server_version)
@@ -80,16 +78,25 @@ Examples:
 
 
 class LoadControl(BaseControl):
-
     def _configure(self, parser):
         parser.add_argument("infile", nargs="*")
         parser.add_argument(
-            "-g", "--glob", action="store_true", default=False,
-            help=("Input paths are shell globs that should be expanded and "
-                  "sorted."))
+            "-g",
+            "--glob",
+            action="store_true",
+            default=False,
+            help=(
+                "Input paths are shell globs that should be expanded and "
+                "sorted."
+            ),
+        )
         parser.add_argument(
-            "-k", "--keep-going", action="store_true", default=False,
-            help="Continue processing after an error.")
+            "-k",
+            "--keep-going",
+            action="store_true",
+            default=False,
+            help="Continue processing after an error.",
+        )
         parser.set_defaults(func=self.__call__)
 
     def _load_filehandle(self, fh, keep_going):
@@ -117,16 +124,17 @@ class LoadControl(BaseControl):
         else:
             for filename in infiles:
                 self.ctx.dbg("Loading file %s" % filename)
-                with open(filename, 'r') as fh:
+                with open(filename, "r") as fh:
                     self._load_filehandle(fh, args.keep_going)
 
 
 class ShellControl(BaseControl):
-
     def _configure(self, parser):
         parser.add_argument(
-            "--login", action="store_true",
-            help="Logins in and sets the 'client' variable")
+            "--login",
+            action="store_true",
+            help="Logins in and sets the 'client' variable",
+        )
         parser.add_argument("arg", nargs="*", help="Arguments for IPython.")
         parser.set_defaults(func=self.__call__)
 
@@ -135,8 +143,10 @@ class ShellControl(BaseControl):
         Copied from IPython embed-short example
         """
         import logging
+
         logging.basicConfig()
         from omero.util.upgrade_check import UpgradeCheck
+
         check = UpgradeCheck("shell")
         check.run()
         if check.isUpgradeNeeded():
@@ -145,17 +155,21 @@ class ShellControl(BaseControl):
         ns = {}
         if args.login:
             import omero
+
             client = self.ctx.conn(args)
             ns = {"client": client, "omero": omero}
 
         try:
             # IPython 0.11 (see #7112)
             from IPython import embed
+
             embed(user_ns=ns)
         except ImportError:
             from IPython.Shell import IPShellEmbed
+
             ipshell = IPShellEmbed(args.arg)
             ipshell(local_ns=ns)
+
 
 HELP_USAGE = """usage: %(program_name)s <command> [options] args
 See 'help <command>' or '<command> -h' for more information on syntax
@@ -183,17 +197,24 @@ class HelpControl(BaseControl):
         self.__parser__ = parser  # For formatting later
         parser.set_defaults(func=self.__call__)
         parser.add_argument(
-            "--recursive", action="store_true",
-            help="Also print help for all subcommands")
+            "--recursive",
+            action="store_true",
+            help="Also print help for all subcommands",
+        )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "--all", action="store_true",
-            help="Print help for all commands and topics")
+            "--all",
+            action="store_true",
+            help="Print help for all commands and topics",
+        )
         group.add_argument(
-            "--list", action="store_true",
-            help="Print list of all commands and subcommands")
+            "--list",
+            action="store_true",
+            help="Print list of all commands and subcommands",
+        )
         group.add_argument(
-            "topic", nargs="?", help="Command or topic for more information")
+            "topic", nargs="?", help="Command or topic for more information"
+        )
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -219,13 +240,15 @@ class HelpControl(BaseControl):
 
     def print_usage(self):
         commands, topics = [
-            self.__parser__._format_list(x) for x in
-            [sorted(self.ctx.controls), sorted(self.ctx.topics)]]
+            self.__parser__._format_list(x)
+            for x in [sorted(self.ctx.controls), sorted(self.ctx.topics)]
+        ]
         key_list = {
             "program_name": sys.argv[0],
             "version": VERSION,
             "commands": commands,
-            "topics": topics}
+            "topics": topics,
+        }
         print(HELP_USAGE % key_list)
 
     def print_single_command_or_topic(self, args):
@@ -277,17 +300,20 @@ class HelpControl(BaseControl):
 
 
 class ErrorsControl(BaseControl):
-
     def _configure(self, parser):
         parser.set_defaults(func=self.__call__)
-        parser.add_argument("--length", default=50, type=int,
-                            help="Length of message to print")
-        parser.add_argument("plugins", nargs="*", default=(),
-                            help="Limit to these plugins; otherwise all")
+        parser.add_argument(
+            "--length", default=50, type=int, help="Length of message to print"
+        )
+        parser.add_argument(
+            "plugins",
+            nargs="*",
+            default=(),
+            help="Limit to these plugins; otherwise all",
+        )
 
     def __call__(self, args):
-        arranged = defaultdict(lambda: defaultdict(
-            lambda: defaultdict(list)))
+        arranged = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         for name, control in list(self.ctx.controls.items()):
             if not args.plugins or name in args.plugins:
                 combined = []
@@ -302,23 +328,28 @@ class ErrorsControl(BaseControl):
                 for key, errors in sorted(keys.items()):
                     for err in errors:
                         msg = err.msg
-                        if len(msg) > (args.length+1):
-                            msg = msg[:args.length] + "..."
+                        if len(msg) > (args.length + 1):
+                            msg = msg[: args.length] + "..."
                         msg = msg.replace("\n", " ")
                         msg = msg.strip()
                         t = (err.rcode, name, key, msg)
                         self.ctx.out("%5d\t%10s\t%10s\t'%s'" % t)
 
+
 controls = {
     "help": (HelpControl, "Syntax help for all commands"),
     "quit": (QuitControl, "Quit application"),
     "errors": (ErrorsControl, "Display all plugin error codes"),
-    "shell": (ShellControl, """Starts an IPython interpreter session
+    "shell": (
+        ShellControl,
+        """Starts an IPython interpreter session
 
 All arguments not understood vi %(prog)s will be passed to the shell.
-Use "--" to end parsing, e.g. '%(prog)s -- --help' for IPython help"""),
+Use "--" to end parsing, e.g. '%(prog)s -- --help' for IPython help""",
+    ),
     "version": (VersionControl, "Version number"),
-    "load": (LoadControl, LOAD_HELP)}
+    "load": (LoadControl, LOAD_HELP),
+}
 
 try:
     for k, v in list(controls.items()):

--- a/src/omero/plugins/chgrp.py
+++ b/src/omero/plugins/chgrp.py
@@ -48,20 +48,24 @@ Examples:
 
 
 class ChgrpControl(GraphControl):
-
     def cmd_type(self):
         import omero
         import omero.all
+
         return omero.cmd.Chgrp2
 
     def _pre_objects(self, parser):
         parser.add_argument(
-            "grp", nargs="?", type=ExperimenterGroupArg,
-            help="""Group to move objects to""")
+            "grp",
+            nargs="?",
+            type=ExperimenterGroupArg,
+            help="""Group to move objects to""",
+        )
 
     def is_admin(self, client):
         # check if the user currently logged is an admin
         from omero.model.enums import AdminPrivilegeChgrp
+
         ec = self.ctx.get_event_context()
         return AdminPrivilegeChgrp in ec.adminPrivileges
 
@@ -73,6 +77,7 @@ class ChgrpControl(GraphControl):
 
         # Retrieve group
         import omero
+
         try:
             group = client.sf.getAdminService().getGroup(gid)
         except omero.ApiUsageException:
@@ -84,8 +89,9 @@ class ChgrpControl(GraphControl):
         ids = [x.child.id.val for x in group.copyGroupExperimenterMap()]
         # check if the user is an admin
         if uid not in ids and not admin:
-            self.ctx.die(197, "Current user is not member of group: %s" %
-                         group.id.val)
+            self.ctx.die(
+                197, "Current user is not member of group: %s" % group.id.val
+            )
 
         # Set requests group
         if isinstance(req, omero.cmd.DoAll):
@@ -104,6 +110,7 @@ class ChgrpControl(GraphControl):
 
     def print_detailed_report(self, req, rsp, status):
         import omero
+
         if isinstance(rsp, omero.cmd.DoAllRsp):
             for response in rsp.responses:
                 if isinstance(response, omero.cmd.Chgrp2Response):
@@ -122,6 +129,7 @@ class ChgrpControl(GraphControl):
             obj_ids = self._get_object_ids(rsp.deletedObjects)
             for k in obj_ids:
                 self.ctx.out("  %s:%s" % (k, obj_ids[k]))
+
 
 try:
     register("chgrp", ChgrpControl, HELP)

--- a/src/omero/plugins/chown.py
+++ b/src/omero/plugins/chown.py
@@ -73,24 +73,30 @@ Examples:
 
 
 class ChownControl(GraphControl):
-
     def cmd_type(self):
         import omero
         import omero.all
+
         return omero.cmd.Chown2
 
     def _pre_objects(self, parser):
         parser.add_argument(
-            "usr", nargs="?", type=ExperimenterArg,
+            "usr",
+            nargs="?",
+            type=ExperimenterArg,
             help="user to transfer ownership of specified objects and/or all"
-                 " objects owned by specified user(s) to")
+            " objects owned by specified user(s) to",
+        )
 
     def _objects(self, parser):
         parser.add_argument(
-            "obj", nargs="*", type=GraphArg(self.cmd_type()),
+            "obj",
+            nargs="*",
+            type=GraphArg(self.cmd_type()),
             help="objects to be processed in the form <Class>:<Id>"
-                 " and/or user(s) to transfer all data from in the"
-                 " form Experimenter:<Id>")
+            " and/or user(s) to transfer all data from in the"
+            " form Experimenter:<Id>",
+        )
 
     def populate_target_users(self, command_check):
         """
@@ -102,7 +108,8 @@ class ChownControl(GraphControl):
         """
         try:
             command_check.targetUsers = command_check.targetObjects.pop(
-                "Experimenter")
+                "Experimenter"
+            )
         except KeyError:
             pass
 
@@ -122,6 +129,7 @@ class ChownControl(GraphControl):
 
         # Set requests user
         import omero
+
         if isinstance(req, omero.cmd.DoAll):
             for request in req.requests:
                 if isinstance(request, omero.cmd.SkipHead):
@@ -138,6 +146,7 @@ class ChownControl(GraphControl):
 
     def print_detailed_report(self, req, rsp, status):
         import omero
+
         if isinstance(rsp, omero.cmd.DoAllRsp):
             for response in rsp.responses:
                 if isinstance(response, omero.cmd.Chown2Response):
@@ -156,6 +165,7 @@ class ChownControl(GraphControl):
             objIds = self._get_object_ids(rsp.deletedObjects)
             for k in objIds:
                 self.ctx.out("  %s:%s" % (k, objIds[k]))
+
 
 try:
     register("chown", ChownControl, HELP)

--- a/src/omero/plugins/delete.py
+++ b/src/omero/plugins/delete.py
@@ -52,14 +52,15 @@ Examples:
 
 
 class DeleteControl(GraphControl):
-
     def cmd_type(self):
         import omero
         import omero.all
+
         return omero.cmd.Delete2
 
     def print_detailed_report(self, req, rsp, status):
         import omero
+
         if isinstance(rsp, omero.cmd.DoAllRsp):
             for response in rsp.responses:
                 if isinstance(response, omero.cmd.Delete2Response):

--- a/src/omero/plugins/duplicate.py
+++ b/src/omero/plugins/duplicate.py
@@ -56,14 +56,15 @@ Examples:
 
 
 class DuplicateControl(GraphControl):
-
     def cmd_type(self):
         import omero
         import omero.all
+
         return omero.cmd.Duplicate
 
     def print_detailed_report(self, req, rsp, status):
         import omero
+
         if isinstance(rsp, omero.cmd.DoAllRsp):
             for response in rsp.responses:
                 if isinstance(response, omero.cmd.DuplicateResponse):
@@ -77,6 +78,7 @@ class DuplicateControl(GraphControl):
             objIds = self._get_object_ids(rsp.duplicates)
             for k in objIds:
                 self.ctx.out("  %s:%s" % (k, objIds[k]))
+
 
 try:
     if "OMERO_DEV_PLUGINS" in os.environ:

--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -49,8 +49,11 @@ from omero.cli import ProxyStringType
 from omero.gateway import BlitzGateway
 from omero.model.enums import (
     AdminPrivilegeChown,
-    AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
-    AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo)
+    AdminPrivilegeWriteOwned,
+    AdminPrivilegeWriteManagedRepo,
+    AdminPrivilegeDeleteOwned,
+    AdminPrivilegeDeleteManagedRepo,
+)
 from omero.rtypes import rstring
 from omero.rtypes import unwrap
 from omero.sys import Principal
@@ -63,8 +66,8 @@ from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
 HELP = """Filesystem utilities"""
 
 
-if platform.system() == 'Windows':
-    HELP += ("\n\n%s" % WINDOWS_WARNING)
+if platform.system() == "Windows":
+    HELP += "\n\n%s" % WINDOWS_WARNING
 
 Entry = namedtuple("Entry", ("level", "id", "path", "mimetype"))
 
@@ -78,10 +81,9 @@ def contents(mrepo, path, ctx=None):
 
     def parse(tree, level=0):
         for k, v in list(tree.items()):
-            yield Entry(level, v.get("id"),
-                        k, v.get("mimetype"))
+            yield Entry(level, v.get("id"), k, v.get("mimetype"))
             if "files" in v:
-                for sub in parse(v.get("files"), level+1):
+                for sub in parse(v.get("files"), level + 1):
                     yield sub
 
     for entry in parse(tree):
@@ -135,8 +137,8 @@ def prep_directory(client, mrepo):
         oid = list(dir.items())[0][1].get("id")
         ofile = client.sf.getQueryService().get("OriginalFile", oid)
 
-        delete1 = Delete2(targetObjects={'Fileset': [fs.id.val]})
-        delete2 = Delete2(targetObjects={'OriginalFile': [ofile.id.val]})
+        delete1 = Delete2(targetObjects={"Fileset": [fs.id.val]})
+        delete2 = Delete2(targetObjects={"OriginalFile": [ofile.id.val]})
         doall = DoAll()
         doall.requests = [delete1, delete2]
         cb = client.submit(doall)
@@ -150,11 +152,14 @@ def prep_directory(client, mrepo):
 
 def get_logfile(query, fid):
     from omero.sys import ParametersI
-    q = ("select o from FilesetJobLink l "
-         "join l.parent as fs join l.child as j "
-         "join j.originalFileLinks l2 join l2.child as o "
-         "where fs.id = :id and "
-         "o.mimetype = 'application/omero-log-file'")
+
+    q = (
+        "select o from FilesetJobLink l "
+        "join l.parent as fs join l.child as j "
+        "join j.originalFileLinks l2 join l2.child as o "
+        "where fs.id = :id and "
+        "o.mimetype = 'application/omero-log-file'"
+    )
     return query.findByQuery(q, ParametersI().addId(fid))
 
 
@@ -180,7 +185,7 @@ def rename_fileset(client, mrepo, fileset, new_dir, ctx=None):
         Note that final elements are empty
         """
         parts = dir.split("/")
-        parpath = "/".join(parts[0:-2]+[""])
+        parpath = "/".join(parts[0:-2] + [""])
         parname = parts[-2]
         logname = parts[-2] + ".log"
         return parpath, parname, logname
@@ -233,7 +238,6 @@ def rename_fileset(client, mrepo, fileset, new_dir, ctx=None):
 
 
 class FsControl(CmdControl):
-
     def _configure(self, parser):
 
         parser.add_login_arguments()
@@ -243,134 +247,188 @@ class FsControl(CmdControl):
         images.add_style_argument()
         images.add_limit_arguments()
         images.add_argument(
-            "--order", default="newest",
+            "--order",
+            default="newest",
             choices=("newest", "oldest", "largest"),
-            help="order of the rows returned")
+            help="order of the rows returned",
+        )
         images.add_argument(
-            "--archived", action="store_true",
-            help="list only images with archived data")
+            "--archived",
+            action="store_true",
+            help="list only images with archived data",
+        )
 
         mkdir = parser.add(sub, self.mkdir)
         mkdir.add_argument(
-            "new_dir",
-            help="directory to create in the repository")
+            "new_dir", help="directory to create in the repository"
+        )
         mkdir.add_argument(
-            "--parents", action="store_true",
-            help="ensure whole path exists")
+            "--parents", action="store_true", help="ensure whole path exists"
+        )
 
         rename = parser.add(sub, self.rename)
         rename.add_argument(
             "fileset",
             type=ProxyStringType("Fileset"),
-            help="Fileset which should be renamed: ID or Fileset:ID")
+            help="Fileset which should be renamed: ID or Fileset:ID",
+        )
         rename.add_argument(
-            "--no-move", action="store_true",
-            help="do not move original files and import log")
+            "--no-move",
+            action="store_true",
+            help="do not move original files and import log",
+        )
 
         repos = parser.add(sub, self.repos)
         repos.add_style_argument()
         repos.add_argument(
-            "--managed", action="store_true",
-            help="repos only managed repositories")
+            "--managed",
+            action="store_true",
+            help="repos only managed repositories",
+        )
 
         sets = parser.add(sub, self.sets)
         sets.add_style_argument()
         sets.add_limit_arguments()
         sets.add_argument(
-            "--order", default="newest",
+            "--order",
+            default="newest",
             choices=("newest", "oldest", "prefix"),
-            help="order of the rows returned")
+            help="order of the rows returned",
+        )
         sets.add_argument(
-            "--without-images", action="store_true",
-            help="list only sets without images (i.e. corrupt)")
+            "--without-images",
+            action="store_true",
+            help="list only sets without images (i.e. corrupt)",
+        )
         sets.add_argument(
-            "--with-transfer", nargs="+", action="append",
-            help="list sets by their in-place import method")
+            "--with-transfer",
+            nargs="+",
+            action="append",
+            help="list sets by their in-place import method",
+        )
         sets.add_argument(
-            "--check", action="store_true",
-            help="verify the file checksums for each fileset (admins only)")
+            "--check",
+            action="store_true",
+            help="verify the file checksums for each fileset (admins only)",
+        )
 
         ls = parser.add(sub, self.ls)
-        ls.add_argument(
-            "fileset",
-            type=ProxyStringType("Fileset"))
+        ls.add_argument("fileset", type=ProxyStringType("Fileset"))
 
         logfile = parser.add(sub, self.logfile)
         logfile.add_argument("fileset", type=ProxyStringType("Fileset"))
         logfile.add_argument(
-            "filename",  nargs="?", default="-",
-            help="Local filename to be saved to. '-' for stdout")
+            "filename",
+            nargs="?",
+            default="-",
+            help="Local filename to be saved to. '-' for stdout",
+        )
         logopts = logfile.add_mutually_exclusive_group()
         logopts.add_argument(
-            "--name", action="store_true",
-            help="return the path of the logfile within the ManagedRepository")
+            "--name",
+            action="store_true",
+            help="return the path of the logfile within the ManagedRepository",
+        )
         logopts.add_argument(
-            "--size", action="store_true",
-            help="return the size of the logfile in bytes")
+            "--size",
+            action="store_true",
+            help="return the size of the logfile in bytes",
+        )
 
         usage = parser.add(sub, self.usage)
         usage.set_args_unsorted()
         usage.add_login_arguments()
         usage.add_style_argument()
         usage.add_argument(
-            "--wait", type=int,
+            "--wait",
+            type=int,
             help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=-1)
+            "(Indefinite < 0; No wait=0).",
+            default=-1,
+        )
         usage.add_argument(
-            "--size-only", action="store_true",
-            help="Print total bytes used in bytes")
+            "--size-only",
+            action="store_true",
+            help="Print total bytes used in bytes",
+        )
         usage.add_argument(
-            "--report", action="store_true",
-            help="Print detailed breakdown of disk usage")
+            "--report",
+            action="store_true",
+            help="Print detailed breakdown of disk usage",
+        )
         usage.add_argument(
-            "--sum-by", nargs="+", choices=("user", "group", "component"),
-            help=("Breakdown of disk usage by a combination of "
-                  "user, group and component"))
+            "--sum-by",
+            nargs="+",
+            choices=("user", "group", "component"),
+            help=(
+                "Breakdown of disk usage by a combination of "
+                "user, group and component"
+            ),
+        )
         usage.add_argument(
-            "--sort-by", nargs="+",
+            "--sort-by",
+            nargs="+",
             choices=("user", "group", "component", "size", "files"),
-            help=("Sort the report table by one or more of "
-                  "user, group, component, size and files"))
+            help=(
+                "Sort the report table by one or more of "
+                "user, group, component, size and files"
+            ),
+        )
         usage.add_argument(
-            "--reverse", action="store_true",
-            help="Reverse sort order")
+            "--reverse", action="store_true", help="Reverse sort order"
+        )
         unit_group = usage.add_mutually_exclusive_group()
         unit_group.add_argument(
-            "--units", choices="KMGTP",
-            help="Units to use for disk usage")
+            "--units", choices="KMGTP", help="Units to use for disk usage"
+        )
         unit_group.add_argument(
-            "--human-readable", action="store_true",
-            help="Use most appropriate units")
+            "--human-readable",
+            action="store_true",
+            help="Use most appropriate units",
+        )
         usage.add_argument(
-            "--groups",  action="store_true",
-            help="Print size for all current user's groups")
+            "--groups",
+            action="store_true",
+            help="Print size for all current user's groups",
+        )
         usage.add_argument(
-            "obj", nargs="*",
-            help=("Objects to be queried in the form "
-                  "'<Class>:<Id>[,<Id> ...]', or '<Class>:*' "
-                  "to query all the objects of the given type "))
+            "obj",
+            nargs="*",
+            help=(
+                "Objects to be queried in the form "
+                "'<Class>:<Id>[,<Id> ...]', or '<Class>:*' "
+                "to query all the objects of the given type "
+            ),
+        )
 
         importtime = parser.add(sub, self.importtime)
         importtime.add_argument(
-            "fileset", nargs="?",
-            type=ProxyStringType("Fileset"))
+            "fileset", nargs="?", type=ProxyStringType("Fileset")
+        )
         importtime_alternatives = importtime.add_mutually_exclusive_group()
         importtime_alternatives.add_argument(
-            "--cache", action="store_true",
-            help="to cache the results by annotating the fileset")
+            "--cache",
+            action="store_true",
+            help="to cache the results by annotating the fileset",
+        )
         importtime_alternatives.add_argument(
-            "--summary", action="store_true",
-            help="summarize the results cached for filesets")
+            "--summary",
+            action="store_true",
+            help="summarize the results cached for filesets",
+        )
 
         for x in (images, sets):
             x.add_argument(
-                "--extended", action="store_true",
-                help="provide more details for each (slow)")
+                "--extended",
+                action="store_true",
+                help="provide more details for each (slow)",
+            )
 
     def _table(self, args):
         """
         """
         from omero.util.text import TableBuilder
+
         tb = TableBuilder("#")
         if args.style:
             tb.set_style(args.style)
@@ -428,17 +486,17 @@ Examples:
         select = (
             "select i.id, i.name, fs.id,"
             "count(f1.id)+count(f2.id), "
-            "sum(coalesce(f1.size,0) + coalesce(f2.size, 0)) ")
-        archived = (not args.archived and "left outer " or "")
+            "sum(coalesce(f1.size,0) + coalesce(f2.size, 0)) "
+        )
+        archived = not args.archived and "left outer " or ""
         query1 = (
             "from Image i join i.pixels p "
             "%sjoin p.pixelsFileMaps m %sjoin m.parent f1 "
             "left outer join i.fileset as fs "
             "left outer join fs.usedFiles as uf "
-            "left outer join uf.originalFile as f2 ") % \
-            (archived, archived)
-        query2 = (
-            "group by i.id, i.name, fs.id ")
+            "left outer join uf.originalFile as f2 "
+        ) % (archived, archived)
+        query2 = "group by i.id, i.name, fs.id "
 
         if args.order == "newest":
             query3 = "order by i.id desc"
@@ -451,13 +509,18 @@ Examples:
         client = self.ctx.conn(args)
         service = client.sf.getQueryService()
 
-        count = unwrap(service.projection(
-            "select count(i) " + query1,
-            None, {"omero.group": "-1"}))[0][0]
-        rows = unwrap(service.projection(
-            select + query1 + query2 + query3,
-            ParametersI().page(args.offset, args.limit),
-            {"omero.group": "-1"}))
+        count = unwrap(
+            service.projection(
+                "select count(i) " + query1, None, {"omero.group": "-1"}
+            )
+        )[0][0]
+        rows = unwrap(
+            service.projection(
+                select + query1 + query2 + query3,
+                ParametersI().page(args.offset, args.limit),
+                {"omero.group": "-1"},
+            )
+        )
 
         # Formatting
         for row in rows:
@@ -495,10 +558,10 @@ omero.fs.repo.path are all set to be owned by the root user.
 
         if len(args.new_dir) < 2:
             raise ValueError("directory path too short", args.new_dir)
-        if args.new_dir[0] == '/':
+        if args.new_dir[0] == "/":
             args.new_dir = args.new_dir[1:]
-        if args.new_dir[-1] != '/':
-            args.new_dir += '/'
+        if args.new_dir[-1] != "/":
+            args.new_dir += "/"
 
         client = self.ctx.conn(args)
 
@@ -520,10 +583,14 @@ moved.
 
         # See https://trello.com/c/J3LNquSH/ for more information.
         # When reenabling, also reenable testRenameAdminOnly.
-        self.ctx.die(30, 'disabled since OMERO 5.4.7 due to Pixels.path bug')
+        self.ctx.die(30, "disabled since OMERO 5.4.7 due to Pixels.path bug")
         # Keep privilege imports used until @admin_only decorator restored.
-        [AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
-         AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo]
+        [
+            AdminPrivilegeWriteOwned,
+            AdminPrivilegeWriteManagedRepo,
+            AdminPrivilegeDeleteOwned,
+            AdminPrivilegeDeleteManagedRepo,
+        ]
 
         fid = args.fileset.id.val
         client = self.ctx.conn(args)
@@ -542,17 +609,16 @@ moved.
                 self.ctx.die(111, "Fileset:%s belongs to %s" % (fid, oid))
         except ServerError as se:
             self.ctx.die(
-                112, "Could not load Fileset:%s- %s" % (fid, se.message))
+                112, "Could not load Fileset:%s- %s" % (fid, se.message)
+            )
 
         new_client = None
         if oid != uid:
             user = query.get("Experimenter", oid)
             group = query.get("ExperimenterGroup", gid)
-            principal = Principal(
-                user.omeName.val, group.name.val, "Sessions")
+            principal = Principal(user.omeName.val, group.name.val, "Sessions")
             service = client.sf.getSessionService()
-            session = service.createSessionWithTimeouts(
-                principal, 0, 30000)
+            session = service.createSessionWithTimeouts(principal, 0, 30000)
             props = client.getPropertyMap()
             new_client = Client(props)
             new_client.joinSession(session.uuid.val)
@@ -573,6 +639,7 @@ moved.
             self.ctx.die(113, "No files moved!")
         elif not args.no_move:
             from omero.grid import RawAccessRequest
+
             for from_path, to_path in tomove:
                 raw = RawAccessRequest()
                 raw.repoUuid = root.hash.val
@@ -585,9 +652,11 @@ moved.
                     self.ctx.die(114, ce.err)
         else:
             self.ctx.err(
-                "Done. You will now need to move these files manually:")
+                "Done. You will now need to move these files manually:"
+            )
             self.ctx.err(
-                "-----------------------------------------------------")
+                "-----------------------------------------------------"
+            )
             b = "".join([root.path.val, root.name.val])
             for from_path, to_path in tomove:
                 t = "/".join([b, to_path])
@@ -623,7 +692,7 @@ Examples:
         shared = client.sf.sharedResources()
         repos = shared.repositories()
         repos = list(zip(repos.descriptions, repos.proxies))
-        repos.sort(key = cmp_to_key(my_cmp))
+        repos.sort(key=cmp_to_key(my_cmp))
 
         tb = self._table(args)
         tb.cols(["Id", "UUID", "Type", "Path"])
@@ -672,19 +741,17 @@ Examples:
         annselect = (
             "(select ann.textValue from Fileset f4 "
             "join f4.annotationLinks fal join fal.child ann "
-            "where f4.id = fs.id and ann.ns =:ns) ")
+            "where f4.id = fs.id and ann.ns =:ns) "
+        )
         select = (
             "select fs.id, fs.templatePrefix, "
             "(select size(f2.images) from Fileset f2 "
             "where f2.id = fs.id),"
             "(select size(f3.usedFiles) from Fileset f3 "
-            "where f3.id = fs.id),") \
-            + annselect
-        query1 = (
-            "from Fileset fs "
-            "where 1 = 1 ")
-        query2 = (
-            "group by fs.id, fs.templatePrefix ")
+            "where f3.id = fs.id),"
+        ) + annselect
+        query1 = "from Fileset fs " "where 1 = 1 "
+        query2 = "group by fs.id, fs.templatePrefix "
 
         if args.order:
             if args.order == "newest":
@@ -701,12 +768,12 @@ Examples:
 
         params = ParametersI()
         params.addString("ns", NSFILETRANSFER)
-        count = service.projection("select count(fs) " + query1,
-                                   params, {"omero.group": "-1"})
+        count = service.projection(
+            "select count(fs) " + query1, params, {"omero.group": "-1"}
+        )
 
         params.page(args.offset, args.limit)
-        objs = service.projection(select + query,
-                                  params, {"omero.group": "-1"})
+        objs = service.projection(select + query, params, {"omero.group": "-1"})
         objs = unwrap(objs)
         count = unwrap(count)[0][0]
 
@@ -740,17 +807,22 @@ Examples:
             # Now perform check if required
             if args.check:
                 from omero.grid import RawAccessRequest
+
                 desc, prx = self.get_managed_repo(client)
                 ctx = client.getContext(group=-1)
                 check_params = ParametersI()
                 check_params.addId(obj[0])
-                rows = service.projection((
-                    "select h.value, f.hash, "
-                    "f.path || '/' || f.name "
-                    "from Fileset fs join fs.usedFiles uf "
-                    "join uf.originalFile f join f.hasher h "
-                    "where fs.id = :id"
-                    ), check_params, ctx)
+                rows = service.projection(
+                    (
+                        "select h.value, f.hash, "
+                        "f.path || '/' || f.name "
+                        "from Fileset fs join fs.usedFiles uf "
+                        "join uf.originalFile f join f.hasher h "
+                        "where fs.id = :id"
+                    ),
+                    check_params,
+                    ctx,
+                )
 
                 if not rows:
                     obj.append("Empty")
@@ -816,7 +888,8 @@ Examples:
         else:
             self.ctx.die(
                 117,
-                "Log file not accessible for Fileset:%s" % args.fileset.id.val)
+                "Log file not accessible for Fileset:%s" % args.fileset.id.val,
+            )
 
     def get_managed_repo(self, client):
         """
@@ -875,7 +948,8 @@ Examples:
                 groups = exp.linkedExperimenterGroupList()
                 gids = [x.id.val for x in groups]
                 args.obj.append(
-                    "ExperimenterGroup:%s" % ",".join(map(str, gids)))
+                    "ExperimenterGroup:%s" % ",".join(map(str, gids))
+                )
 
         req.targetObjects, req.targetClasses = self._usage_obj(args.obj)
         cb = None
@@ -898,7 +972,7 @@ Examples:
                 parts = o.split(":", 1)
                 assert len(parts) == 2
                 klass = parts[0]
-                if '*' in parts[1]:
+                if "*" in parts[1]:
                     classes.add(klass)
                 else:
                     ids = [int(id) for id in parts[1].split(",")]
@@ -913,9 +987,9 @@ Examples:
         Convert from bytes to KiB, MiB, GiB, TiB or PiB.
         """
         oneK = 1024.0
-        powers = {'K': 1, 'M': 2, 'G': 3, 'T': 4, 'P': 5}
+        powers = {"K": 1, "M": 2, "G": 3, "T": 4, "P": 5}
         if units in list(powers.keys()):
-            return round(old_div(size,oneK**powers[units]), 1)
+            return round(old_div(size, oneK ** powers[units]), 1)
         else:
             raise ValueError("Unrecognized units: ", units)
 
@@ -926,7 +1000,7 @@ Examples:
         """
         err = self.get_error(rsp)
         if err:
-            self.ctx.err("Error: " + rsp.parameters['message'])
+            self.ctx.err("Error: " + rsp.parameters["message"])
         else:
             size = sum(rsp.totalBytesUsed.values())
             if args.size_only:
@@ -934,13 +1008,15 @@ Examples:
             else:
                 files = sum(rsp.totalFileCount.values())
                 if args.units:
-                    size = ("%s %siB"
-                            % (self._to_units(size, args.units), args.units))
+                    size = "%s %siB" % (
+                        self._to_units(size, args.units),
+                        args.units,
+                    )
                 elif args.human_readable:
                     size = filesizeformat(size)
                 self.ctx.out(
-                    "Total disk usage: %s bytes in %d files"
-                    % (size, files))
+                    "Total disk usage: %s bytes in %d files" % (size, files)
+                )
 
             if args.report and not args.size_only and size > 0:
                 self._detailed_usage_report(req, rsp, status, args)
@@ -958,8 +1034,8 @@ Examples:
         showCols = list(sum_by)
         showCols.extend(["size", "files"])
 
-        align = 'l'*len(sum_by)
-        align += 'rr'
+        align = "l" * len(sum_by)
+        align += "rr"
         tb = TableBuilder(*showCols)
         tb.set_align(align)
         if args.style:
@@ -968,8 +1044,9 @@ Examples:
         subtotals = {}
         if "component" in sum_by:
             for userGroup in list(rsp.bytesUsedByReferer.keys()):
-                for (element, size) in list(rsp.bytesUsedByReferer[
-                        userGroup].items()):
+                for (element, size) in list(
+                    rsp.bytesUsedByReferer[userGroup].items()
+                ):
                     files = rsp.fileCountByReferer[userGroup][element]
                     keyList = []
                     if "user" in sum_by:
@@ -1055,30 +1132,32 @@ Examples:
 
 
 class ImportTime(object):
-
     def __init__(self, ctx, query):
         self.cli_ctx = ctx
         self.ice_ctx = {"omero.group": "-1"}
         self.query = query
-        self.ns = 'openmicroscopy.org/omero/import/metrics'
+        self.ns = "openmicroscopy.org/omero/import/metrics"
         self.metrics = dict()
 
         import_tuples = [
-            ('UPLOAD', 'upload (ms)'), ('UPLOAD_C', '# files'),
-            ('SET_ID', 'setId (ms)'),
-            ('METADATA', 'metadata (ms)'),
-            ('PIXELDATA', 'pixeldata (ms)'), ('PIXELDATA_C', '# planes'),
-            ('OVERLAY', 'overlays (ms)'),
-            ('RDEF', 'rnd defs (ms)'), ('RDEF_C', '# settings'),
-            ('THUMBNAIL', 'thumbnails (ms)'), ('THUMBNAIL_C', '# thumbnails')
+            ("UPLOAD", "upload (ms)"),
+            ("UPLOAD_C", "# files"),
+            ("SET_ID", "setId (ms)"),
+            ("METADATA", "metadata (ms)"),
+            ("PIXELDATA", "pixeldata (ms)"),
+            ("PIXELDATA_C", "# planes"),
+            ("OVERLAY", "overlays (ms)"),
+            ("RDEF", "rnd defs (ms)"),
+            ("RDEF_C", "# settings"),
+            ("THUMBNAIL", "thumbnails (ms)"),
+            ("THUMBNAIL_C", "# thumbnails"),
         ]
 
         # Easier in Python 2.7 with OrderedDict.
         # Even easier in Python 3.7 in which dictionaries preserve ordering.
         self.import_phases = [key for (key, name) in import_tuples]
         self.import_phases_to_names = dict(import_tuples)
-        self.import_names_to_phases = dict(
-            [(y, x) for (x, y) in import_tuples])
+        self.import_names_to_phases = dict([(y, x) for (x, y) in import_tuples])
 
     def query_durations(self):
         """Determine values for the phase durations for the import metrics"""
@@ -1095,14 +1174,16 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(self.fileset_id)
-            .addString('mimetype', 'application/omero-log-file')
+            .addString("mimetype", "application/omero-log-file")
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         if not results:
-            self.cli_ctx.die(30, 'Could not query for import log.')
+            self.cli_ctx.die(30, "Could not query for import log.")
 
         upload_job_id = results[0][0].val
         upload_start = results[0][1].val
@@ -1119,15 +1200,17 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(upload_job_id)
-            .addString('type', 'ome.model.jobs.UploadJob')
-            .addString('action', 'UPDATE')
+            .addString("type", "ome.model.jobs.UploadJob")
+            .addString("action", "UPDATE")
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         if not results:
-            self.cli_ctx.die(31, 'Upload job is created but not yet updated.')
+            self.cli_ctx.die(31, "Upload job is created but not yet updated.")
 
         upload_end = results[0][0].val
 
@@ -1143,15 +1226,17 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(import_log_id)
-            .addString('type', 'ome.model.core.OriginalFile')
-            .addString('action', 'UPDATE')
+            .addString("type", "ome.model.core.OriginalFile")
+            .addString("action", "UPDATE")
             .page(0, 3),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         if not results or len(results) < 3:
-            self.cli_ctx.die(32, 'Thumbnails step is not yet finished.')
+            self.cli_ctx.die(32, "Thumbnails step is not yet finished.")
 
         metadata_before_id = results[0][0]
         pixeldata_before_id = results[1][0]
@@ -1173,16 +1258,18 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(self.fileset_id)
-            .addString('type', 'ome.model.core.Image')
-            .addString('action', 'INSERT')
-            .add('last', metadata_before_id)
+            .addString("type", "ome.model.core.Image")
+            .addString("action", "INSERT")
+            .add("last", metadata_before_id)
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         if not results:
-            self.cli_ctx.die(33, 'Could not find images from metadata step.')
+            self.cli_ctx.die(33, "Could not find images from metadata step.")
 
         set_id_end = results[0][0].val
 
@@ -1198,14 +1285,16 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(self.fileset_id)
-            .addString('type', 'ome.model.roi.Roi')
-            .addString('action', 'INSERT')
-            .add('first', pixeldata_before_id)
-            .add('last', thumbnails_before_id)
+            .addString("type", "ome.model.roi.Roi")
+            .addString("action", "INSERT")
+            .add("first", pixeldata_before_id)
+            .add("last", thumbnails_before_id)
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         overlays_start = results[0][0].val if results else None
 
@@ -1221,14 +1310,16 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(self.fileset_id)
-            .addString('type', 'ome.model.display.RenderingDef')
-            .addString('action', 'INSERT')
-            .add('first', pixeldata_before_id)
-            .add('last', thumbnails_before_id)
+            .addString("type", "ome.model.display.RenderingDef")
+            .addString("action", "INSERT")
+            .add("first", pixeldata_before_id)
+            .add("last", thumbnails_before_id)
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         settings_start = results[0][0].val if results else None
 
@@ -1244,90 +1335,86 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
+            hql,
+            ParametersI()
             .addId(self.fileset_id)
-            .addString('type', 'ome.model.display.Thumbnail')
-            .addString('action', 'INSERT')
-            .add('first', pixeldata_before_id)
-            .add('last', thumbnails_before_id)
+            .addString("type", "ome.model.display.Thumbnail")
+            .addString("action", "INSERT")
+            .add("first", pixeldata_before_id)
+            .add("last", thumbnails_before_id)
             .page(0, 1),
-            self.ice_ctx)
+            self.ice_ctx,
+        )
 
         thumbnails_start = results[0][0].val if results else None
 
         # Calculate duration of import phases.
 
-        self.metrics['UPLOAD'] = upload_end - upload_start
-        self.metrics['SET_ID'] = set_id_end - upload_end
-        self.metrics['METADATA'] = metadata_end - set_id_end
+        self.metrics["UPLOAD"] = upload_end - upload_start
+        self.metrics["SET_ID"] = set_id_end - upload_end
+        self.metrics["METADATA"] = metadata_end - set_id_end
 
         if overlays_start:
             if settings_start:
-                self.metrics['OVERLAY'] = settings_start - pixeldata_end
+                self.metrics["OVERLAY"] = settings_start - pixeldata_end
             elif thumbnails_start:
-                self.metrics['OVERLAY'] = thumbnails_start - pixeldata_end
+                self.metrics["OVERLAY"] = thumbnails_start - pixeldata_end
             else:
-                self.metrics['OVERLAY'] = thumbnails_end - pixeldata_end
+                self.metrics["OVERLAY"] = thumbnails_end - pixeldata_end
 
         if settings_start:
             # If there are no rendering settings, pyramids must be built first.
-            self.metrics['PIXELDATA'] = pixeldata_end - metadata_end
+            self.metrics["PIXELDATA"] = pixeldata_end - metadata_end
 
             if thumbnails_start:
-                self.metrics['RDEF'] = thumbnails_start - settings_start
-                self.metrics['THUMBNAIL'] = thumbnails_end - thumbnails_start
+                self.metrics["RDEF"] = thumbnails_start - settings_start
+                self.metrics["THUMBNAIL"] = thumbnails_end - thumbnails_start
             else:
-                self.metrics['RDEF'] = thumbnails_end - settings_start
+                self.metrics["RDEF"] = thumbnails_end - settings_start
 
     def query_counts(self):
         """Determine values for the per-item counts for the import metrics"""
         from omero.sys import ParametersI
+
         fileset = ParametersI().addId(self.fileset_id)
 
-        hql = (
-            "SELECT COUNT(*) FROM FilesetEntry " +
-            "WHERE fileset.id = :id"
-        )
+        hql = "SELECT COUNT(*) FROM FilesetEntry " + "WHERE fileset.id = :id"
 
-        result = self.query.projection(hql, fileset,
-                                       self.ice_ctx)[0][0].val
+        result = self.query.projection(hql, fileset, self.ice_ctx)[0][0].val
         if result > 0:
-            self.metrics['UPLOAD_C'] = result
+            self.metrics["UPLOAD_C"] = result
 
-        if 'PIXELDATA' in self.metrics:
+        if "PIXELDATA" in self.metrics:
             hql = (
-                "SELECT SUM(sizeC * sizeT * sizeZ) FROM Pixels " +
-                "WHERE image.fileset.id = :id"
+                "SELECT SUM(sizeC * sizeT * sizeZ) FROM Pixels "
+                + "WHERE image.fileset.id = :id"
             )
 
-            result = self.query.projection(hql, fileset,
-                                           self.ice_ctx)[0][0].val
+            result = self.query.projection(hql, fileset, self.ice_ctx)[0][0].val
             if result > 0:
-                self.metrics['PIXELDATA_C'] = result
+                self.metrics["PIXELDATA_C"] = result
 
-        if 'RDEF' in self.metrics:
+        if "RDEF" in self.metrics:
             hql = (
-                "SELECT COUNT(*) FROM RenderingDef " +
-                "WHERE pixels.image.fileset.id = :id " +
-                "AND details.owner = pixels.details.owner"
-                )
+                "SELECT COUNT(*) FROM RenderingDef "
+                + "WHERE pixels.image.fileset.id = :id "
+                + "AND details.owner = pixels.details.owner"
+            )
 
-            result = self.query.projection(hql, fileset,
-                                           self.ice_ctx)[0][0].val
+            result = self.query.projection(hql, fileset, self.ice_ctx)[0][0].val
             if result > 0:
-                self.metrics['RDEF_C'] = result
+                self.metrics["RDEF_C"] = result
 
-        if 'THUMBNAIL' in self.metrics:
+        if "THUMBNAIL" in self.metrics:
             hql = (
-                "SELECT COUNT(*) FROM Thumbnail " +
-                "WHERE pixels.image.fileset.id = :id " +
-                "AND details.owner = pixels.details.owner"
-                )
+                "SELECT COUNT(*) FROM Thumbnail "
+                + "WHERE pixels.image.fileset.id = :id "
+                + "AND details.owner = pixels.details.owner"
+            )
 
-            result = self.query.projection(hql, fileset,
-                                           self.ice_ctx)[0][0].val
+            result = self.query.projection(hql, fileset, self.ice_ctx)[0][0].val
             if result > 0:
-                self.metrics['THUMBNAIL_C'] = result
+                self.metrics["THUMBNAIL_C"] = result
 
     def get_cache(self):
         """Retrieve import metrics from a map annotation on the fileset"""
@@ -1341,10 +1428,10 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
-            .addId(self.fileset_id)
-            .addString('ns', self.ns),
-            self.ice_ctx)
+            hql,
+            ParametersI().addId(self.fileset_id).addString("ns", self.ns),
+            self.ice_ctx,
+        )
 
         if results:
             for [name, value] in results:
@@ -1368,9 +1455,12 @@ class ImportTime(object):
 
         for phase in self.import_phases:
             if phase in self.metrics:
-                link.child.mapValue.append(NamedValue(
-                    self.import_phases_to_names[phase],
-                    str(self.metrics[phase])))
+                link.child.mapValue.append(
+                    NamedValue(
+                        self.import_phases_to_names[phase],
+                        str(self.metrics[phase]),
+                    )
+                )
 
         update.saveObject(link)
 
@@ -1378,47 +1468,59 @@ class ImportTime(object):
         """Report how long it took to import an existing fileset"""
         metrics_keys = set(self.metrics)
 
-        if set(['UPLOAD', 'UPLOAD_C']) <= metrics_keys:
-            time = old_div(self.metrics['UPLOAD'], 1000.0)
-            count = self.metrics['UPLOAD_C']
+        if set(["UPLOAD", "UPLOAD_C"]) <= metrics_keys:
+            time = old_div(self.metrics["UPLOAD"], 1000.0)
+            count = self.metrics["UPLOAD_C"]
             plural = "s" if count > 1 else ""
-            print(("   upload time of {0:6.2f}s for "
-                   "{1} file{2} ({3:.3f}s/file)")
-                  .format(time, count, plural, old_div(time,count)))
+            print(
+                (
+                    "   upload time of {0:6.2f}s for "
+                    "{1} file{2} ({3:.3f}s/file)"
+                ).format(time, count, plural, old_div(time, count))
+            )
 
-        time = old_div(self.metrics['SET_ID'], 1000.0)
+        time = old_div(self.metrics["SET_ID"], 1000.0)
         print("    setId time of {0:6.2f}s".format(time))
 
-        time = old_div(self.metrics['METADATA'], 1000.0)
+        time = old_div(self.metrics["METADATA"], 1000.0)
         print(" metadata time of {0:6.2f}s".format(time))
 
-        if set(['PIXELDATA', 'PIXELDATA_C']) <= metrics_keys:
-            time = old_div(self.metrics['PIXELDATA'], 1000.0)
-            count = self.metrics['PIXELDATA_C']
+        if set(["PIXELDATA", "PIXELDATA_C"]) <= metrics_keys:
+            time = old_div(self.metrics["PIXELDATA"], 1000.0)
+            count = self.metrics["PIXELDATA_C"]
             plural = "s" if count > 1 else ""
-            print(("   pixels time of {0:6.2f}s for "
-                   "{1} plane{2} ({3:.3f}s/plane)")
-                  .format(time, count, plural, old_div(time,count)))
+            print(
+                (
+                    "   pixels time of {0:6.2f}s for "
+                    "{1} plane{2} ({3:.3f}s/plane)"
+                ).format(time, count, plural, old_div(time, count))
+            )
 
-        if 'OVERLAY' in metrics_keys:
-            time = old_div(self.metrics['OVERLAY'], 1000.0)
+        if "OVERLAY" in metrics_keys:
+            time = old_div(self.metrics["OVERLAY"], 1000.0)
             print(" overlays time of {0:6.2f}s".format(time))
 
-        if set(['RDEF', 'RDEF_C']) <= metrics_keys:
-            time = old_div(self.metrics['RDEF'], 1000.0)
-            count = self.metrics['RDEF_C']
+        if set(["RDEF", "RDEF_C"]) <= metrics_keys:
+            time = old_div(self.metrics["RDEF"], 1000.0)
+            count = self.metrics["RDEF_C"]
             plural = "s" if count > 1 else ""
-            print(("    rdefs time of {0:6.2f}s for "
-                   "{1} rendering setting{2} ({3:.3f}s/rdef)")
-                  .format(time, count, plural, old_div(time,count)))
+            print(
+                (
+                    "    rdefs time of {0:6.2f}s for "
+                    "{1} rendering setting{2} ({3:.3f}s/rdef)"
+                ).format(time, count, plural, old_div(time, count))
+            )
 
-        if set(['THUMBNAIL', 'THUMBNAIL_C']) <= metrics_keys:
-            time = old_div(self.metrics['THUMBNAIL'], 1000.0)
-            count = self.metrics['THUMBNAIL_C']
+        if set(["THUMBNAIL", "THUMBNAIL_C"]) <= metrics_keys:
+            time = old_div(self.metrics["THUMBNAIL"], 1000.0)
+            count = self.metrics["THUMBNAIL_C"]
             plural = "s" if count > 1 else ""
-            print(("thumbnail time of {0:6.2f}s for "
-                   "{1} thumbnail{2} ({3:.3f}s/thumbnail)")
-                  .format(time, count, plural, old_div(time,count)))
+            print(
+                (
+                    "thumbnail time of {0:6.2f}s for "
+                    "{1} thumbnail{2} ({3:.3f}s/thumbnail)"
+                ).format(time, count, plural, old_div(time, count))
+            )
 
     def print_summary(self):
         """Report import metrics from map annotations on filesets"""
@@ -1433,18 +1535,17 @@ class ImportTime(object):
         )
 
         results = self.query.projection(
-            hql, ParametersI()
-            .addString('ns', self.ns),
-            self.ice_ctx)
+            hql, ParametersI().addString("ns", self.ns), self.ice_ctx
+        )
 
         if not results:
             print("no import times to report")
             return
 
-        columns = ['fileset']
+        columns = ["fileset"]
         for phase in self.import_phases:
             columns.append(self.import_phases_to_names[phase])
-        print(','.join(['"{0}"'.format(column) for column in columns]))
+        print(",".join(['"{0}"'.format(column) for column in columns]))
 
         self.fileset_id = None
 
@@ -1466,8 +1567,8 @@ class ImportTime(object):
             if phase in self.metrics:
                 values.append(str(self.metrics[phase]))
             else:
-                values.append('')
-        print(','.join(values))
+                values.append("")
+        print(",".join(values))
         self.metrics.clear()
 
 

--- a/src/omero/plugins/group.py
+++ b/src/omero/plugins/group.py
@@ -16,14 +16,14 @@ from omero.model.enums import AdminPrivilegeModifyGroup
 
 HELP = """Group administration methods"""
 defaultperms = {
-    'private': 'rw----',
-    'read-only': 'rwr---',
-    'read-annotate': 'rwra--',
-    'read-write': 'rwrw--'}
+    "private": "rw----",
+    "read-only": "rwr---",
+    "read-annotate": "rwra--",
+    "read-write": "rwrw--",
+}
 
 
 class GroupControl(UserGroupControl):
-
     def _configure(self, parser):
 
         self.exc = ExceptionHandler()
@@ -54,26 +54,34 @@ server-permissions.html
 
         parser.add_login_arguments()
         sub = parser.sub()
-        add = parser.add(sub, self.add,
-                         "Add a new group with given permissions " + PERM_TXT)
+        add = parser.add(
+            sub, self.add, "Add a new group with given permissions " + PERM_TXT
+        )
         add.add_argument(
-            "--ignore-existing", action="store_true", default=False,
-            help="Do not fail if user already exists")
+            "--ignore-existing",
+            action="store_true",
+            default=False,
+            help="Do not fail if user already exists",
+        )
         add.add_argument("name", help="Name of the group")
         self.add_permissions_arguments(add)
 
-        perms = parser.add(sub, self.perms,
-                           "Modify a group's permissions " + PERM_TXT)
+        perms = parser.add(
+            sub, self.perms, "Modify a group's permissions " + PERM_TXT
+        )
         self.add_id_name_arguments(perms, "group")
         self.add_permissions_arguments(perms)
 
         list = parser.add(
-            sub, self.list, help="List information about all groups")
+            sub, self.list, help="List information about all groups"
+        )
 
         info = parser.add(
-            sub, self.info,
+            sub,
+            self.info,
             "List information about the group(s). Default to the context"
-            " group")
+            " group",
+        )
         self.add_group_arguments(info)
 
         for x in (list, info):
@@ -82,37 +90,59 @@ server-permissions.html
             x.add_group_sorting_arguments()
 
         listusers = parser.add(
-            sub, self.listusers, "List users of the current group")
+            sub, self.listusers, "List users of the current group"
+        )
         self.add_group_arguments(listusers)
         listusers.add_style_argument()
         listusers.add_group_print_arguments()
         listusers.add_user_sorting_arguments()
 
-        copyusers = parser.add(sub, self.copyusers, "Copy the users of one"
-                               " group to another group")
-        copyusers.add_argument("from_group", help="ID or name of the source"
-                               " group whose users will be copied")
-        copyusers.add_argument("to_group", help="ID or name of the target"
-                               " group which will have new users added")
+        copyusers = parser.add(
+            sub,
+            self.copyusers,
+            "Copy the users of one" " group to another group",
+        )
         copyusers.add_argument(
-            "--as-owner", action="store_true",
-            default=False, help="Copy the group owners only")
+            "from_group",
+            help="ID or name of the source" " group whose users will be copied",
+        )
+        copyusers.add_argument(
+            "to_group",
+            help="ID or name of the target"
+            " group which will have new users added",
+        )
+        copyusers.add_argument(
+            "--as-owner",
+            action="store_true",
+            default=False,
+            help="Copy the group owners only",
+        )
 
-        adduser = parser.add(sub, self.adduser,
-                             "Add one or more users to a group")
+        adduser = parser.add(
+            sub, self.adduser, "Add one or more users to a group"
+        )
         self.add_id_name_arguments(adduser, "group")
-        group = self.add_user_arguments(
-            adduser, action=" to add to the group")
-        group.add_argument("--as-owner", action="store_true", default=False,
-                           help="Add the users as owners of the group")
+        group = self.add_user_arguments(adduser, action=" to add to the group")
+        group.add_argument(
+            "--as-owner",
+            action="store_true",
+            default=False,
+            help="Add the users as owners of the group",
+        )
 
-        removeuser = parser.add(sub, self.removeuser,
-                                "Remove one or more users from a group")
+        removeuser = parser.add(
+            sub, self.removeuser, "Remove one or more users from a group"
+        )
         self.add_id_name_arguments(removeuser, "group")
         group = self.add_user_arguments(
-            removeuser, action=" to remove from the group")
-        group.add_argument("--as-owner", action="store_true", default=False,
-                           help="Remove the users from the group owner list")
+            removeuser, action=" to remove from the group"
+        )
+        group.add_argument(
+            "--as-owner",
+            action="store_true",
+            default=False,
+            help="Remove the users from the group owner list",
+        )
 
         for x in (add, perms, list, copyusers, adduser, removeuser):
             x.add_login_arguments()
@@ -120,13 +150,18 @@ server-permissions.html
     def add_permissions_arguments(self, parser):
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "--perms", help="Group permissions set as string, e.g. 'rw----' ")
+            "--perms", help="Group permissions set as string, e.g. 'rw----' "
+        )
         group.add_argument(
-            "--type", help="Group permissions set symbolically",
-            default="private", choices=list(defaultperms.keys()))
+            "--type",
+            help="Group permissions set symbolically",
+            default="private",
+            choices=list(defaultperms.keys()),
+        )
 
     def parse_perms(self, args):
         from omero_model_PermissionsI import PermissionsI as Perms
+
         perms = getattr(args, "perms", None)
         if not perms:
             perms = defaultperms[args.type]
@@ -153,26 +188,29 @@ server-permissions.html
             grp = admin.lookupGroup(args.name)
             if grp:
                 if args.ignore_existing:
-                    self.ctx.out("Group exists: %s (id=%s)"
-                                 % (args.name, grp.id.val))
+                    self.ctx.out(
+                        "Group exists: %s (id=%s)" % (args.name, grp.id.val)
+                    )
                     return
                 else:
-                    self.ctx.die(3, "Group exists: %s (id=%s)"
-                                 % (args.name, grp.id.val))
+                    self.ctx.die(
+                        3, "Group exists: %s (id=%s)" % (args.name, grp.id.val)
+                    )
         except omero.ApiUsageException:
             pass  # Apparently no such group exists
 
         try:
             id = admin.createGroup(g)
-            self.ctx.out("Added group %s (id=%s) with permissions %s"
-                         % (args.name, id, perms))
+            self.ctx.out(
+                "Added group %s (id=%s) with permissions %s"
+                % (args.name, id, perms)
+            )
         except omero.ValidationException as ve:
             # Possible, though unlikely after previous check
             if self.exc.is_constraint_violation(ve):
                 self.ctx.die(66, "Group already exists: %s" % args.name)
             else:
-                self.ctx.die(67, "Unknown ValidationException: %s"
-                             % ve.message)
+                self.ctx.die(67, "Unknown ValidationException: %s" % ve.message)
         except omero.SecurityViolation as se:
             self.ctx.die(68, "Security violation: %s" % se.message)
         except omero.ServerError as se:
@@ -190,22 +228,30 @@ server-permissions.html
 
         old_perms = str(g.details.permissions)
         if old_perms == str(perms):
-            self.ctx.out("Permissions for group %s (id=%s) already %s"
-                         % (g.name.val, gid, perms))
+            self.ctx.out(
+                "Permissions for group %s (id=%s) already %s"
+                % (g.name.val, gid, perms)
+            )
         else:
             try:
                 chmod = omero.cmd.Chmod2(
-                    targetObjects={'ExperimenterGroup': [gid]},
-                    permissions=str(perms))
+                    targetObjects={"ExperimenterGroup": [gid]},
+                    permissions=str(perms),
+                )
                 c.submit(chmod)
-                self.ctx.out("Changed permissions for group %s (id=%s) to %s"
-                             % (g.name.val, gid, perms))
+                self.ctx.out(
+                    "Changed permissions for group %s (id=%s) to %s"
+                    % (g.name.val, gid, perms)
+                )
             except omero.CmdError as ce:
                 import traceback
+
                 self.ctx.dbg(traceback.format_exc())
-                self.ctx.die(504, "Cannot change permissions for group %s"
-                             " (id=%s) to %s: %s"
-                             % (g.name.val, gid, perms, ce.err))
+                self.ctx.die(
+                    504,
+                    "Cannot change permissions for group %s"
+                    " (id=%s) to %s: %s" % (g.name.val, gid, perms, ce.err),
+                )
 
     def list(self, args):
         c = self.ctx.conn(args)
@@ -223,7 +269,7 @@ server-permissions.html
         admin = c.sf.getAdminService()
         [gids, groups] = self.list_groups(admin, args, use_context=True)
         if len(gids) != 1:
-            self.ctx.die(516, 'Too many group arguments')
+            self.ctx.die(516, "Too many group arguments")
         users = admin.containedExperimenters(gids[0])
         self.output_users_list(admin, users, args)
 
@@ -249,13 +295,16 @@ server-permissions.html
         for uid in list(uids):
             if join:
                 if uid in uid_list:
-                    self.ctx.out("%s is already %s group %s"
-                                 % (uid, relation, group.id.val))
+                    self.ctx.out(
+                        "%s is already %s group %s"
+                        % (uid, relation, group.id.val)
+                    )
                     uids.remove(uid)
             else:
                 if uid not in uid_list:
-                    self.ctx.out("%s is not %s group %s"
-                                 % (uid, relation, group.id.val))
+                    self.ctx.out(
+                        "%s is not %s group %s" % (uid, relation, group.id.val)
+                    )
                     uids.remove(uid)
         return uids
 
@@ -273,12 +322,14 @@ server-permissions.html
 
         if args.as_owner:
             self.addownersbyid(a, t_grp, uids)
-            self.ctx.out("Owners of %s copied to %s"
-                         % (args.from_group, args.to_group))
+            self.ctx.out(
+                "Owners of %s copied to %s" % (args.from_group, args.to_group)
+            )
         else:
             self.addusersbyid(a, t_grp, uids)
-            self.ctx.out("Users of %s copied to %s"
-                         % (args.from_group, args.to_group))
+            self.ctx.out(
+                "Users of %s copied to %s" % (args.from_group, args.to_group)
+            )
 
     def adduser(self, args):
         c = self.ctx.conn(args)
@@ -303,6 +354,7 @@ server-permissions.html
             self.removeownersbyid(a, group, uids)
         else:
             self.removeusersbyid(a, group, uids)
+
 
 try:
     register("group", GroupControl, HELP)

--- a/src/omero/plugins/hql.py
+++ b/src/omero/plugins/hql.py
@@ -30,28 +30,41 @@ WHITELISTED_VALUES = [0, False]
 
 
 class HqlControl(BaseControl):
-
     def _configure(self, parser):
         parser.set_defaults(func=self.__call__)
         parser.add_argument("query", nargs="?", help="Single query to run")
         parser.add_argument(
-            "--admin", help="Run an admin query (deprecated; use 'all')",
-            default=False, action="store_true")
+            "--admin",
+            help="Run an admin query (deprecated; use 'all')",
+            default=False,
+            action="store_true",
+        )
         parser.add_argument(
-            "--all", help="Perform query on all groups", default=False,
-            action="store_true", dest="admin")
+            "--all",
+            help="Perform query on all groups",
+            default=False,
+            action="store_true",
+            dest="admin",
+        )
         parser.add_argument(
             "--ids-only",
             action="store_true",
-            help="Show only the ids of returned objects")
+            help="Show only the ids of returned objects",
+        )
         parser.add_limit_arguments()
         parser.add_style_argument()
         parser.add_login_arguments()
-        self.add_error("NO_QUIET", 67,
-                       "Can't ask for query with --quiet option")
-        self.add_error("NOT_ADMIN", 53,
-                       ("SecurityViolation: Current user is not an"
-                        " admin and cannot use '--admin'"))
+        self.add_error(
+            "NO_QUIET", 67, "Can't ask for query with --quiet option"
+        )
+        self.add_error(
+            "NOT_ADMIN",
+            53,
+            (
+                "SecurityViolation: Current user is not an"
+                " admin and cannot use '--admin'"
+            ),
+        )
         self.add_error("BAD_QUERY", 52, "Bad query: %s")
 
     def __call__(self, args):
@@ -79,8 +92,7 @@ class HqlControl(BaseControl):
         p = ParametersI()
         p.page(args.offset, args.limit)
         rv = self.project(q, args.query, p, ice_map)
-        has_details = self.display(rv, style=args.style,
-                                   idsonly=args.ids_only)
+        has_details = self.display(rv, style=args.style, idsonly=args.ids_only)
         if self.ctx.isquiet or not sys.stdout.isatty():
             return
 
@@ -106,8 +118,10 @@ To quit, enter 'q' or just enter.
             # Stay in loop
             if id.startswith("p"):
                 p.page(p.getOffset().val + p.getLimit().val, p.getLimit())
-                self.ctx.dbg("\nCurrent page: offset=%s, limit=%s\n" %
-                             (p.theFilter.offset.val, p.theFilter.limit.val))
+                self.ctx.dbg(
+                    "\nCurrent page: offset=%s, limit=%s\n"
+                    % (p.theFilter.offset.val, p.theFilter.limit.val)
+                )
                 rv = self.project(q, args.query, p, ice_map)
                 self.display(rv, style=args.style, idsonly=args.ids_only)
             elif id.startswith("r"):
@@ -152,8 +166,11 @@ To quit, enter 'q' or just enter.
             id = ""
             values = {}
             # Handling for simple lookup
-            if not idsonly and len(object_list) == 1 and \
-                    isinstance(object_list[0], omero.rtypes.RObjectI):
+            if (
+                not idsonly
+                and len(object_list) == 1
+                and isinstance(object_list[0], omero.rtypes.RObjectI)
+            ):
                 has_details.append(idx)
                 o = object_list[0].val
                 if o:
@@ -188,6 +205,7 @@ To quit, enter 'q' or just enter.
         from omero.model import IObject
         from omero.model import Details
         from omero.rtypes import RTimeI
+
         # if isinstance(object, list):
         #    return [self.unwrap(x, cache) for x in object]
         # elif isinstance(object, RObject):
@@ -196,7 +214,7 @@ To quit, enter 'q' or just enter.
         if isinstance(unwrapped, IObject):
             rv = "%s:%s" % (unwrapped.__class__.__name__, unwrapped.id.val)
         elif isinstance(object, RTimeI):
-            rv = time.ctime(old_div(unwrapped,1000.0))
+            rv = time.ctime(old_div(unwrapped, 1000.0))
         elif isinstance(object, Details):
             owner = None
             group = None
@@ -220,8 +238,9 @@ To quit, enter 'q' or just enter.
             values.pop(key)
 
         # Filter out _Loaded keys
-        loaded_keys = [x for x in values if x.startswith("_")
-                       and x.endswith("Loaded")]
+        loaded_keys = [
+            x for x in values if x.startswith("_") and x.endswith("Loaded")
+        ]
         for key in loaded_keys:
             values.pop(key)
 
@@ -230,11 +249,16 @@ To quit, enter 'q' or just enter.
             values.pop("_details")
 
         # Filter out multi-valued and empty-valued items
-        multi_valued = sorted([k for k in values
-                               if isinstance(values[k], list)])
-        empty_valued = sorted([
-            k for k in values if not values[k] and values[k] not in
-            WHITELISTED_VALUES])
+        multi_valued = sorted(
+            [k for k in values if isinstance(values[k], list)]
+        )
+        empty_valued = sorted(
+            [
+                k
+                for k in values
+                if not values[k] and values[k] not in WHITELISTED_VALUES
+            ]
+        )
 
         for x in multi_valued + empty_valued:
             if x in values:
@@ -250,6 +274,7 @@ To quit, enter 'q' or just enter.
 
     def project(self, querySvc, queryStr, params, ice_map):
         import omero
+
         try:
             rv = querySvc.projection(queryStr, params, ice_map)
             self.ctx.set("last.hql.rv", rv)
@@ -262,6 +287,7 @@ To quit, enter 'q' or just enter.
         except omero.QueryException as qe:
             self.ctx.set("last.hql.rv", [])
             self.raise_error("BAD_QUERY", qe.message)
+
 
 try:
     register("hql", HqlControl, HELP)

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -97,12 +97,11 @@ Report bugs to <ome-users@lists.openmicroscopy.org.uk>
 TESTHELP = """Run the Importer TestEngine suite (devs-only)"""
 DEBUG_CHOICES = ["ALL", "DEBUG", "ERROR", "FATAL", "INFO", "TRACE", "WARN"]
 OUTPUT_CHOICES = ["ids", "legacy", "yaml"]
-SKIP_CHOICES = ['all', 'checksum', 'minmax', 'thumbnails', 'upgrade']
+SKIP_CHOICES = ["all", "checksum", "minmax", "thumbnails", "upgrade"]
 NO_ARG = object()
 
 
 class CommandArguments(object):
-
     def __init__(self, ctx, args):
         self.__ctx = ctx
         self.__args = args
@@ -114,11 +113,29 @@ class CommandArguments(object):
         self.__py_additional = list()
         # Python arguments
         self.__py_keys = (
-            "javahelp", "skip", "file", "errs", "logback",
-            "port", "password", "group", "create", "func",
-            "bulk", "prog", "user", "key", "path", "logprefix",
-            "JAVA_DEBUG", "quiet", "server", "depth", "clientdir",
-            "sudo")
+            "javahelp",
+            "skip",
+            "file",
+            "errs",
+            "logback",
+            "port",
+            "password",
+            "group",
+            "create",
+            "func",
+            "bulk",
+            "prog",
+            "user",
+            "key",
+            "path",
+            "logprefix",
+            "JAVA_DEBUG",
+            "quiet",
+            "server",
+            "depth",
+            "clientdir",
+            "sudo",
+        )
         self.set_login_arguments(ctx, args)
         self.set_skip_arguments(args)
 
@@ -144,12 +161,12 @@ class CommandArguments(object):
 
     def reset_arg(self, cmd_list, idx, key, val=NO_ARG):
         arg_list = self.build_arg_list(key, val)
-        cmd_list[idx:idx+len(arg_list)] = arg_list
+        cmd_list[idx : idx + len(arg_list)] = arg_list
 
     def build_arg_list(self, key, val=NO_ARG):
         arg_list = []
         if len(key) == 1:
-            arg_list.append("-"+key)
+            arg_list.append("-" + key)
             if val != NO_ARG:
                 if isinstance(val, basestring):
                     arg_list.append(val)
@@ -158,8 +175,7 @@ class CommandArguments(object):
             if val == NO_ARG:
                 arg_list.append("--%s" % key)
             elif isinstance(val, basestring):
-                arg_list.append(
-                    "--%s=%s" % (key, val))
+                arg_list.append("--%s=%s" % (key, val))
             else:
                 arg_list.append("--%s" % key)
         return arg_list
@@ -230,9 +246,11 @@ class CommandArguments(object):
             self.__java_initial.append("-h")
 
         # Connection is required unless help arguments or -f is passed
-        connection_required = ("-h" not in self.__java_initial and
-                               not args.f and
-                               not args.advanced_help)
+        connection_required = (
+            "-h" not in self.__java_initial
+            and not args.f
+            and not args.advanced_help
+        )
         if connection_required:
             client = ctx.conn(args)
             host = client.getProperty("omero.host")
@@ -251,13 +269,13 @@ class CommandArguments(object):
     def set_skip_values(self, skip):
         """Set the arguments to skip steps during import"""
 
-        if ('all' in skip or 'checksum' in skip):
+        if "all" in skip or "checksum" in skip:
             self.__java_initial.append("--checksum-algorithm=File-Size-64")
-        if ('all' in skip or 'thumbnails' in skip):
+        if "all" in skip or "thumbnails" in skip:
             self.__java_initial.append("--no-thumbnails")
-        if ('all' in skip or 'minmax' in skip):
+        if "all" in skip or "minmax" in skip:
             self.__java_initial.append("--no-stats-info")
-        if ('all' in skip or 'upgrade' in skip):
+        if "all" in skip or "upgrade" in skip:
             self.__java_initial.append("--no-upgrade-check")
 
     def open_files(self):
@@ -286,14 +304,18 @@ class ImportControl(BaseControl):
         parser.add_login_arguments()
 
         parser.add_argument(
-            "--javahelp", "--java-help",
-            action="store_true", help="Show the Java help text")
+            "--javahelp",
+            "--java-help",
+            action="store_true",
+            help="Show the Java help text",
+        )
 
         # The following arguments are strictly used by Python
         # The "---" form is kept for backwards compatibility.
         py_group = parser.add_argument_group(
-            'Python arguments',
-            'Optional arguments which are used to configure import.')
+            "Python arguments",
+            "Optional arguments which are used to configure import.",
+        )
 
         def add_python_argument(*args, **kwargs):
             py_group.add_argument(*args, **kwargs)
@@ -302,186 +324,251 @@ class ImportControl(BaseControl):
             ("bulk", "Bulk YAML file for driving multiple imports"),
             ("logprefix", "Directory or file prefix for --file and --errs"),
             ("file", "File for storing the standard out of the Java process"),
-            ("errs", "File for storing the standard err of the Java process")
+            ("errs", "File for storing the standard err of the Java process"),
         ):
             add_python_argument("--%s" % name, nargs="?", help=help)
             add_python_argument("---%s" % name, nargs="?", help=SUPPRESS)
 
         add_python_argument(
-            "--clientdir", type=str,
+            "--clientdir",
+            type=str,
             help="Path to the directory containing the client JARs. "
-            " Default: lib/client")
+            " Default: lib/client",
+        )
         add_python_argument(
-            "--logback", type=str,
-            help="Path to a logback xml file. "
-            " Default: etc/logback-cli.xml")
+            "--logback",
+            type=str,
+            help="Path to a logback xml file. " " Default: etc/logback-cli.xml",
+        )
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
-            'Naming arguments', 'Optional arguments passed strictly to Java.')
+            "Naming arguments", "Optional arguments passed strictly to Java."
+        )
 
         def add_java_name_argument(*args, **kwargs):
             name_group.add_argument(*args, **kwargs)
 
         add_java_name_argument(
-            "-n", "--name",
+            "-n",
+            "--name",
             help="Image or plate name to use (**)",
-            metavar="NAME")
+            metavar="NAME",
+        )
         add_java_name_argument(
-            "-x", "--description",
+            "-x",
+            "--description",
             help="Image or plate description to use (**)",
-            metavar="DESCRIPTION")
+            metavar="DESCRIPTION",
+        )
         # Deprecated naming arguments
-        add_java_name_argument(
-            "--plate_name",
-            help=SUPPRESS)
-        add_java_name_argument(
-            "--plate_description",
-            help=SUPPRESS)
+        add_java_name_argument("--plate_name", help=SUPPRESS)
+        add_java_name_argument("--plate_description", help=SUPPRESS)
 
         # Feedback options
         feedback_group = parser.add_argument_group(
-            'Feedback arguments',
-            'Optional arguments passed strictly to Java allowing to report'
-            ' errors to the OME team.')
+            "Feedback arguments",
+            "Optional arguments passed strictly to Java allowing to report"
+            " errors to the OME team.",
+        )
 
         def add_feedback_argument(*args, **kwargs):
             feedback_group.add_argument(*args, **kwargs)
 
         add_feedback_argument(
-            "--report", action="store_true",
-            help="Report errors to the OME team (**)")
+            "--report",
+            action="store_true",
+            help="Report errors to the OME team (**)",
+        )
         add_feedback_argument(
-            "--upload", action="store_true",
-            help=("Upload broken files and log file (if any) with report."
-                  " Required --report (**)"))
+            "--upload",
+            action="store_true",
+            help=(
+                "Upload broken files and log file (if any) with report."
+                " Required --report (**)"
+            ),
+        )
         add_feedback_argument(
-            "--logs", action="store_true",
-            help=("Upload log file (if any) with report."
-                  " Required --report (**)"))
+            "--logs",
+            action="store_true",
+            help=(
+                "Upload log file (if any) with report."
+                " Required --report (**)"
+            ),
+        )
         add_feedback_argument(
             "--email",
             help="Email for reported errors. Required --report (**)",
-            metavar="EMAIL")
-        add_feedback_argument(
-            "--qa-baseurl",
-            help=SUPPRESS)
+            metavar="EMAIL",
+        )
+        add_feedback_argument("--qa-baseurl", help=SUPPRESS)
 
         # Annotation options
         annotation_group = parser.add_argument_group(
-            'Annotation arguments',
-            'Optional arguments passed strictly to Java allowing to annotate'
-            ' imports.')
+            "Annotation arguments",
+            "Optional arguments passed strictly to Java allowing to annotate"
+            " imports.",
+        )
 
         def add_annotation_argument(*args, **kwargs):
             annotation_group.add_argument(*args, **kwargs)
 
         add_annotation_argument(
-            "--annotation-ns", metavar="ANNOTATION_NS",
-            help="Namespace to use for subsequent annotation (**)")
+            "--annotation-ns",
+            metavar="ANNOTATION_NS",
+            help="Namespace to use for subsequent annotation (**)",
+        )
         add_annotation_argument(
-            "--annotation-text", metavar="ANNOTATION_TEXT",
-            help="Content for a text annotation (**)")
+            "--annotation-text",
+            metavar="ANNOTATION_TEXT",
+            help="Content for a text annotation (**)",
+        )
         add_annotation_argument(
             "--annotation-link",
             metavar="ANNOTATION_LINK",
-            help="Comment annotation ID to link all images to (**)")
+            help="Comment annotation ID to link all images to (**)",
+        )
         add_annotation_argument(
-            "--annotation_ns", metavar="ANNOTATION_NS",
-            help=SUPPRESS)
+            "--annotation_ns", metavar="ANNOTATION_NS", help=SUPPRESS
+        )
         add_annotation_argument(
-            "--annotation_text", metavar="ANNOTATION_TEXT",
-            help=SUPPRESS)
+            "--annotation_text", metavar="ANNOTATION_TEXT", help=SUPPRESS
+        )
         add_annotation_argument(
-            "--annotation_link", metavar="ANNOTATION_LINK",
-            help=SUPPRESS)
+            "--annotation_link", metavar="ANNOTATION_LINK", help=SUPPRESS
+        )
 
         java_group = parser.add_argument_group(
-            'Java arguments', 'Optional arguments passed strictly to Java.')
+            "Java arguments", "Optional arguments passed strictly to Java."
+        )
 
         def add_java_argument(*args, **kwargs):
             java_group.add_argument(*args, **kwargs)
 
         add_java_argument(
-            "-f", action="store_true",
-            help="Display the used files and exit (**)")
+            "-f",
+            action="store_true",
+            help="Display the used files and exit (**)",
+        )
         add_java_argument(
-            "-c", action="store_true",
-            help="Continue importing after errors (**)")
+            "-c",
+            action="store_true",
+            help="Continue importing after errors (**)",
+        )
         add_java_argument(
-            "-l", "--readers",
+            "-l",
+            "--readers",
             help="Use the list of readers rather than the default (**)",
-            metavar="READER_FILE")
+            metavar="READER_FILE",
+        )
         add_java_argument(
             "-d",
             help="OMERO dataset ID to import image into (**)",
-            metavar="DATASET_ID")
+            metavar="DATASET_ID",
+        )
         add_java_argument(
             "-r",
             help="OMERO screen ID to import plate into (**)",
-            metavar="SCREEN_ID")
+            metavar="SCREEN_ID",
+        )
         add_java_argument(
-            "-T", "--target",
+            "-T",
+            "--target",
             help="OMERO target specification (**)",
-            metavar="TARGET")
+            metavar="TARGET",
+        )
         add_java_argument(
-            "--debug", choices=DEBUG_CHOICES,
+            "--debug",
+            choices=DEBUG_CHOICES,
             help="Turn debug logging on (**)",
-            metavar="LEVEL", dest="JAVA_DEBUG")
+            metavar="LEVEL",
+            dest="JAVA_DEBUG",
+        )
         add_java_argument(
-            "--output", choices=OUTPUT_CHOICES,
+            "--output",
+            choices=OUTPUT_CHOICES,
             help="Set an alternative output style",
-            metavar="TYPE")
+            metavar="TYPE",
+        )
         add_java_argument(
             "--encrypted",
             choices=("true", "false"),
             help="Whether the import should use SSL or not",
-            metavar="TYPE")
+            metavar="TYPE",
+        )
 
         # Arguments previously *following" `--`
         advjava_group = parser.add_argument_group(
-            'Advanced Java arguments', (
-                'Optional arguments passed strictly to Java. '
-                'For more information, see --advanced-help.'))
+            "Advanced Java arguments",
+            (
+                "Optional arguments passed strictly to Java. "
+                "For more information, see --advanced-help."
+            ),
+        )
 
         def add_advjava_argument(*args, **kwargs):
             advjava_group.add_argument(*args, **kwargs)
 
         add_advjava_argument(
-            "--advanced-help", action="store_true",
-            help="Show the advanced help text")
+            "--advanced-help",
+            action="store_true",
+            help="Show the advanced help text",
+        )
         add_advjava_argument(
-            "--transfer", nargs="?", metavar="TYPE",
-            help="Transfer methods like in-place import")
+            "--transfer",
+            nargs="?",
+            metavar="TYPE",
+            help="Transfer methods like in-place import",
+        )
         add_advjava_argument(
-            "--exclude", nargs="?", metavar="TYPE",
-            help="Exclusion filters for preventing re-import")
+            "--exclude",
+            nargs="?",
+            metavar="TYPE",
+            help="Exclusion filters for preventing re-import",
+        )
         add_advjava_argument(
-            "--checksum-algorithm", nargs="?", metavar="TYPE",
-            help="Alternative hashing mechanisms balancing speed & accuracy")
+            "--checksum-algorithm",
+            nargs="?",
+            metavar="TYPE",
+            help="Alternative hashing mechanisms balancing speed & accuracy",
+        )
         add_advjava_argument(
-            "--no-stats-info", action="store_true", help=SUPPRESS)
+            "--no-stats-info", action="store_true", help=SUPPRESS
+        )
         add_advjava_argument(
-            "--no-thumbnails", action="store_true", help=SUPPRESS)
+            "--no-thumbnails", action="store_true", help=SUPPRESS
+        )
         add_advjava_argument(
-            "--no-upgrade-check", action="store_true", help=SUPPRESS)
+            "--no-upgrade-check", action="store_true", help=SUPPRESS
+        )
         add_advjava_argument(
-            "--parallel-upload", metavar="COUNT",
-            help="Number of file upload threads to run at the same time")
+            "--parallel-upload",
+            metavar="COUNT",
+            help="Number of file upload threads to run at the same time",
+        )
         add_advjava_argument(
-            "--parallel-fileset", metavar="COUNT",
-            help="Number of fileset candidates to import at the same time")
+            "--parallel-fileset",
+            metavar="COUNT",
+            help="Number of fileset candidates to import at the same time",
+        )
 
         # Unsure on these.
         add_python_argument(
-            "--depth", default=4, type=int,
-            help="Number of directories to scan down for files")
+            "--depth",
+            default=4,
+            type=int,
+            help="Number of directories to scan down for files",
+        )
         add_python_argument(
-            "--skip", type=str, choices=SKIP_CHOICES, action='append',
-            help="Optional step to skip during import")
+            "--skip",
+            type=str,
+            choices=SKIP_CHOICES,
+            action="append",
+            help="Optional step to skip during import",
+        )
         add_python_argument(
-            "path", nargs="*",
-            help="Path to be passed to the Java process")
+            "path", nargs="*", help="Path to be passed to the Java process"
+        )
 
         parser.set_defaults(func=self.importer)
 
@@ -501,8 +588,11 @@ class ImportControl(BaseControl):
         try:
             classpath = [file.abspath() for file in client_dir.files("*.jar")]
         except OSError as e:
-            self.ctx.die(102, "Cannot get JAR files from '%s' (%s)"
-                         % (client_dir, e.strerror))
+            self.ctx.die(
+                102,
+                "Cannot get JAR files from '%s' (%s)"
+                % (client_dir, e.strerror),
+            )
         if not classpath:
             self.ctx.die(103, "No JAR files found under '%s'" % client_dir)
 
@@ -525,8 +615,8 @@ class ImportControl(BaseControl):
             out, err = command_args.open_files()
 
             p = omero.java.popen(
-                import_command, debug=False, xargs=xargs,
-                stdout=out, stderr=err)
+                import_command, debug=False, xargs=xargs, stdout=out, stderr=err
+            )
 
             self.ctx.rv = p.wait()
 
@@ -686,6 +776,7 @@ class ImportControl(BaseControl):
 
 class TestEngine(ImportControl):
     COMMAND = [TEST_CLASS]
+
 
 try:
     register("import", ImportControl, HELP, epilog=EXAMPLES)

--- a/src/omero/plugins/ldap.py
+++ b/src/omero/plugins/ldap.py
@@ -13,8 +13,10 @@ import sys
 
 from omero.cli import CLI, ExceptionHandler, admin_only, UserGroupControl
 from omero.model.enums import (
-    AdminPrivilegeModifyGroup, AdminPrivilegeModifyGroupMembership,
-    AdminPrivilegeModifyUser)
+    AdminPrivilegeModifyGroup,
+    AdminPrivilegeModifyGroupMembership,
+    AdminPrivilegeModifyUser,
+)
 from omero.rtypes import rbool
 
 HELP = """Administrative support for managing users' LDAP settings
@@ -40,7 +42,6 @@ Examples:
 
 
 class LdapControl(UserGroupControl):
-
     def _configure(self, parser):
 
         self.exc = ExceptionHandler()
@@ -48,50 +49,66 @@ class LdapControl(UserGroupControl):
         sub = parser.sub()
 
         active = parser.add(
-            sub, self.active,
-            help="Return code shows if LDAP is configured (admins-only)")
+            sub,
+            self.active,
+            help="Return code shows if LDAP is configured (admins-only)",
+        )
 
-        list = parser.add(
-            sub, self.list,
-            help="List all OMERO users with DNs")
+        list = parser.add(sub, self.list, help="List all OMERO users with DNs")
         list.add_style_argument()
 
         getdn = parser.add(sub, self.getdn, help="Get DN for user on stdout")
         setdn = parser.add(
-            sub, self.setdn,
+            sub,
+            self.setdn,
             help="""Enable or disable LDAP login for user (admins only)
 
 Once LDAP login is enabled for a user, the password set via OMERO is
 ignored, and any attempt to change it will result in an error. When
 you disable LDAP login, the previous password will be in effect, but if the
-user never had a password, one will need to be set!""")
+user never had a password, one will need to be set!""",
+        )
 
         for x in (getdn, setdn):
             self.add_user_and_group_arguments(x)
-        setdn.add_argument("choice", action="store",
-                           help="Enable/disable LDAP login (true/false)")
+        setdn.add_argument(
+            "choice",
+            action="store",
+            help="Enable/disable LDAP login (true/false)",
+        )
 
         discover = parser.add(
-            sub, self.discover,
+            sub,
+            self.discover,
             help="""Discover DNs for existing OMERO users or groups
 
 This command works in the context of users or groups. Specifying
 --groups will only discover groups, that is check which group exists in
 the LDAP server and OMERO and has the "ldap" flag disabled - such groups
 will be presented to the user. Omitting --groups will apply the same logic
-to users.""")
+to users.""",
+        )
         discover.add_argument(
-            "--commands", action="store_true", default=False,
-            help="Print setdn commands on standard out")
-        discover.add_argument("--groups", action="store_true", default=False,
-                              help="Discover LDAP groups, not users.")
+            "--commands",
+            action="store_true",
+            default=False,
+            help="Print setdn commands on standard out",
+        )
+        discover.add_argument(
+            "--groups",
+            action="store_true",
+            default=False,
+            help="Discover LDAP groups, not users.",
+        )
 
         create = parser.add(
-            sub, self.create,
-            help="Create a local user based on LDAP username (admins only)"
+            sub,
+            self.create,
+            help="Create a local user based on LDAP username (admins only)",
         )
         create.add_argument(
-            "username", help="LDAP username of user to be created")
+            "username", help="LDAP username of user to be created"
+        )
 
         for x in (active, list, getdn, setdn, discover, create):
             x.add_login_arguments()
@@ -112,6 +129,7 @@ to users.""")
 
         from omero.rtypes import unwrap
         from omero.util.text import TableBuilder
+
         list_of_dn_user_maps = unwrap(iadmin.lookupLdapAuthExperimenters())
         if list_of_dn_user_maps is None:
             return
@@ -141,8 +159,9 @@ to users.""")
         dn = None
 
         if args.user_name:
-            [uid, u] = self.find_user_by_name(iadmin, args.user_name,
-                                              fatal=True)
+            [uid, u] = self.find_user_by_name(
+                iadmin, args.user_name, fatal=True
+            )
             if u and u.getLdap().val:
                 name = u.getOmeName().val
                 dn = name + ": " + ildap.findDN(name)
@@ -152,8 +171,9 @@ to users.""")
                 name = u.getOmeName().val
                 dn = name + ": " + ildap.findDN(name)
         elif args.group_name:
-            [gid, g] = self.find_group_by_name(iadmin, args.group_name,
-                                               fatal=True)
+            [gid, g] = self.find_group_by_name(
+                iadmin, args.group_name, fatal=True
+            )
             if g and g.getLdap().val:
                 name = g.getName().val
                 dn = name + ": " + ildap.findGroupDN(name)
@@ -183,21 +203,24 @@ to users.""")
         obj = None
 
         if args.user_name:
-            [uid, obj] = self.find_user_by_name(iadmin, args.user_name,
-                                                fatal=True)
+            [uid, obj] = self.find_user_by_name(
+                iadmin, args.user_name, fatal=True
+            )
         elif args.user_id:
             [uid, obj] = self.find_user_by_id(iadmin, args.user_id, fatal=True)
         elif args.group_name:
-            [gid, obj] = self.find_group_by_name(iadmin, args.group_name,
-                                                 fatal=True)
+            [gid, obj] = self.find_group_by_name(
+                iadmin, args.group_name, fatal=True
+            )
         elif args.group_id:
-            [gid, obj] = self.find_group_by_id(iadmin, args.group_id,
-                                               fatal=True)
+            [gid, obj] = self.find_group_by_id(
+                iadmin, args.group_id, fatal=True
+            )
 
         if obj is not None:
             from omero.model import Experimenter, ExperimenterGroup
-            obj.setLdap(rbool(args.choice.lower()
-                              in ("yes", "true", "t", "1")))
+
+            obj.setLdap(rbool(args.choice.lower() in ("yes", "true", "t", "1")))
             if isinstance(obj, ExperimenterGroup):
                 self.update_group(iupdate, obj)
             elif isinstance(obj, Experimenter):
@@ -217,26 +240,32 @@ to users.""")
             elements = ildap.discover()
 
         if len(elements) > 0:
-            self.ctx.out("Following LDAP %s are disabled in OMERO:"
-                         % element_name)
+            self.ctx.out(
+                "Following LDAP %s are disabled in OMERO:" % element_name
+            )
             for e in elements:
                 if args.groups:
                     if args.commands:
-                        self.ctx.out("%s ldap setdn --group-name %s true"
-                                     % (sys.argv[0], e.getName().getValue()))
+                        self.ctx.out(
+                            "%s ldap setdn --group-name %s true"
+                            % (sys.argv[0], e.getName().getValue())
+                        )
                     else:
-                        self.ctx.out("Group=%s\tname=%s"
-                                     % (e.getId().getValue(),
-                                        e.getName().getValue()))
+                        self.ctx.out(
+                            "Group=%s\tname=%s"
+                            % (e.getId().getValue(), e.getName().getValue())
+                        )
                 else:
                     if args.commands:
-                        self.ctx.out("%s ldap setdn --user-name %s true"
-                                     % (sys.argv[0],
-                                        e.getOmeName().getValue()))
+                        self.ctx.out(
+                            "%s ldap setdn --user-name %s true"
+                            % (sys.argv[0], e.getOmeName().getValue())
+                        )
                     else:
-                        self.ctx.out("Experimenter=%s\tomeName=%s"
-                                     % (e.getId().getValue(),
-                                        e.getOmeName().getValue()))
+                        self.ctx.out(
+                            "Experimenter=%s\tomeName=%s"
+                            % (e.getId().getValue(), e.getOmeName().getValue())
+                        )
 
     @admin_only(AdminPrivilegeModifyUser, AdminPrivilegeModifyGroupMembership)
     def create(self, args):
@@ -246,15 +275,19 @@ to users.""")
 
         import omero
         import Ice
+
         try:
             exp = ildap.createUser(args.username)
             dn = iadmin.lookupLdapAuthExperimenter(exp.id.val)
-            self.ctx.out("Added user %s (id=%s) with DN=%s" %
-                         (exp.omeName.val, exp.id.val, dn))
+            self.ctx.out(
+                "Added user %s (id=%s) with DN=%s"
+                % (exp.omeName.val, exp.id.val, dn)
+            )
         except omero.ValidationException as ve:
             self.ctx.die(132, ve.message)
         except Ice.RequestFailedException as rfe:
             self.ctx.die(133, self.exc.handle_failed_request(rfe))
+
 
 try:
     register("ldap", LdapControl, HELP)

--- a/src/omero/plugins/perf.py
+++ b/src/omero/plugins/perf.py
@@ -18,22 +18,28 @@ from omero.cli import BaseControl, CLI
 from omero_ext.argparse import FileType
 import omero.install.perf_test as perf_test
 
-HELP = """Run perf_test files
+HELP = (
+    """Run perf_test files
 
 %s
 
-""" % perf_test.FILE_FORMAT
+"""
+    % perf_test.FILE_FORMAT
+)
 
 
 class PerfControl(BaseControl):
-
     def _configure(self, parser):
         parser.add_argument(
-            "-l", "--list", action="store_true",
-            help="List available commands")
+            "-l", "--list", action="store_true", help="List available commands"
+        )
         parser.add_argument(
-            "file", nargs="*", type=FileType('r'), default=None,
-            help="Read from files or standard in")
+            "file",
+            nargs="*",
+            type=FileType("r"),
+            default=None,
+            help="Read from files or standard in",
+        )
         parser.set_defaults(func=self.__call__)
         parser.add_login_arguments()
 
@@ -54,6 +60,7 @@ class PerfControl(BaseControl):
             # ctx.add_reporter(perf_test.PlotReporter())
             handler = perf_test.PerfHandler(ctx)
             perf_test.handle(handler, args.file)
+
 
 try:
     register("perf", PerfControl, HELP)

--- a/src/omero/plugins/prefs.py
+++ b/src/omero/plugins/prefs.py
@@ -80,6 +80,7 @@ def _make_open_and_close_config(func, allow_readonly):
         finally:
             if config:
                 config.close()
+
     return open_and_close_config
 
 
@@ -122,128 +123,186 @@ class WriteableConfigControl(BaseControl):
 
 
 class PrefsControl(WriteableConfigControl):
-
     def _configure(self, parser):
         parser.add_argument(
-            "--source", help="Configuration file to be used. Default:"
-            " etc/grid/config.xml")
+            "--source",
+            help="Configuration file to be used. Default:"
+            " etc/grid/config.xml",
+        )
 
         sub = parser.sub()
 
         parser.add(
-            sub, self.all,
-            "List all profiles in the current config.xml file.")
+            sub, self.all, "List all profiles in the current config.xml file."
+        )
 
         default = sub.add_parser(
-            "def", help="List (or set) the current active profile.",
-            description="List (or set) the current active profile.")
+            "def",
+            help="List (or set) the current active profile.",
+            description="List (or set) the current active profile.",
+        )
         default.set_defaults(func=self.default)
         default.add_argument(
-            "NAME", nargs="?",
+            "NAME",
+            nargs="?",
             help="Name of the profile which should be made the new active"
-            " profile.")
+            " profile.",
+        )
 
         list = parser.add(
-            sub, self.list,
-            "List all key-value pairs from the current profile (deprecated)")
+            sub,
+            self.list,
+            "List all key-value pairs from the current profile (deprecated)",
+        )
         list.set_defaults(func=self.list)
 
         get = parser.add(
-            sub, self.get,
-            "Get key-value pairs from the current profile. All by default")
+            sub,
+            self.get,
+            "Get key-value pairs from the current profile. All by default",
+        )
         get.set_defaults(func=self.get)
         get.add_argument(
-            "KEY", nargs="*", help="Names of keys in the current profile")
+            "KEY", nargs="*", help="Names of keys in the current profile"
+        )
 
         for x in [get, list]:
             secrets = x.add_mutually_exclusive_group()
             secrets.add_argument(
-                "--show-password", action="store_true",
+                "--show-password",
+                action="store_true",
                 help="Show values of sensitive keys (passwords, "
-                "tokens, etc.) in the current profile")
+                "tokens, etc.) in the current profile",
+            )
             secrets.add_argument(
-                "--hide-password", action="store_false",
-                dest="show_password", help=SUPPRESS)
+                "--hide-password",
+                action="store_false",
+                dest="show_password",
+                help=SUPPRESS,
+            )
 
         set = parser.add(
-            sub, self.set,
+            sub,
+            self.set,
             "Set key-value pair in the current profile. Omit the"
-            " value to remove the key.")
+            " value to remove the key.",
+        )
         append = parser.add(
-            sub, self.append, "Append value to a key in the current profile.")
+            sub, self.append, "Append value to a key in the current profile."
+        )
         remove = parser.add(
-            sub, self.remove,
-            "Remove value from a key in the current profile.")
+            sub, self.remove, "Remove value from a key in the current profile."
+        )
 
         for x in [set, append, remove]:
-            x.add_argument(
-                "KEY", help="Name of the key in the current profile")
+            x.add_argument("KEY", help="Name of the key in the current profile")
             # report is intended for use with cfg mgmt tools
-            x.add_argument("--report", action="store_true",
-                           help="Report if changes are made")
+            x.add_argument(
+                "--report",
+                action="store_true",
+                help="Report if changes are made",
+            )
         set.add_argument(
-            "-f", "--file", type=ExistingFile('r'),
-            help="Load value from file")
+            "-f", "--file", type=ExistingFile("r"), help="Load value from file"
+        )
         set.add_argument(
-            "VALUE", nargs="?",
-            help="Value to be set. If it is missing, the key will be removed")
+            "VALUE",
+            nargs="?",
+            help="Value to be set. If it is missing, the key will be removed",
+        )
         append.add_argument(
-            "--set", action="store_true",
-            help="Append only if not already in the list")
+            "--set",
+            action="store_true",
+            help="Append only if not already in the list",
+        )
         append.add_argument("VALUE", help="Value to be appended")
         remove.add_argument("VALUE", help="Value to be removed")
 
         drop = parser.add(
-            sub, self.drop, "Remove the profile from the configuration file")
+            sub, self.drop, "Remove the profile from the configuration file"
+        )
         drop.add_argument("NAME", help="Name of the profile to remove")
 
         parser.add(sub, self.keys, "List all keys for the current profile")
 
         load = parser.add(
-            sub, self.load,
-            "Read into current profile from a file or standard input")
+            sub,
+            self.load,
+            "Read into current profile from a file or standard input",
+        )
         load.add_argument(
-            "-q", action="store_true", help="No error on conflict")
+            "-q", action="store_true", help="No error on conflict"
+        )
         load.add_argument(
-            "file", nargs="*", type=ExistingFile('r'), default="-",
+            "file",
+            nargs="*",
+            type=ExistingFile("r"),
+            default="-",
             help="Files to read from. Default to standard input if not"
-            " specified")
+            " specified",
+        )
 
         parse = parser.add(
-            sub, self.parse,
+            sub,
+            self.parse,
             "Parse the configuration properties from the etc/omero.properties"
-            " file and Web properties for readability.")
+            " file and Web properties for readability.",
+        )
         parse.add_argument(
-            "-f", "--file", type=ExistingFile('r'),
-            help="Alternative location for a Java properties file")
+            "-f",
+            "--file",
+            type=ExistingFile("r"),
+            help="Alternative location for a Java properties file",
+        )
         parse_group = parse.add_mutually_exclusive_group()
         parse_group.add_argument(
-            "--defaults", action="store_true",
-            help="Show key/value configuration defaults")
+            "--defaults",
+            action="store_true",
+            help="Show key/value configuration defaults",
+        )
         parse_group.add_argument(
-            "--rst", action="store_true",
-            help="Generate reStructuredText from omero.properties")
+            "--rst",
+            action="store_true",
+            help="Generate reStructuredText from omero.properties",
+        )
         parse_group.add_argument(
-            "--keys", action="store_true",
-            help="Print just the keys from omero.properties")
+            "--keys",
+            action="store_true",
+            help="Print just the keys from omero.properties",
+        )
         parse_group.add_argument(
-            "--headers", action="store_true",
-            help="Print all headers from omero.properties")
+            "--headers",
+            action="store_true",
+            help="Print all headers from omero.properties",
+        )
         parse.add_argument(
-            "--no-web", action="store_true",
-            help="Do not parse Web properties")
+            "--no-web", action="store_true", help="Do not parse Web properties"
+        )
 
-        parser.add(sub, self.edit, "Present the properties for the current"
-                   " profile in your editor. Saving them will update your"
-                   " profile.")
-        parser.add(sub, self.version, "Print the configuration version for"
-                   " the current profile.")
-        parser.add(sub, self.path, "Print the file that is used for "
-                   " configuration")
-        parser.add(sub, self.lock, "Acquire the config file lock and hold"
-                   " it")
-        parser.add(sub, self.upgrade, "Create a 4.2 config.xml file based on"
-                   " your current Java Preferences")
+        parser.add(
+            sub,
+            self.edit,
+            "Present the properties for the current"
+            " profile in your editor. Saving them will update your"
+            " profile.",
+        )
+        parser.add(
+            sub,
+            self.version,
+            "Print the configuration version for" " the current profile.",
+        )
+        parser.add(
+            sub, self.path, "Print the file that is used for " " configuration"
+        )
+        parser.add(
+            sub, self.lock, "Acquire the config file lock and hold" " it"
+        )
+        parser.add(
+            sub,
+            self.upgrade,
+            "Create a 4.2 config.xml file based on"
+            " your current Java Preferences",
+        )
 
     def open_config(self, args):
         if args.source:
@@ -251,14 +310,13 @@ class PrefsControl(WriteableConfigControl):
             if not cfg_xml.exists():
                 self.ctx.die(124, "File not found: %s" % args.source)
         else:
-            if 'OMERODIR' in os.environ:
-                base_dir = path(os.environ.get('OMERODIR'))
+            if "OMERODIR" in os.environ:
+                base_dir = path(os.environ.get("OMERODIR"))
             else:
-                self.ctx.die(125, 'FATAL: OMERODIR env variable not set')
+                self.ctx.die(125, "FATAL: OMERODIR env variable not set")
             grid_dir = base_dir / "etc" / "grid"
             if not grid_dir.exists():
-                self.ctx.err("%s not found; creating %s" %
-                             (grid_dir, grid_dir))
+                self.ctx.err("%s not found; creating %s" % (grid_dir, grid_dir))
                 os.makedirs(grid_dir)
             cfg_xml = grid_dir / "config.xml"
         try:
@@ -271,8 +329,8 @@ class PrefsControl(WriteableConfigControl):
     def assert_valid_property_name(self, key):
         from re import search
 
-        if search(r'[^A-Za-z0-9._-]', key):
-            self.ctx.die(506, 'Illegal property name: {0}'.format(key))
+        if search(r"[^A-Za-z0-9._-]", key):
+            self.ctx.die(506, "Illegal property name: {0}".format(key))
 
     @with_config
     def all(self, args, config):
@@ -294,8 +352,9 @@ class PrefsControl(WriteableConfigControl):
 
     @with_config
     def list(self, args, config):
-        self.ctx.err('WARNING: "config list" is deprecated, '
-                     'use "config get" instead')
+        self.ctx.err(
+            'WARNING: "config list" is deprecated, ' 'use "config get" instead'
+        )
         args.KEY = []
         self.get(args, config)
 
@@ -308,17 +367,17 @@ class PrefsControl(WriteableConfigControl):
             for k in config.IGNORE:
                 k in keys and keys.remove(k)
 
-        is_password = (lambda x: x.lower().endswith('pass') or
-                       x.lower().endswith('password'))
+        is_password = lambda x: x.lower().endswith(
+            "pass"
+        ) or x.lower().endswith("password")
         for k in keys:
             if k not in orig:
                 continue
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if is_password(k) and not getattr(
-                        args, "show_password", False):
-                    self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
+                if is_password(k) and not getattr(args, "show_password", False):
+                    self.ctx.out("%s=%s" % (k, "*" * 8 if config[k] else ""))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))
 
@@ -336,26 +395,28 @@ class PrefsControl(WriteableConfigControl):
             if args.file == "-":
                 # Read from standard input
                 import fileinput
+
                 f = fileinput.input(args.file)
             else:
                 f = args.file
             try:
                 self.assert_valid_property_name(args.KEY)
-                config[args.KEY] = (''.join(f)).rstrip()
+                config[args.KEY] = ("".join(f)).rstrip()
             finally:
                 f.close()
         elif args.VALUE is None:
             del config[args.KEY]
             if args.report:
-                self.ctx.out('Changed: Removed %s' % args.KEY)
+                self.ctx.out("Changed: Removed %s" % args.KEY)
         else:
             self.assert_valid_property_name(args.KEY)
             config[args.KEY] = args.VALUE
             if args.report:
-                self.ctx.out('Changed: Set %s:%s' % (args.KEY, args.VALUE))
+                self.ctx.out("Changed: Set %s:%s" % (args.KEY, args.VALUE))
 
     def get_list_value(self, args, config):
         import json
+
         try:
             list_value = json.loads(config[args.KEY])
         except ValueError:
@@ -368,13 +429,15 @@ class PrefsControl(WriteableConfigControl):
     def get_omeroweb_default(self, key):
         try:
             from omeroweb import settings
+
             setting = settings.CUSTOM_SETTINGS_MAPPINGS.get(key)
             default = setting[2](setting[1]) if setting else []
         except Exception as e:
             self.ctx.dbg(traceback.format_exc())
-            self.ctx.die(514,
-                         "Cannot retrieve default value for property %s: %s" %
-                         (key, e))
+            self.ctx.die(
+                514,
+                "Cannot retrieve default value for property %s: %s" % (key, e),
+            )
         if not isinstance(default, list):
             self.ctx.die(515, "Property %s is not a list" % key)
         return default
@@ -382,9 +445,10 @@ class PrefsControl(WriteableConfigControl):
     @with_rw_config
     def append(self, args, config):
         import json
+
         if args.KEY in list(config.keys()):
             list_value = self.get_list_value(args, config)
-        elif args.KEY.startswith('omero.web.'):
+        elif args.KEY.startswith("omero.web."):
             list_value = self.get_omeroweb_default(args.KEY)
         else:
             list_value = []
@@ -393,27 +457,28 @@ class PrefsControl(WriteableConfigControl):
             list_value.append(json.loads(args.VALUE))
             config[args.KEY] = json.dumps(list_value)
             if args.report:
-                self.ctx.out(
-                    'Changed: Appended %s:%s' % (args.KEY, args.VALUE))
+                self.ctx.out("Changed: Appended %s:%s" % (args.KEY, args.VALUE))
 
     @with_rw_config
     def remove(self, args, config):
         if args.KEY not in list(config.keys()):
-            if args.KEY.startswith('omero.web.'):
+            if args.KEY.startswith("omero.web."):
                 list_value = self.get_omeroweb_default(args.KEY)
             else:
                 self.ctx.die(512, "Property %s is not defined" % (args.KEY))
         else:
             list_value = self.get_list_value(args, config)
         import json
+
         if json.loads(args.VALUE) not in list_value:
-            self.ctx.die(513, "%s is not defined in %s"
-                         % (args.VALUE, args.KEY))
+            self.ctx.die(
+                513, "%s is not defined in %s" % (args.VALUE, args.KEY)
+            )
 
         list_value.remove(json.loads(args.VALUE))
         config[args.KEY] = json.dumps(list_value)
         if args.report:
-            self.ctx.out('Changed: Removed %s:%s' % (args.KEY, args.VALUE))
+            self.ctx.out("Changed: Removed %s:%s" % (args.KEY, args.VALUE))
 
     @with_config
     def keys(self, args, config):
@@ -423,6 +488,7 @@ class PrefsControl(WriteableConfigControl):
 
     def parse(self, args):
         from omero.install.config_parser import PropertyParser
+
         pp = PropertyParser()
         if args.file:
             args.file.close()
@@ -439,7 +505,7 @@ class PrefsControl(WriteableConfigControl):
 
         # Parse OMERO.web configuration properties
         if not args.no_web:
-            pp.parse_module('omeroweb.settings')
+            pp.parse_module("omeroweb.settings")
 
         # Display options
         if args.headers:
@@ -464,6 +530,7 @@ class PrefsControl(WriteableConfigControl):
                 if f == "-":
                     # Read from standard input
                     import fileinput
+
                     f = fileinput.input(f)
 
                 try:
@@ -486,16 +553,20 @@ class PrefsControl(WriteableConfigControl):
     @with_rw_config
     def edit(self, args, config, edit_path=edit_path):
         from omero.util.temp_files import create_path, remove_path
+
         start_text = "# Edit your preferences below. Comments are ignored\n"
         for k in sorted(config.keys()):
-            start_text += ("%s=%s\n" % (k, config[k]))
+            start_text += "%s=%s\n" % (k, config[k])
         temp_file = create_path()
         try:
             edit_path(temp_file, start_text)
         except RuntimeError as re:
             self.ctx.dbg(traceback.format_exc())
-            self.ctx.die(954, "%s: Failed to edit %s"
-                         % (getattr(re, "pid", "Unknown"), temp_file))
+            self.ctx.die(
+                954,
+                "%s: Failed to edit %s"
+                % (getattr(re, "pid", "Unknown"), temp_file),
+            )
         args.NAME = config.default()
         old_config = dict(config)
         self.drop(args, config)
@@ -538,8 +609,12 @@ class PrefsControl(WriteableConfigControl):
         MSG = """Manually modify them via "omero config old set ..." and \
 re-run"""
         m = config.as_map()
-        for x in ("keyStore", "keyStorePassword", "trustStore",
-                  "trustStorePassword"):
+        for x in (
+            "keyStore",
+            "keyStorePassword",
+            "trustStore",
+            "trustStorePassword",
+        ):
             old = "omero.ldap." + x
             new = "omero.security." + x
             if old in m:
@@ -554,21 +629,24 @@ re-run"""
             values = values.split(",")
 
         if len(attributes) != len(values):
-            raise ValueError("%s != %s\nLDAP properties in pre-4.2"
-                             " configuration are invalid.\n%s"
-                             % (attributes, values, MSG))
+            raise ValueError(
+                "%s != %s\nLDAP properties in pre-4.2"
+                " configuration are invalid.\n%s" % (attributes, values, MSG)
+            )
         pairs = list(zip(attributes, values))
         if pairs:
             if len(pairs) == 1:
                 user_filter = "(%s=%s)" % (tuple(pairs[0]))
             else:
-                user_filter = "(&%s)" % ["(%s=%s)" % tuple(pair)
-                                         for pair in pairs]
+                user_filter = "(&%s)" % [
+                    "(%s=%s)" % tuple(pair) for pair in pairs
+                ]
             config["omero.ldap.user_filter"] = user_filter
 
         if "omero.ldap.groups" in m:
-            raise ValueError("Not currently handling omero.ldap.groups\n%s"
-                             % MSG)
+            raise ValueError(
+                "Not currently handling omero.ldap.groups\n%s" % MSG
+            )
 
         config["omero.config.upgraded"] = "4.2.0"
 
@@ -595,14 +673,17 @@ re-run"""
 
         if keys and _key in keys and _new != _old:
 
-            self.ctx.die(502, "Duplicate property: %s ('%s' => '%s')"
-                         % (_key, _old, _new))
+            self.ctx.die(
+                502,
+                "Duplicate property: %s ('%s' => '%s')" % (_key, _old, _new),
+            )
             keys.append(_key)
 
         config[_key] = _new
 
     def old(self, args):
         self.ctx.out(getprefs(args.target, str(old_div(self.ctx.dir, "lib"))))
+
 
 try:
     register("config", PrefsControl, HELP)

--- a/src/omero/plugins/script.py
+++ b/src/omero/plugins/script.py
@@ -76,7 +76,6 @@ RE1 = re.compile(r"\s*script\s+upload\s+--official\s*")
 
 
 class ScriptControl(BaseControl):
-
     def _complete(self, text, line, begidx, endidx):
         """
         Returns a file after "upload" and otherwise delegates to the
@@ -85,13 +84,13 @@ class ScriptControl(BaseControl):
         for RE in (RE1, RE0):
             m = RE.match(line)
             if m:
-                replaced = RE.sub('', line)
+                replaced = RE.sub("", line)
                 suggestions = self._complete_file(replaced, os.getcwd())
                 if False:  # line.find("--official") < 0:
                     add = "--official"
                     parts = line.split(" ")
                     if "--official".startswith(parts[-1]):
-                        new = add[len(parts[-1]):]
+                        new = add[len(parts[-1]) :]
                         if new:
                             add = new
                     suggestions.insert(0, add)
@@ -101,9 +100,11 @@ class ScriptControl(BaseControl):
     def _configure(self, parser):
         def _who(parser):
             return parser.add_argument(
-                "who", nargs="*",
+                "who",
+                nargs="*",
                 help="Who to execute for: user, group, user=1, group=5"
-                " (default=official)")
+                " (default=official)",
+            )
 
         parser.add_login_arguments()
         sub = parser.sub()
@@ -112,99 +113,148 @@ class ScriptControl(BaseControl):
         # "Extended help")
 
         demo = parser.add(
-            sub, self.demo,
-            "Runs a short demo of the scripting system")
+            sub, self.demo, "Runs a short demo of the scripting system"
+        )
 
-        list = parser.add(
-            sub, self.list, help="List files for user or group")
+        list = parser.add(sub, self.list, help="List files for user or group")
         _who(list)
 
         cat = parser.add(sub, self.cat, "Prints a script to standard out")
         edit = parser.add(
-            sub, self.edit,
-            "Opens a script in $EDITOR and saves it back to the server")
+            sub,
+            self.edit,
+            "Opens a script in $EDITOR and saves it back to the server",
+        )
         params = parser.add(
-            sub, self.params, help="Print the parameters for a given script")
+            sub, self.params, help="Print the parameters for a given script"
+        )
         launch = parser.add(
-            sub, self.launch, help="Launch a script with parameters")
+            sub, self.launch, help="Launch a script with parameters"
+        )
         disable = parser.add(
-            sub, self.disable,
-            help="Makes script non-executable by setting the mimetype")
+            sub,
+            self.disable,
+            help="Makes script non-executable by setting the mimetype",
+        )
         disable.add_argument(
-            "--mimetype", default="text/plain",
-            help="Use a mimetype other than the default (%(default)s)")
+            "--mimetype",
+            default="text/plain",
+            help="Use a mimetype other than the default (%(default)s)",
+        )
         enable = parser.add(
-            sub, self.enable, help="Makes a script executable (e.g. sets"
-            " mimetype to %s)" % MIMETYPE)
+            sub,
+            self.enable,
+            help="Makes a script executable (e.g. sets"
+            " mimetype to %s)" % MIMETYPE,
+        )
         enable.add_argument(
-            "--mimetype", default=MIMETYPE,
-            help="Use a mimetype other than the default (%(default)s)")
+            "--mimetype",
+            default=MIMETYPE,
+            help="Use a mimetype other than the default (%(default)s)",
+        )
         replace = parser.add(
-            sub, self.replace,
-            help="Replace an existing script with a new value")
+            sub,
+            self.replace,
+            help="Replace an existing script with a new value",
+        )
 
         for x in (launch, params, cat, disable, enable, edit, replace):
             x.add_argument(
                 "original_file",
-                help="Id or path of a script file stored in OMERO")
+                help="Id or path of a script file stored in OMERO",
+            )
         launch.add_argument(
-            "input", nargs="*",
-            help="Inputs for the script of the form 'param=value'")
+            "input",
+            nargs="*",
+            help="Inputs for the script of the form 'param=value'",
+        )
 
         jobs = parser.add(
-            sub, self.jobs, help="List current jobs for user or group")
+            sub, self.jobs, help="List current jobs for user or group"
+        )
         jobs.add_argument(
-            "--all", action="store_true",
-            help="Show all jobs, not just running ones")
+            "--all",
+            action="store_true",
+            help="Show all jobs, not just running ones",
+        )
         _who(jobs)
 
         serve = parser.add(
-            sub, self.serve,
-            help="Start a usermode processor for scripts")
+            sub, self.serve, help="Start a usermode processor for scripts"
+        )
         serve.add_argument(
-            "--verbose", action="store_true",
-            help="Enable debug logging on processor")
+            "--verbose",
+            action="store_true",
+            help="Enable debug logging on processor",
+        )
         serve.add_argument(
-            "-b", "--background", action="store_true",
-            help="Run processor in background. Used in demo")
+            "-b",
+            "--background",
+            action="store_true",
+            help="Run processor in background. Used in demo",
+        )
         serve.add_argument(
-            "-t", "--timeout", default=0, type=int,
-            help="Seconds that the processor should run. 0 means no timeout")
+            "-t",
+            "--timeout",
+            default=0,
+            type=int,
+            help="Seconds that the processor should run. 0 means no timeout",
+        )
         _who(serve)
 
         upload = parser.add(sub, self.upload, help="Upload a script")
         upload.add_argument(
-            "--official", action="store_true",
-            help="If set, creates a system script. Must be an admin")
-        upload.add_argument(
-            "file", help="Local script file to upload to OMERO")
+            "--official",
+            action="store_true",
+            help="If set, creates a system script. Must be an admin",
+        )
+        upload.add_argument("file", help="Local script file to upload to OMERO")
 
         replace.add_argument(
-            "file",
-            help="Local script which should overwrite the existing one")
+            "file", help="Local script which should overwrite the existing one"
+        )
 
-        delete = parser.add(
-            sub, self.delete, help="delete an existing script")
+        delete = parser.add(sub, self.delete, help="delete an existing script")
         delete.add_argument(
-            "id", type=int,
-            help="Id of the original file which is to be deleted")
+            "id",
+            type=int,
+            help="Id of the original file which is to be deleted",
+        )
 
         run = parser.add(
-            sub, self.run,
+            sub,
+            self.run,
             help="Run a script with the OMERO libraries loaded and current"
-            " login")
+            " login",
+        )
         run.add_argument("file", help="Local script file to run")
         run.add_argument(
-            "input", nargs="*",
-            help="Inputs for the script of the form 'param=value'")
+            "input",
+            nargs="*",
+            help="Inputs for the script of the form 'param=value'",
+        )
 
         # log = parser.add(sub, self.log, help = "TBD", tbd="TRUE")
-        for x in (demo, cat, edit, params, launch, disable, enable, jobs,
-                  serve, upload, replace, delete, run):
+        for x in (
+            demo,
+            cat,
+            edit,
+            params,
+            launch,
+            disable,
+            enable,
+            jobs,
+            serve,
+            upload,
+            replace,
+            delete,
+            run,
+        ):
             x.add_login_arguments()
 
     def help(self, args):
-        self.ctx.out("""
+        self.ctx.out(
+            """
 
         Available or planned(*) commands:
         ================================
@@ -281,10 +331,12 @@ class ScriptControl(BaseControl):
         #
 
         run
-        """)
+        """
+        )
 
     def demo(self, args):
         from omero.util.temp_files import create_path
+
         t = create_path("Demo_Script", ".py")
 
         try:
@@ -293,36 +345,40 @@ class ScriptControl(BaseControl):
             from sha import new as sha_new
 
         digest = sha_new()
-        digest.update(DEMO_SCRIPT.encode('utf-8'))
+        digest.update(DEMO_SCRIPT.encode("utf-8"))
         sha1 = digest.hexdigest()
 
         self.ctx.out("\nExample script writing session")
-        self.ctx.out("="*80)
+        self.ctx.out("=" * 80)
 
         def msg(title, method=None, *arguments):
             self.ctx.out("\n")
-            self.ctx.out("\t+" + ("-"*68) + "+")
+            self.ctx.out("\t+" + ("-" * 68) + "+")
             title = "\t| %-66.66s | " % title
             self.ctx.out(title)
             if method:
                 cmd = "%s %s" % (method.__name__, " ".join(arguments))
                 cmd = "\t| COMMAND: omero script %-40.40s | " % cmd
                 self.ctx.out(cmd)
-            self.ctx.out("\t+" + ("-"*68) + "+")
+            self.ctx.out("\t+" + ("-" * 68) + "+")
             self.ctx.out(" ")
             if method:
                 try:
-                    self.ctx.invoke(['script', method.__name__] +
-                                    list(arguments))
+                    self.ctx.invoke(
+                        ["script", method.__name__] + list(arguments)
+                    )
                 except Exception as e:
                     import traceback
+
                     self.ctx.out("\nEXECUTION FAILED: %s" % e)
                     self.ctx.dbg(traceback.format_exc())
 
         client = self.ctx.conn(args)
         current_user = self.ctx.get_event_context().userId
-        query = "select o from OriginalFile o where o.hash = '%s' and" \
+        query = (
+            "select o from OriginalFile o where o.hash = '%s' and"
             " o.details.owner.id = %s" % (sha1, current_user)
+        )
         files = client.sf.getQueryService().findAllByQuery(query, None)
         if len(files) == 0:
             msg("Saving demo script to %s" % t)
@@ -336,16 +392,37 @@ class ScriptControl(BaseControl):
 
         msg("Listing available scripts for user", self.list, "user")
         msg("Printing script content for file %s" % id, self.cat, str(id))
-        msg("Serving file %s in background" % id, self.serve, "user",
-            "--background")
-        msg("Printing script params for file %s" % id, self.params,
-            "file=%s" % id)
-        msg("Launching script with parameters: a=bad-string (fails)",
-            self.launch, "file=%s" % id, "a=bad-string")
-        msg("Launching script with parameters: a=bad-string opt=6 (fails)",
-            self.launch, "file=%s" % id, "a=bad-string", "opt=6")
-        msg("Launching script with parameters: a=foo opt=1 (passes)",
-            self.launch, "file=%s" % id, "a=foo", "opt=1")
+        msg(
+            "Serving file %s in background" % id,
+            self.serve,
+            "user",
+            "--background",
+        )
+        msg(
+            "Printing script params for file %s" % id,
+            self.params,
+            "file=%s" % id,
+        )
+        msg(
+            "Launching script with parameters: a=bad-string (fails)",
+            self.launch,
+            "file=%s" % id,
+            "a=bad-string",
+        )
+        msg(
+            "Launching script with parameters: a=bad-string opt=6 (fails)",
+            self.launch,
+            "file=%s" % id,
+            "a=bad-string",
+            "opt=6",
+        )
+        msg(
+            "Launching script with parameters: a=foo opt=1 (passes)",
+            self.launch,
+            "file=%s" % id,
+            "a=foo",
+            "opt=1",
+        )
         try:
             for p in list(getattr(self, "_processors", [])):
                 p.cleanup()
@@ -379,6 +456,7 @@ class ScriptControl(BaseControl):
                 return
             from omero.util.temp_files import create_path
             from omero.util import edit_path
+
             p = create_path()
             edit_path(p, txt)
             scriptSvc.editScript(ofile, p.text())
@@ -388,8 +466,9 @@ class ScriptControl(BaseControl):
     def jobs(self, args):
         self.ctx.conn(args)
         cols = ("username", "groupname", "started", "finished")
-        query = "select j, %s, s.value from Job j join j.status s" \
-            % (",".join(["j.%s" % j for j in cols]))
+        query = "select j, %s, s.value from Job j join j.status s" % (
+            ",".join(["j.%s" % j for j in cols])
+        )
         if not args.all:
             query += " where j.finished is null"
 
@@ -406,6 +485,7 @@ class ScriptControl(BaseControl):
         import omero
         import omero.scripts
         import omero.rtypes
+
         svc = client.sf.getScriptService()
         try:
             params = svc.getParams(script_id)
@@ -445,8 +525,7 @@ class ScriptControl(BaseControl):
 
             f = rv.get(m, None)
             if f and f.val:
-                self.ctx.out("\n\t*** start %s (id=%s)***"
-                             % (m, f.val.id.val))
+                self.ctx.out("\n\t*** start %s (id=%s)***" % (m, f.val.id.val))
                 try:
                     client.download(ofile=f.val, filehandle=handle())
                 except Exception:
@@ -482,6 +561,7 @@ class ScriptControl(BaseControl):
         client = self.ctx.conn(args)
         script_id, ofile = self._file(args, client)
         import omero
+
         svc = client.sf.getScriptService()
 
         try:
@@ -497,8 +577,9 @@ class ScriptControl(BaseControl):
             self.ctx.out("name:  %s" % job_params.name)
             self.ctx.out("version:  %s" % job_params.version)
             self.ctx.out("authors:  %s" % ", ".join(job_params.authors))
-            self.ctx.out("institutions:  %s"
-                         % ", ".join(job_params.institutions))
+            self.ctx.out(
+                "institutions:  %s" % ", ".join(job_params.institutions)
+            )
             self.ctx.out("description:  %s" % job_params.description)
             self.ctx.out("namespaces:  %s" % ", ".join(job_params.namespaces))
             self.ctx.out("stdout:  %s" % job_params.stdoutFormat)
@@ -506,12 +587,23 @@ class ScriptControl(BaseControl):
 
             def print_params(which, params):
                 import omero
+
                 self.ctx.out(which)
-                for k in sorted(params,
-                                key=lambda name: params.get(name).grouping):
+                for k in sorted(
+                    params, key=lambda name: params.get(name).grouping
+                ):
                     v = params.get(k)
-                    self.ctx.out("  %s - %s" % (k, (v.description and
-                                 v.description or "(no description)")))
+                    self.ctx.out(
+                        "  %s - %s"
+                        % (
+                            k,
+                            (
+                                v.description
+                                and v.description
+                                or "(no description)"
+                            ),
+                        )
+                    )
                     self.ctx.out("    Optional: %s" % v.optional)
                     self.ctx.out("    Type: %s" % v.prototype.ice_staticId())
                     if isinstance(v.prototype, omero.RCollection):
@@ -519,13 +611,15 @@ class ScriptControl(BaseControl):
                         if len(coll) == 0:
                             self.ctx.out("    Subtype: (empty)")
                         else:
-                            self.ctx.out("    Subtype: %s"
-                                         % coll[0].ice_staticId())
+                            self.ctx.out(
+                                "    Subtype: %s" % coll[0].ice_staticId()
+                            )
 
                     elif isinstance(v.prototype, omero.RMap):
                         try:
-                            proto_value = \
-                                v.prototype.val.values[0].ice_staticId()
+                            proto_value = v.prototype.val.values[
+                                0
+                            ].ice_staticId()
                         except Exception:
                             proto_value = None
 
@@ -545,8 +639,10 @@ class ScriptControl(BaseControl):
                     self.ctx.out("    Min: %s" % min_max(v.min))
                     self.ctx.out("    Max: %s" % min_max(v.max))
                     values = omero.rtypes.unwrap(v.values)
-                    self.ctx.out("    Values: %s"
-                                 % (values and ", ".join(values) or ""))
+                    self.ctx.out(
+                        "    Values: %s" % (values and ", ".join(values) or "")
+                    )
+
             print_params("inputs:", job_params.inputs)
             print_params("outputs:", job_params.outputs)
 
@@ -566,6 +662,7 @@ class ScriptControl(BaseControl):
 
         # Similar to omero.util.Server starting here
         import logging
+
         original = list(logging._handlerList)
         roots = list(logging.getLogger().handlers)
         logging._handlerList = []
@@ -573,23 +670,29 @@ class ScriptControl(BaseControl):
 
         from omero.util import configure_logging
         from omero.processor import usermode_processor
+
         lvl = debug and 10 or 20
         configure_logging(loglevel=lvl)
 
         try:
             try:
                 impl = usermode_processor(
-                    client, serverid="omero.scripts.serve", accepts_list=who,
-                    omero_home=self.ctx.dir)
+                    client,
+                    serverid="omero.scripts.serve",
+                    accepts_list=who,
+                    omero_home=self.ctx.dir,
+                )
                 self._processors.append(impl)
             except Exception as e:
                 self.ctx.die(100, "Failed initialization: %s" % e)
 
             if background:
+
                 def cleanup():
                     impl.cleanup()
                     logging._handlerList = original
                     logging.getLogger().handlers = roots
+
                 atexit.register(cleanup)
             else:
                 if self._isWindows():
@@ -643,6 +746,7 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
             self.ctx.die(502, "File does not exist: %s" % p.abspath())
 
         import omero
+
         c = self.ctx.conn(args)
         scriptSvc = c.sf.getScriptService()
 
@@ -651,8 +755,11 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
                 id = scriptSvc.uploadOfficialScript(args.file, p.text())
             except omero.ApiUsageException as aue:
                 if "editScript" in aue.message:
-                    self.ctx.die(502, "%s already exists; use 'replace'"
-                                 " instead" % args.file)
+                    self.ctx.die(
+                        502,
+                        "%s already exists; use 'replace'"
+                        " instead" % args.file,
+                    )
                 else:
                     self.ctx.die(504, "ApiUsageException: %s" % aue.message)
             except omero.SecurityViolation as sv:
@@ -660,13 +767,15 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
         else:
             id = scriptSvc.uploadScript(args.file, p.text())
 
-        self.ctx.err("Uploaded %sscript"
-                     % (args.official and "official " or ""))
+        self.ctx.err(
+            "Uploaded %sscript" % (args.official and "official " or "")
+        )
         self.ctx.out("OriginalFile:%s" % id)
         self.ctx.set("script.file.id", id)
 
     def replace(self, args):
         import omero
+
         client = self.ctx.conn(args)
         script_id, ofile = self._file(args, client)
         fpath = args.file
@@ -691,16 +800,21 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
 
     def disable(self, args):
         ofile = self.setmimetype(args)
-        self.ctx.out("Disabled %s by setting mimetype to %s"
-                     % (ofile.id.val, args.mimetype))
+        self.ctx.out(
+            "Disabled %s by setting mimetype to %s"
+            % (ofile.id.val, args.mimetype)
+        )
 
     def enable(self, args):
         ofile = self.setmimetype(args)
-        self.ctx.out("Enabled %s by setting mimetype to %s"
-                     % (ofile.id.val, args.mimetype))
+        self.ctx.out(
+            "Enabled %s by setting mimetype to %s"
+            % (ofile.id.val, args.mimetype)
+        )
 
     def setmimetype(self, args):
         from omero.rtypes import rstring
+
         client = self.ctx.conn(args)
         script_id, ofile = self._file(args, client)
         if args.mimetype == MIMETYPE:  # is default
@@ -725,6 +839,7 @@ http://stackoverflow.com/questions/3471461/raw-input-and-timeout/3911560
 
             from omero.scripts import parse_file
             from omero.util.temp_files import create_path
+
             path = create_path()
             text = """
 omero.host=%(omero.host)s
@@ -739,8 +854,12 @@ omero.pass=%(omero.sess)s
                 if v is not None:
                     client.setInput(k, v)
 
-            p = self.ctx.popen([sys.executable, args.file], stdout=sys.stdout,
-                               stderr=sys.stderr, ICE_CONFIG=str(path))
+            p = self.ctx.popen(
+                [sys.executable, args.file],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                ICE_CONFIG=str(path),
+            )
             p.wait()
             if p.poll() != 0:
                 self.ctx.die(p.poll(), "Execution failed.")
@@ -750,13 +869,15 @@ omero.pass=%(omero.sess)s
     #
     def _parse_inputs(self, args, params):
         from omero.scripts import parse_inputs, parse_input, MissingInputs
+
         try:
             rv = parse_inputs(args.input, params)
         except MissingInputs as mi:
             rv = mi.inputs
             for key in mi.keys:
-                value = self.ctx.input("""Enter value for "%s": """ % key,
-                                       required=True)
+                value = self.ctx.input(
+                    """Enter value for "%s": """ % key, required=True
+                )
                 rv.update(parse_input("%s=%s" % (key, value), params))
         return rv
 
@@ -765,6 +886,7 @@ omero.pass=%(omero.sess)s
         Parses a list of scripts to self.ctx.out
         """
         from omero.util.text import TableBuilder
+
         tb = TableBuilder("id", msg)
         for x in scripts:
             tb.row(x.id.val, x.path.val + x.name.val)
@@ -795,10 +917,15 @@ omero.pass=%(omero.sess)s
         """
 
         import omero
-        WHO_FACTORY = {"user": omero.model.ExperimenterI,
-                       "group": omero.model.ExperimenterGroupI}
-        WHO_CURRENT = {"user": lambda ec: ec.userId,
-                       "group": lambda ec: ec.groupId}
+
+        WHO_FACTORY = {
+            "user": omero.model.ExperimenterI,
+            "group": omero.model.ExperimenterGroupI,
+        }
+        WHO_CURRENT = {
+            "user": lambda ec: ec.userId,
+            "group": lambda ec: ec.groupId,
+        }
 
         for key, factory in list(WHO_FACTORY.items()):
             if who.startswith(key):

--- a/src/omero/plugins/search.py
+++ b/src/omero/plugins/search.py
@@ -42,41 +42,53 @@ See also:
 
 
 class SearchControl(HqlControl):
-
     def _configure(self, parser):
         parser.add_argument(
-            "--index", action="store_true", default=False,
-            help="Index an object as a administrator")
+            "--index",
+            action="store_true",
+            default=False,
+            help="Index an object as a administrator",
+        )
         parser.add_argument(
             "--no-parse",
             action="store_true",
-            help="Pass the search string directly to Lucene with no parsing")
+            help="Pass the search string directly to Lucene with no parsing",
+        )
         parser.add_argument(
-            "--field", nargs="*",
+            "--field",
+            nargs="*",
             default=(),
-            help=("Fields which should be searched "
-                  "(e.g. name, description, annotation)"))
+            help=(
+                "Fields which should be searched "
+                "(e.g. name, description, annotation)"
+            ),
+        )
         parser.add_argument(
             "--from",
             dest="_from",
             metavar="YYYY-MM-DD",
             type=self.date,
-            help="Start date for limiting searches (YYYY-MM-DD)")
+            help="Start date for limiting searches (YYYY-MM-DD)",
+        )
         parser.add_argument(
             "--to",
             dest="_to",
             metavar="YYYY-MM-DD",
             type=self.date,
-            help="End date for limiting searches (YYYY-MM-DD)")
+            help="End date for limiting searches (YYYY-MM-DD)",
+        )
         parser.add_argument(
             "--date-type",
             default="import",
             choices=("acquisitionDate", "import"),
-            help=("Which field to use for --from/--to "
-                  "(default: acquisitionDate)"))
+            help=(
+                "Which field to use for --from/--to "
+                "(default: acquisitionDate)"
+            ),
+        )
         parser.add_argument(
-            "type",
-            help="Object type to search for, e.g. 'Image' or 'Well'")
+            "type", help="Object type to search for, e.g. 'Image' or 'Well'"
+        )
         HqlControl._configure(self, parser)
         parser.set_defaults(func=self.search)
 
@@ -136,11 +148,16 @@ class SearchControl(HqlControl):
                                 args.date_type = "details.creationEvent.time"
                             search.byLuceneQueryBuilder(
                                 ",".join(args.field),
-                                args._from, args._to, args.date_type,
-                                args.query, ctx)
+                                args._from,
+                                args._to,
+                                args.date_type,
+                                args.query,
+                                ctx,
+                            )
                         except OperationNotExistException:
                             self.ctx.err(
-                                "Server does not support byLuceneQueryBuilder")
+                                "Server does not support byLuceneQueryBuilder"
+                            )
                             search.byFullText(args.query)
 
                     if not search.hasNext(ctx):
@@ -153,9 +170,9 @@ class SearchControl(HqlControl):
                         results = [[x] for x in results]
                         if not args.ids_only:
                             results = [[robject(x[0])] for x in results]
-                        self.display(results,
-                                     style=args.style,
-                                     idsonly=args.ids_only)
+                        self.display(
+                            results, style=args.style, idsonly=args.ids_only
+                        )
                 except omero.ApiUsageException as aue:
                     self.ctx.die(434, aue.message)
 

--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -170,21 +170,26 @@ class SessionsControl(UserGroupControl):
             if base_dir:
                 warnings.warn(
                     "--session-dir is deprecated. Use OMERO_SESSIONDIR"
-                    " instead.", DeprecationWarning)
+                    " instead.",
+                    DeprecationWarning,
+                )
 
             # Read base directory from deprecated OMERO_SESSION_DIR envvar
-            base_dir = os.environ.get('OMERO_SESSION_DIR', base_dir)
-            if 'OMERO_SESSION_DIR' in os.environ:
+            base_dir = os.environ.get("OMERO_SESSION_DIR", base_dir)
+            if "OMERO_SESSION_DIR" in os.environ:
                 warnings.warn(
                     "OMERO_SESSION_DIR is deprecated. Use OMERO_SESSIONDIR"
-                    " instead.", DeprecationWarning)
+                    " instead.",
+                    DeprecationWarning,
+                )
 
             # Read sessions directory from OMERO_SESSIONDIR envvar
             session_dir = None
             if base_dir:
                 from omero_ext.path import path
+
                 session_dir = path(base_dir) / "omero" / "sessions"
-            sessions_dir = os.environ.get('OMERO_SESSIONDIR', session_dir)
+            sessions_dir = os.environ.get("OMERO_SESSIONDIR", session_dir)
 
             return self.FACTORY(sessions_dir)
         except OSError as ose:
@@ -195,87 +200,121 @@ class SessionsControl(UserGroupControl):
         parser.add_login_arguments()
         sub = parser.sub()
         parser.add(sub, self.help, "Extended help")
-        login = parser.add(
-            sub, self.login, self.login.__doc__)
+        login = parser.add(sub, self.login, self.login.__doc__)
         logout = parser.add(
-            sub, self.logout, "Logout and remove current session key")
+            sub, self.logout, "Logout and remove current session key"
+        )
         self._configure_login(login)
 
         group = parser.add(
-            sub, self.group,
-            "Set the group of the given session by id or name" + GROUPHELP)
+            sub,
+            self.group,
+            "Set the group of the given session by id or name" + GROUPHELP,
+        )
         group.add_argument(
             "target",
             nargs="?",
-            help="Id or name of the group to switch this session to")
+            help="Id or name of the group to switch this session to",
+        )
 
         timeout = parser.add(
-            sub, self.timeout,
-            "Query or set the timeToIdle for the given session")
+            sub,
+            self.timeout,
+            "Query or set the timeToIdle for the given session",
+        )
         timeout.add_argument(
             "seconds",
             nargs="?",
             type=int,
-            help="Number of seconds to set the timeToIdle value to")
+            help="Number of seconds to set the timeToIdle value to",
+        )
         timeout.add_argument(
-            "--session",
-            help="Session other than the current to update")
+            "--session", help="Session other than the current to update"
+        )
 
-        list = parser.add(sub, self.list, (
-            "List all available sessions stored locally\n\n" + LISTHELP))
+        list = parser.add(
+            sub,
+            self.list,
+            ("List all available sessions stored locally\n\n" + LISTHELP),
+        )
         list.add_argument(
-            "--no-purge", dest="purge", action="store_false",
-            help="Do not remove inactive sessions")
+            "--no-purge",
+            dest="purge",
+            action="store_false",
+            help="Do not remove inactive sessions",
+        )
 
-        who = parser.add(sub, self.who, (
-            "List all active server sessions\n\n" + WHOHELP))
+        who = parser.add(
+            sub, self.who, ("List all active server sessions\n\n" + WHOHELP)
+        )
         who.add_argument(
-            "--show-uuid", help="Show uuids for sessions",
-            action="store_true")
-
+            "--show-uuid", help="Show uuids for sessions", action="store_true"
+        )
 
         keepalive = parser.add(
-            sub, self.keepalive, "Keeps the current session alive")
+            sub, self.keepalive, "Keeps the current session alive"
+        )
         keepalive.add_argument(
-            "-f", "--frequency", type=int, default=60,
-            help="Time in seconds between keep alive calls", metavar="SECS")
+            "-f",
+            "--frequency",
+            type=int,
+            default=60,
+            help="Time in seconds between keep alive calls",
+            metavar="SECS",
+        )
 
         clear = parser.add(
-            sub, self.clear, "Close and remove locally stored sessions")
+            sub, self.clear, "Close and remove locally stored sessions"
+        )
         clear.add_argument(
-            "--all", action="store_true",
-            help="Remove all locally stored sessions not just inactive ones")
+            "--all",
+            action="store_true",
+            help="Remove all locally stored sessions not just inactive ones",
+        )
 
         file = parser.add(
-            sub, self.file, "Print the path to the current session file")
+            sub, self.file, "Print the path to the current session file"
+        )
 
         key = parser.add(
-            sub, self.key, "Print the key of the current active session")
+            sub, self.key, "Print the key of the current active session"
+        )
 
         for x in (file, key, logout, keepalive, list, clear, group):
             self._configure_dir(x)
 
-        open = parser.add(sub, self.open, "Create a session for "
-                                          "the given user and group")
+        open = parser.add(
+            sub, self.open, "Create a session for " "the given user and group"
+        )
         self.add_single_user_argument(open)
         self.add_single_group_argument(open, required=False)
-        open.add_argument("--timeout", nargs="?", type=int, default=0,
-                          help="Timeout in seconds (optional; default: "
-                               "maximum possible)")
+        open.add_argument(
+            "--timeout",
+            nargs="?",
+            type=int,
+            default=0,
+            help="Timeout in seconds (optional; default: " "maximum possible)",
+        )
 
-        close = parser.add(sub, self.close, "Close the session with "
-                                            "the given session ID")
+        close = parser.add(
+            sub, self.close, "Close the session with " "the given session ID"
+        )
         close.add_argument("sessionId", nargs="?", help="The session ID")
 
     def _configure_login(self, login):
         login.add_login_arguments()
         login.add_argument(
-            "-t", "--timeout", type=int,
+            "-t",
+            "--timeout",
+            type=int,
             help="Timeout for session. After this many inactive seconds, the"
-            " session will be closed")
+            " session will be closed",
+        )
         login.add_argument(
-            "connection", nargs="?",
-            help="Connection string. See extended help for examples")
+            "connection",
+            nargs="?",
+            help="Connection string. See extended help for examples",
+        )
         self._configure_dir(login)
 
     def _configure_dir(self, parser):
@@ -303,8 +342,7 @@ class SessionsControl(UserGroupControl):
             p.group = groupname
         p.eventType = "User"
         svc = client.sf.getSessionService()
-        sess = svc.createSessionWithTimeout(p, (int(args.timeout)
-                                                * 1000))
+        sess = svc.createSessionWithTimeout(p, (int(args.timeout) * 1000))
         sessId = sess.getUuid().val
         tti = old_div(sess.getTimeToIdle().val, 1000)
         ttl = old_div(sess.getTimeToLive().val, 1000)
@@ -331,20 +369,22 @@ class SessionsControl(UserGroupControl):
             self.ctx.out("Session %s closed." % args.sessionId)
 
     def login(self, args):
-        ("Login to a given server, and store session key locally.\n\n"
-         "USER, HOST, and PORT are set as args or in a ssh-style "
-         "connection string.\n"
-         "PASSWORD can be entered interactively, or passed via "
-         "-w (insecure!).\n"
-         "Alternatively, a session KEY can be passed with '-k'.\n"
-         "Admin users can use --sudo=ADMINUSER to login for others.\n\n"
-         "Examples:\n"
-         "  omero login example.com\n"
-         "  omero login user@example.com\n"
-         "  omero login user@example.com:24064\n"
-         "  omero login -k SESSIONKEY example.com\n"
-         "  omero login --sudo=root user@example\n"
-         "\n")
+        (
+            "Login to a given server, and store session key locally.\n\n"
+            "USER, HOST, and PORT are set as args or in a ssh-style "
+            "connection string.\n"
+            "PASSWORD can be entered interactively, or passed via "
+            "-w (insecure!).\n"
+            "Alternatively, a session KEY can be passed with '-k'.\n"
+            "Admin users can use --sudo=ADMINUSER to login for others.\n\n"
+            "Examples:\n"
+            "  omero login example.com\n"
+            "  omero login user@example.com\n"
+            "  omero login user@example.com:24064\n"
+            "  omero login -k SESSIONKEY example.com\n"
+            "  omero login --sudo=root user@example\n"
+            "\n"
+        )
 
         """
         Goals:
@@ -379,8 +419,10 @@ class SessionsControl(UserGroupControl):
 
         if args.server:
             if server:
-                self.ctx.die(3, "Server specified twice: %s and %s"
-                             % (server, args.server))
+                self.ctx.die(
+                    3,
+                    "Server specified twice: %s and %s" % (server, args.server),
+                )
             else:
                 server = args.server
 
@@ -389,15 +431,17 @@ class SessionsControl(UserGroupControl):
 
         if args.user:
             if name:
-                self.ctx.die(4, "Username specified twice: %s and %s"
-                             % (name, args.user))
+                self.ctx.die(
+                    4, "Username specified twice: %s and %s" % (name, args.user)
+                )
             else:
                 name = args.user
 
         if args.port:
             if port:
-                self.ctx.die(5, "Port specified twice: %s and %s"
-                             % (port, args.port))
+                self.ctx.die(
+                    5, "Port specified twice: %s and %s" % (port, args.port)
+                )
             else:
                 port = args.port
 
@@ -424,44 +468,58 @@ class SessionsControl(UserGroupControl):
         #
         elif previous[0] and previous[1]:
 
-                server_differs = (server is not None and server != previous[0])
-                name_differs = (name is not None and name != previous[1])
-                port_differs = (port is not None and port != previous[3])
+            server_differs = server is not None and server != previous[0]
+            name_differs = name is not None and name != previous[1]
+            port_differs = port is not None and port != previous[3]
 
-                if not create and not server_differs and not name_differs \
-                        and not port_differs:
+            if (
+                not create
+                and not server_differs
+                and not name_differs
+                and not port_differs
+            ):
+                try:
+                    if previous[2] is not None:
+                        # Missing session uuid file. Deleted? See #4199
+                        conflicts = store.conflicts(
+                            previous[0], previous[1], previous[2], props, True
+                        )
+                        if conflicts:
+                            self.ctx.dbg(
+                                "Not attaching because of"
+                                " conflicts: %s" % conflicts
+                            )
+                        else:
+                            rv = store.attach(*previous[:-1])
+                            return self.handle(rv, "Using")
+                    if not self.ctx.isquiet:
+                        self.ctx.out(
+                            "Previously logged in to %s:%s as %s"
+                            % (previous[0], previous[3], previous[1])
+                        )
+                except Exception as e:
+                    self.ctx.out(
+                        "Previous session expired for %s on"
+                        " %s:%s" % (previous[1], previous[0], previous[3])
+                    )
+                    self.ctx.dbg(
+                        "Exception on attach: %s"
+                        % traceback.format_exception(None, e, sys.exc_info()[2])
+                    )
                     try:
-                        if previous[2] is not None:
-                            # Missing session uuid file. Deleted? See #4199
-                            conflicts = store.conflicts(
-                                previous[0], previous[1], previous[2], props,
-                                True)
-                            if conflicts:
-                                self.ctx.dbg("Not attaching because of"
-                                             " conflicts: %s" % conflicts)
-                            else:
-                                rv = store.attach(*previous[:-1])
-                                return self.handle(rv, "Using")
-                        if not self.ctx.isquiet:
-                            self.ctx.out("Previously logged in to %s:%s as %s"
-                                         % (previous[0], previous[3],
-                                            previous[1]))
-                    except Exception as e:
-                        self.ctx.out("Previous session expired for %s on"
-                                     " %s:%s" % (previous[1], previous[0],
-                                                 previous[3]))
-                        self.ctx.dbg("Exception on attach: %s"
-                                     % traceback.format_exception(None, e, sys.exc_info()[2]))
-                        try:
-                            store.remove(*previous[:-1])
-                        except OSError as ose:
-                            self.ctx.dbg("Session file missing: %s" % ose)
-                        except:
-                            self.ctx.dbg("Exception on remove: %s"
-                                         % traceback.format_exception(None, e, sys.exc_info()[2]))
-                            # Could tell user to manually clear here and then
-                            # self.ctx.die()
-                            self.ctx.err("Failed to remove session: %s" % e)
+                        store.remove(*previous[:-1])
+                    except OSError as ose:
+                        self.ctx.dbg("Session file missing: %s" % ose)
+                    except:
+                        self.ctx.dbg(
+                            "Exception on remove: %s"
+                            % traceback.format_exception(
+                                None, e, sys.exc_info()[2]
+                            )
+                        )
+                        # Could tell user to manually clear here and then
+                        # self.ctx.die()
+                        self.ctx.err("Failed to remove session: %s" % e)
 
         #
         # If we've reached here, then the user either does not have
@@ -494,11 +552,24 @@ class SessionsControl(UserGroupControl):
                 # did not come from a CLI login, and so we're not going to
                 # modify the value returned by store.get_current()
                 self.ctx.dbg("No local session file found for %s." % args.key)
-                rv = self.attach(store, server, args.key, args.key, props,
-                                 False, set_current=False)
+                rv = self.attach(
+                    store,
+                    server,
+                    args.key,
+                    args.key,
+                    props,
+                    False,
+                    set_current=False,
+                )
             else:
-                rv = self.check_and_attach(store, server, stored_name,
-                                           args.key, props, check_group=False)
+                rv = self.check_and_attach(
+                    store,
+                    server,
+                    stored_name,
+                    args.key,
+                    props,
+                    check_group=False,
+                )
             action = "Joined"
             if not rv:
                 if port:
@@ -509,8 +580,9 @@ class SessionsControl(UserGroupControl):
         elif not create:
             available = store.available(server, name)
             for uuid in available:
-                rv = self.check_and_attach(store, server, name, uuid, props,
-                                           check_group=True)
+                rv = self.check_and_attach(
+                    store, server, name, uuid, props, check_group=True
+                )
                 action = "Reconnected to"
 
         if not rv:
@@ -529,8 +601,9 @@ class SessionsControl(UserGroupControl):
                             prompt = "Password for %s:" % args.sudo
                         else:
                             prompt = "Password:"
-                        pasw = self.ctx.input(prompt, hidden=True,
-                                              required=True)
+                        pasw = self.ctx.input(
+                            prompt, hidden=True, required=True
+                        )
                     rv = store.create(name, pasw, props, sudo=args.sudo)
                     break
                 except PermissionDeniedException as pde:
@@ -544,27 +617,36 @@ class SessionsControl(UserGroupControl):
                     self.ctx.die(525, "User account error: %s." % rse.message)
                 except Ice.ConnectionRefusedException:
                     if port:
-                        self.ctx.die(554, "Ice.ConnectionRefusedException:"
-                                     " %s:%s isn't running" % (server, port))
+                        self.ctx.die(
+                            554,
+                            "Ice.ConnectionRefusedException:"
+                            " %s:%s isn't running" % (server, port),
+                        )
                     else:
-                        self.ctx.die(554, "Ice.ConnectionRefusedException: %s"
-                                     " isn't running" % server)
+                        self.ctx.die(
+                            554,
+                            "Ice.ConnectionRefusedException: %s"
+                            " isn't running" % server,
+                        )
                 except Ice.DNSException:
-                    self.ctx.die(555, "Ice.DNSException: bad host name: '%s'"
-                                 % server)
+                    self.ctx.die(
+                        555, "Ice.DNSException: bad host name: '%s'" % server
+                    )
                 except omero.SecurityViolation as sv:
                     self.ctx.die(557, "SecurityViolation: %s" % sv.message)
                 except Exception as e:
                     exc = traceback.format_exc()
                     self.ctx.dbg(exc)
-                    self.ctx.die(556, "InternalException: Failed to connect:"
-                                 " %s" % e)
+                    self.ctx.die(
+                        556, "InternalException: Failed to connect:" " %s" % e
+                    )
             action = "Created"
 
         return self.handle(rv, action)
 
-    def check_and_attach(self, store, server, name, uuid, props,
-                         check_group=False):
+    def check_and_attach(
+        self, store, server, name, uuid, props, check_group=False
+    ):
         """
         Checks for conflicts in the settings for this session,
         and if there are none, then attempts an "attach()". If
@@ -574,21 +656,27 @@ class SessionsControl(UserGroupControl):
         exists = store.exists(server, name, uuid)
 
         if exists:
-            conflicts = store.conflicts(server, name, uuid, props,
-                                        check_group=check_group)
+            conflicts = store.conflicts(
+                server, name, uuid, props, check_group=check_group
+            )
             if conflicts:
                 if "omero.port" in conflicts:
-                    self.ctx.dbg("Skipping session %s due to mismatching"
-                                 " ports: %s " % (uuid, conflicts))
+                    self.ctx.dbg(
+                        "Skipping session %s due to mismatching"
+                        " ports: %s " % (uuid, conflicts)
+                    )
                 elif not self.ctx.isquiet:
-                    self.ctx.err("Skipped session %s due to property"
-                                 " conflicts: %s" % (uuid, conflicts))
+                    self.ctx.err(
+                        "Skipped session %s due to property"
+                        " conflicts: %s" % (uuid, conflicts)
+                    )
                 return None
 
         return self.attach(store, server, name, uuid, props, exists)
 
-    def attach(self, store, server, name, uuid, props, exists,
-               set_current=True):
+    def attach(
+        self, store, server, name, uuid, props, exists, set_current=True
+    ):
         rv = None
         try:
             if exists:
@@ -616,12 +704,11 @@ class SessionsControl(UserGroupControl):
         host = client.getProperty("omero.host")
         port = client.getProperty("omero.port")
 
-        msg = "%s session for %s@%s:%s." \
-            % (action, ec.userName, host, port)
+        msg = "%s session for %s@%s:%s." % (action, ec.userName, host, port)
         msg += self._parse_timeout(idle, " Idle timeout: ")
         msg += self._parse_timeout(live, " Expires in : ")
 
-        msg += (" Current group: %s" % ec.groupName)
+        msg += " Current group: %s" % ec.groupName
 
         if not self.ctx.isquiet:
             self.ctx.err(msg)
@@ -672,18 +759,23 @@ class SessionsControl(UserGroupControl):
         old_id = ec.groupId
         old_name = ec.groupName
         if old_id == group_id and not self.ctx.isquiet:
-            self.ctx.err("Group '%s' (id=%s) is already active"
-                         % (group_name, group_id))
+            self.ctx.err(
+                "Group '%s' (id=%s) is already active" % (group_name, group_id)
+            )
         else:
             try:
-                sf.setSecurityContext(omero.model.ExperimenterGroupI(
-                    group_id, False))
+                sf.setSecurityContext(
+                    omero.model.ExperimenterGroupI(group_id, False)
+                )
                 self.ctx.set_event_context(
-                    sf.getAdminService().getEventContext())
-                self.ctx.out("Group '%s' (id=%s) switched to '%s' (id=%s)" % (
-                    old_name, old_id, group_name, group_id))
+                    sf.getAdminService().getEventContext()
+                )
+                self.ctx.out(
+                    "Group '%s' (id=%s) switched to '%s' (id=%s)"
+                    % (old_name, old_id, group_name, group_id)
+                )
             except omero.SecurityViolation as sv:
-                    self.ctx.die(564, "SecurityViolation: %s" % sv.message)
+                self.ctx.die(564, "SecurityViolation: %s" % sv.message)
 
     def timeout(self, args):
         client = self.ctx.conn(args)
@@ -700,7 +792,7 @@ class SessionsControl(UserGroupControl):
 
         if args.seconds is None:
             # Query only
-            secs = old_div(unwrap(obj.timeToIdle),1000.0)
+            secs = old_div(unwrap(obj.timeToIdle), 1000.0)
             self.ctx.out(secs)
             return secs
 
@@ -753,16 +845,20 @@ class SessionsControl(UserGroupControl):
 
                     if rv is None and args.purge:
                         try:
-                            self.ctx.dbg("Purging %s / %s / %s"
-                                         % (server, name, uuid))
+                            self.ctx.dbg(
+                                "Purging %s / %s / %s" % (server, name, uuid)
+                            )
                             store.remove(server, name, uuid)
                             continue
                         except IOError as ioe:
                             self.ctx.dbg("Aborting session purging. %s" % ioe)
                             break
 
-                    if server == previous[0] and name == previous[1] and \
-                            uuid == previous[2]:
+                    if (
+                        server == previous[0]
+                        and name == previous[1]
+                        and uuid == previous[2]
+                    ):
                         msg = "Logged in"
 
                     if port:
@@ -777,6 +873,7 @@ class SessionsControl(UserGroupControl):
                     results["Started"].append(started)
 
         from omero.util.text import Table, Column
+
         columns = tuple([Column(x, results[x]) for x in headers])
         self.ctx.out(str(Table(*columns)))
 
@@ -794,9 +891,14 @@ class SessionsControl(UserGroupControl):
 
             headers = ["name", "group", "logged in", "agent", "timeout"]
             extra = set()
-            results = {"name": [], "group": [],
-                       "logged in": [], "agent": [],
-                       "timeout": [], "uuid": []}
+            results = {
+                "name": [],
+                "group": [],
+                "logged in": [],
+                "agent": [],
+                "timeout": [],
+                "uuid": [],
+            }
 
             # Preparse data to find extra columns
             for idx, s in enumerate(rsp.sessions):
@@ -820,7 +922,7 @@ class SessionsControl(UserGroupControl):
                         if k.endswith("Time"):
                             t = old_div(v, 1000.0)
                             t = time.localtime(t)
-                            v = time.strftime('%Y-%m-%d %H:%M:%S', t)
+                            v = time.strftime("%Y-%m-%d %H:%M:%S", t)
                     except:
                         pass
                     results[k].append(v)
@@ -834,8 +936,7 @@ class SessionsControl(UserGroupControl):
                         t = t + " (*)"
                     results["logged in"].append(t)
                     results["agent"].append(unwrap(s.userAgent))
-                    results["timeout"].append(
-                        self._parse_timeout(s.timeToIdle))
+                    results["timeout"].append(self._parse_timeout(s.timeToIdle))
                     results["uuid"].append(ec.sessionUuid)
                 else:
                     # Insufficient privileges. The EventContext
@@ -847,6 +948,7 @@ class SessionsControl(UserGroupControl):
                     results["uuid"].append(msg)
 
             from omero.util.text import Table, Column
+
             columns = tuple([Column(x, results[x]) for x in headers])
             self.ctx.out(str(Table(*columns)))
         except omero.CmdError as ce:
@@ -855,8 +957,9 @@ class SessionsControl(UserGroupControl):
         except omero.ClientError as ce:
             if ce.message == "Null handle":
                 v = client.sf.getConfigService().getVersion()
-                self.ctx.die(561,
-                             "Operation unsupported. Server version: %s" % v)
+                self.ctx.die(
+                    561, "Operation unsupported. Server version: %s" % v
+                )
             else:
                 exc = traceback.format_exc()
                 self.ctx.dbg(exc)
@@ -885,14 +988,14 @@ class SessionsControl(UserGroupControl):
                     except Exception as e:
                         self.err("Keep alive failed: %s" % str(e))
                         return
+
         t = T()
         t.client = self.ctx.conn(args)
         t.err = self.ctx.err
         t.event = get_event(name="keepalive")
         t.start()
         try:
-            self.ctx.out("Running keep alive every %s seconds"
-                         % args.frequency)
+            self.ctx.out("Running keep alive every %s seconds" % args.frequency)
             self.ctx.input("Press enter to cancel.")
         finally:
             t.client = None
@@ -925,6 +1028,7 @@ class SessionsControl(UserGroupControl):
             return self.get_client()
 
         import omero
+
         try:
             data = self.initData(properties)
             self.set_client(omero.client(sys.argv, id=data))
@@ -944,11 +1048,12 @@ class SessionsControl(UserGroupControl):
         """Parse a connection string of form (user@)server(:port)"""
 
         import re
-        pat = r'^((?P<name>.+)@)?(?P<server>.*?)(:(?P<port>\d{1,5}))?$'
+
+        pat = r"^((?P<name>.+)@)?(?P<server>.*?)(:(?P<port>\d{1,5}))?$"
         match = re.match(pat, server)
-        server = match.group('server')
-        name = match.group('name')
-        port = match.group('port')
+        server = match.group("server")
+        name = match.group("name")
+        port = match.group("port")
         if not name:
             name = default_name
         return server, name, port

--- a/src/omero/plugins/submit.py
+++ b/src/omero/plugins/submit.py
@@ -28,7 +28,6 @@ class Cancel(Exception):
 
 
 class SubmitCLI(CLI):
-
     def __init__(self):
         CLI.__init__(self)
         self.queue = []
@@ -49,13 +48,13 @@ class SubmitCLI(CLI):
         print("Uploading")
         print(self.queue)
 
+
 HELP = """When run without arguments, submit shell is opened
 which takes commands without executing them. On save,
 the file is trasferred to the server, and executed."""
 
 
 class SubmitControl(BaseControl):
-
     def _configure(self, parser):
         parser.add_argument("arg", nargs="*", help="single command with args")
         parser.set_defaults(func=self.__call__)
@@ -75,6 +74,7 @@ class SubmitControl(BaseControl):
                 l = len(submit.queue)
                 if l > 0:
                     print(l, " items queued. Really cancel? [Yn]")
+
 
 try:
     # register("submit", SubmitControl, HELP)

--- a/src/omero/plugins/tag.py
+++ b/src/omero/plugins/tag.py
@@ -42,8 +42,14 @@ Examples:
 
 
 class Tag(object):
-    def __init__(self, tag_id=None, name=None, description=None, owner=None,
-                 children=None):
+    def __init__(
+        self,
+        tag_id=None,
+        name=None,
+        description=None,
+        owner=None,
+        children=None,
+    ):
         self.tag_id = tag_id
         self.name = name
         self.description = description
@@ -87,7 +93,6 @@ def clip(s, width):
 
 
 class TagControl(BaseControl):
-
     def _configure(self, parser):
 
         self.exc = ExceptionHandler()
@@ -96,18 +101,23 @@ class TagControl(BaseControl):
         sub = parser.sub()
 
         listtags = parser.add(
-            sub, self.list, help="List all the tags, grouped by tagset")
+            sub, self.list, help="List all the tags, grouped by tagset"
+        )
         self.add_standard_params(listtags)
         listtags.add_argument(
-            "--tagset", nargs="+", type=int, help="One or more tagset IDs")
+            "--tagset", nargs="+", type=int, help="One or more tagset IDs"
+        )
         self.add_tag_common_params(listtags)
         listtags.add_login_arguments()
 
         listsets = parser.add(sub, self.listsets, help="List tag sets")
         self.add_standard_params(listsets)
         listsets.add_argument(
-            "--tag", nargs="+", type=int,
-            help="List only tagsets containing the following tag ID(s)")
+            "--tag",
+            nargs="+",
+            type=int,
+            help="List only tagsets containing the following tag ID(s)",
+        )
         self.add_tag_common_params(listsets)
         listsets.add_login_arguments()
 
@@ -115,11 +125,14 @@ class TagControl(BaseControl):
         self.add_newtag_params(create)
         create.add_login_arguments()
 
-        createset = parser.add(
-            sub, self.createset, help="Create a new tag set")
+        createset = parser.add(sub, self.createset, help="Create a new tag set")
         createset.add_argument(
-            "--tag", nargs="+", required=True, type=int,
-            help="ID(s) of the tag(s) to include in this set")
+            "--tag",
+            nargs="+",
+            required=True,
+            type=int,
+            help="ID(s) of the tag(s) to include in this set",
+        )
         self.add_newtag_params(createset)
         createset.add_login_arguments()
 
@@ -145,58 +158,70 @@ JSON File Format:
   },{
     ....
   }]
-            """)
+            """,
+        )
         loadj.set_defaults(func=self.load)
         loadj.add_argument(
-            "filename", nargs="?", help="The filename containing tag JSON")
+            "filename", nargs="?", help="The filename containing tag JSON"
+        )
         loadj.add_login_arguments()
 
-        links = parser.add(
-            sub, self.link, help="Link annotation to an object")
+        links = parser.add(sub, self.link, help="Link annotation to an object")
         links.add_argument(
             "object",
             help="The object to link to. Should be of form"
-            " <object_type>:<object_id>")
-        links.add_argument(
-            'tag_id', type=int,
-            help="The tag annotation ID")
+            " <object_type>:<object_id>",
+        )
+        links.add_argument("tag_id", type=int, help="The tag annotation ID")
         self.add_standard_params(links)
         links.add_login_arguments()
 
     # Recurring parameter methods
     def add_newtag_params(self, parser):
+        parser.add_argument("--name", help="The name of the new tag or tagset")
         parser.add_argument(
-            "--name", help="The name of the new tag or tagset")
-        parser.add_argument(
-            "--desc", "--description",
-            help="The description of the new tag or tagset")
+            "--desc",
+            "--description",
+            help="The description of the new tag or tagset",
+        )
 
     def add_tag_common_params(self, parser):
         parser.add_argument(
             "--uid",
-            help="List only tags/tagsets belonging to the following user ID")
+            help="List only tags/tagsets belonging to the following user ID",
+        )
         parser.add_argument(
-            "--desc", "--description", "--descriptions",
-            action="store_true", default=False,
-            help="Display descriptions of tags")
+            "--desc",
+            "--description",
+            "--descriptions",
+            action="store_true",
+            default=False,
+            help="Display descriptions of tags",
+        )
 
     def add_standard_params(self, parser):
         parser.add_argument(
-            "--admin", action="store_true", default=False,
-            help="Perform action as an administrator")
+            "--admin",
+            action="store_true",
+            default=False,
+            help="Perform action as an administrator",
+        )
         parser.add_argument(
-            "--nopage", action="store_true", default=False,
-            help="Disable pagination")
+            "--nopage",
+            action="store_true",
+            default=False,
+            help="Disable pagination",
+        )
 
     # Output methods
     def print_line(self, line, index):
         if self.console_length is None:
-                self.ctx.out(line)
+            self.ctx.out(line)
         elif index % self.console_length == 0 and index:
             input = input("[Enter], [f]orward forever, or [q]uit: ")
-            if input.lower() == 'q':
+            if input.lower() == "q":
                 sys.exit(0)
-            elif input.lower() == 'f':
+            elif input.lower() == "f":
                 self.console_length = None
         else:
             self.ctx.out(line)
@@ -223,18 +248,19 @@ JSON File Format:
         this_system = platform.system().lower()
 
         try:
-            if this_system in ['linux', 'darwin', 'macosx', 'cygwin']:
-                output = exec_command(['tput', 'lines'])
+            if this_system in ["linux", "darwin", "macosx", "cygwin"]:
+                output = exec_command(["tput", "lines"])
                 if len(output) > 0:
                     lines = int(output[0].rstrip())
-                output = exec_command(['tput', 'cols'])
+                output = exec_command(["tput", "cols"])
                 if len(output) > 0:
                     width = int(output[0].rstrip())
-            elif this_system in ['windows', 'win32']:
+            elif this_system in ["windows", "win32"]:
                 # http://stackoverflow.com/questions/566746/\
                 # how-to-get-console-window-width-in-python
                 from ctypes import windll, create_string_buffer
                 from struct import unpack
+
                 # stdin handle is -10
                 # stdout handle is -11
                 # stderr handle is -12
@@ -242,9 +268,19 @@ JSON File Format:
                 csbi = create_string_buffer(22)
                 res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
                 if res:
-                    (bufx, bufy, curx, cury, wattr,
-                     left, top, right, bottom,
-                     maxx, maxy) = unpack("hhhhHhhhhhh", csbi.raw)
+                    (
+                        bufx,
+                        bufy,
+                        curx,
+                        cury,
+                        wattr,
+                        left,
+                        top,
+                        right,
+                        bottom,
+                        maxx,
+                        maxy,
+                    ) = unpack("hhhhHhhhhhh", csbi.raw)
                     lines = bottom - top + 1
                     width = bottom - top + 1
         except:
@@ -266,7 +302,7 @@ JSON File Format:
 
         # Now add the empty tagsets to the collection
         params = omero.sys.ParametersI()
-        params.addString('ns', omero.constants.metadata.NSINSIGHTTAGSET)
+        params.addString("ns", omero.constants.metadata.NSINSIGHTTAGSET)
         ice_map = dict()
         if args.admin:
             ice_map["omero.group"] = "-1"
@@ -288,14 +324,13 @@ JSON File Format:
 
         if tagset:
             sql += " and ann.id = :tid"
-            params.map['tid'] = rlong(int(tagset))
+            params.map["tid"] = rlong(int(tagset))
 
         for element in q.projection(sql, params, ice_map):
             tag_id, description, text = list(map(unwrap, element))
-            tc.empties.append(Tag(
-                tag_id=tag_id,
-                name=text,
-                description=description))
+            tc.empties.append(
+                Tag(tag_id=tag_id, name=text, description=description)
+            )
 
         return tc
 
@@ -304,7 +339,7 @@ JSON File Format:
         Returns a TagCollection object
         """
         params = omero.sys.ParametersI()
-        params.addString('ns', omero.constants.metadata.NSINSIGHTTAGSET)
+        params.addString("ns", omero.constants.metadata.NSINSIGHTTAGSET)
         ice_map = dict()
         if args.admin:
             ice_map["omero.group"] = "-1"
@@ -326,7 +361,7 @@ JSON File Format:
             sql += " and ann.details.owner.id = :eid"
         if tagset:
             sql += " and ann.id = :tid"
-            params.map['tid'] = rlong(int(tagset))
+            params.map["tid"] = rlong(int(tagset))
 
         tc = TagCollection()
 
@@ -334,11 +369,13 @@ JSON File Format:
             parent = unwrap(element[0])
             child = unwrap(element[1])
             tc.mapping.setdefault(parent, []).append(child)
-            parent_tags.append(Tag(
-                tag_id=parent,
-                name=unwrap(element[3]),
-                description=unwrap(element[2])
-            ))
+            parent_tags.append(
+                Tag(
+                    tag_id=parent,
+                    name=unwrap(element[3]),
+                    description=unwrap(element[2]),
+                )
+            )
 
         if tagset:
             sql = """
@@ -365,10 +402,9 @@ JSON File Format:
 
             for element in q.projection(sql, params, ice_map):
                 tag_id, text, description = list(map(unwrap, element))
-                tc.orphans.append(Tag(
-                    tag_id=tag_id,
-                    name=text,
-                    description=description))
+                tc.orphans.append(
+                    Tag(tag_id=tag_id, name=text, description=description)
+                )
 
             # Now set up search for rest of tags
             sql = """
@@ -385,15 +421,16 @@ JSON File Format:
                 sql += " where ann.details.owner.id = :eid"
 
         for element in q.projection(sql, params, ice_map):
-            tag_id, description, text, owner, first, last = list(map(unwrap,
-                                                                element))
+            tag_id, description, text, owner, first, last = list(
+                map(unwrap, element)
+            )
             tc.tags[tag_id] = Tag(
                 tag_id=tag_id,
                 name=text,
                 description=description,
                 owner=owner,
-                children=tc.mapping.get(tag_id) or 0
-                )
+                children=tc.mapping.get(tag_id) or 0,
+            )
             tc.owners[owner] = "%s %s" % (first, last)
 
         for parent in parent_tags:
@@ -409,7 +446,7 @@ JSON File Format:
         If tag is provided, will return the tagsets with those tags.
         """
         params = omero.sys.ParametersI()
-        params.addString('ns', omero.constants.metadata.NSINSIGHTTAGSET)
+        params.addString("ns", omero.constants.metadata.NSINSIGHTTAGSET)
         ice_map = dict()
         if args.admin:
             ice_map["omero.group"] = "-1"
@@ -430,7 +467,7 @@ JSON File Format:
                 where a.ns=:ns
                 """
             sql += " and b.child.id = :tid"
-            params.map['tid'] = rlong(int(tag))
+            params.map["tid"] = rlong(int(tag))
         else:
             sql = """
                 select a.id, a.description, a.textValue,
@@ -445,13 +482,11 @@ JSON File Format:
             sql += " and a.details.owner.id = :eid"
 
         for element in q.projection(sql, params, ice_map):
-            tag_id, description, text, owner, first, last = list(map(unwrap,
-                                                                element))
+            tag_id, description, text, owner, first, last = list(
+                map(unwrap, element)
+            )
             tc.tags[tag_id] = Tag(
-                tag_id=tag_id,
-                name=text,
-                description=description,
-                owner=owner
+                tag_id=tag_id, name=text, description=description, owner=owner
             )
             tc.owners[owner] = "%s %s" % (first, last)
 
@@ -468,14 +503,15 @@ JSON File Format:
             if args.desc:
                 lines.append("|   '%s'" % tags[key].description)
                 lines.append("|")
-            lines.append('|\\')
+            lines.append("|\\")
             for tag_key in mapping[key]:
-                lines.append("| +- %s:'%s'" % (str(tag_key),
-                             tags[tag_key].name))
+                lines.append(
+                    "| +- %s:'%s'" % (str(tag_key), tags[tag_key].name)
+                )
                 if args.desc:
                     lines.append("|   '%s'" % tags[tag_key].description)
                     lines.append("|")
-            lines.append('')
+            lines.append("")
 
         return lines
 
@@ -485,12 +521,12 @@ JSON File Format:
         lines representing the orphan output.
         """
         lines = []
-        lines.append('Orphaned tags:')
+        lines.append("Orphaned tags:")
         for orphan in orphans:
             lines.append("> %s:'%s'" % (str(orphan.tag_id), orphan.name))
             if args.desc:
                 lines.append("   '%s'" % orphan.description)
-                lines.append('')
+                lines.append("")
         return lines
 
     def generate_empties(self, empties, args):
@@ -499,12 +535,12 @@ JSON File Format:
         lines representing the empty tagset output.
         """
         lines = []
-        lines.append('Empty tagsets:')
+        lines.append("Empty tagsets:")
         for empty in empties:
             lines.append("> %s:'%s'" % (str(empty.tag_id), empty.name))
             if args.desc:
                 lines.append("   '%s'" % empty.description)
-                lines.append('')
+                lines.append("")
         return lines
 
     def create_tag(self, name, description, text="tag"):
@@ -520,7 +556,7 @@ JSON File Format:
         if name is None:
             name = builtins.input("Please enter a name for this %s: " % text)
 
-        if name is not None and name != '':
+        if name is not None and name != "":
             tag = TagAnnotationI()
             tag.textValue = rstring(name)
             if description is not None and len(description) > 0:
@@ -595,21 +631,23 @@ JSON File Format:
         to_add = []
 
         for element in p:
-            if 'set' in element:
-                tag = self.create_tag(str(element['name']),
-                                      str(element['desc']))
+            if "set" in element:
+                tag = self.create_tag(
+                    str(element["name"]), str(element["desc"])
+                )
                 tag.ns = rstring(omero.constants.metadata.NSINSIGHTTAGSET)
                 links = []
-                for e in element['set']:
-                    t = self.create_tag(str(e['name']), str(e['desc']))
+                for e in element["set"]:
+                    t = self.create_tag(str(e["name"]), str(e["desc"]))
                     link = AnnotationAnnotationLinkI()
                     link.parent = tag
                     link.child = t
                     links.append(link)
                 to_add.extend(links)
             else:
-                to_add.append(self.create_tag(str(element['name']),
-                              str(element['desc'])))
+                to_add.append(
+                    self.create_tag(str(element["name"]), str(element["desc"]))
+                )
 
         client = self.ctx.conn(args)
         session = client.getSession()
@@ -632,15 +670,17 @@ JSON File Format:
         """
 
         try:
-            obj_type, obj_id = args.object.split(':')
+            obj_type, obj_id = args.object.split(":")
             obj_id = int(obj_id)
         except ValueError:
             obj_type = None
             obj_id = None
 
         if obj_type is None or obj_id is None:
-            self.ctx.err("Missing object or object not of form"
-                         " <object_type>:<object_id>")
+            self.ctx.err(
+                "Missing object or object not of form"
+                " <object_type>:<object_id>"
+            )
             sys.exit(1)
 
         if not args.tag_id:
@@ -671,10 +711,14 @@ JSON File Format:
         obj = query_service.findByQuery(
             "select o from %s as o "
             "left outer join fetch o.annotationLinks "
-            "where o.id = :id" % obj_type, parameters, ice_map)
+            "where o.id = :id" % obj_type,
+            parameters,
+            ice_map,
+        )
         if obj is None:
             self.ctx.err(
-                "Object query returned nothing. Check your object type.")
+                "Object query returned nothing. Check your object type."
+            )
             sys.exit(1)
 
         obj.linkAnnotation(annotation)
@@ -709,7 +753,7 @@ JSON File Format:
             if len(tc.orphans) > 0:
                 lines.extend(self.generate_orphans(tc.orphans, args))
                 if len(tc.empties) > 0:
-                    lines.append('')
+                    lines.append("")
             if len(tc.empties) > 0:
                 lines.extend(self.generate_empties(tc.empties, args))
         self.pagetext(lines)
@@ -731,7 +775,9 @@ JSON File Format:
             self.width, self.console_length = self.determine_console_size()
 
         if args.desc:
-            max_field_width = int((old_div((self.width - max_id_width), 2.0)) - 2)
+            max_field_width = int(
+                (old_div((self.width - max_id_width), 2.0)) - 2
+            )
         else:
             max_field_width = self.width - max_id_width - 2
 
@@ -746,16 +792,18 @@ JSON File Format:
         separator = (
             "-" * max_id_width,
             "-" * max_field_width,
-            "-" * max_field_width
+            "-" * max_field_width,
         )
 
         lines.append(separator)
 
-        lines.append((
-            clip("ID", max_id_width),
-            clip("Name", max_field_width),
-            clip("Description", max_field_width)
-        ))
+        lines.append(
+            (
+                clip("ID", max_id_width),
+                clip("Name", max_field_width),
+                clip("Description", max_field_width),
+            )
+        )
 
         lines.append(separator)
 
@@ -763,18 +811,15 @@ JSON File Format:
             tc = self.list_tagsets(args, tag_id)
             for key, tag in list(tc.tags.items()):
                 if args.nopage:
-                    lines.append((
-                        tag.tag_id,
-                        tag.name,
-                        tag.description
-
-                    ))
+                    lines.append((tag.tag_id, tag.name, tag.description))
                 else:
-                    lines.append((
-                        clip(str(tag.tag_id), max_id_width),
-                        clip(tag.name, max_field_width),
-                        clip(tag.description, max_field_width)
-                    ))
+                    lines.append(
+                        (
+                            clip(str(tag.tag_id), max_id_width),
+                            clip(tag.name, max_field_width),
+                            clip(tag.description, max_field_width),
+                        )
+                    )
 
         lines.append(separator)
 

--- a/src/omero/plugins/user.py
+++ b/src/omero/plugins/user.py
@@ -11,15 +11,16 @@
 import sys
 
 from omero.cli import UserGroupControl, CLI, ExceptionHandler, admin_only
-from omero.model.enums import (AdminPrivilegeModifyGroupMembership,
-                               AdminPrivilegeModifyUser)
+from omero.model.enums import (
+    AdminPrivilegeModifyGroupMembership,
+    AdminPrivilegeModifyUser,
+)
 from omero.rtypes import unwrap as _
 
 HELP = "Support for adding and managing users"
 
 
 class UserControl(UserGroupControl):
-
     def _configure(self, parser):
 
         self.exc = ExceptionHandler()
@@ -29,16 +30,21 @@ class UserControl(UserGroupControl):
 
         add = parser.add(sub, self.add, help="Add user")
         add.add_argument(
-            "--ignore-existing", action="store_true", default=False,
-            help="Do not fail if user already exists")
-        add.add_argument(
-            "-m", "--middlename", help="Middle name, if available")
+            "--ignore-existing",
+            action="store_true",
+            default=False,
+            help="Do not fail if user already exists",
+        )
+        add.add_argument("-m", "--middlename", help="Middle name, if available")
         add.add_argument("-e", "--email")
         add.add_argument("-i", "--institution")
         # Capitalized since conflict with main values
         add.add_argument(
-            "-a", "--admin", action="store_true",
-            help="Whether the user should be an admin")
+            "-a",
+            "--admin",
+            action="store_true",
+            help="Whether the user should be an admin",
+        )
         add.add_argument("username", help="User's login name")
         add.add_argument("firstname", help="User's first name")
         add.add_argument("lastname", help="User's last name")
@@ -46,17 +52,24 @@ class UserControl(UserGroupControl):
 
         password_group = add.add_mutually_exclusive_group()
         password_group.add_argument(
-            "-P", "--userpassword", help="Password for user")
+            "-P", "--userpassword", help="Password for user"
+        )
         password_group.add_argument(
-            "--no-password", action="store_true", default=False,
-            help="Create user with empty password")
+            "--no-password",
+            action="store_true",
+            default=False,
+            help="Create user with empty password",
+        )
 
         list = parser.add(
-            sub, self.list, help="List information about all users")
+            sub, self.list, help="List information about all users"
+        )
 
         info = parser.add(
-            sub, self.info,
-            "List information about the user(s). Default to the context user")
+            sub,
+            self.info,
+            "List information about the user(s). Default to the context user",
+        )
         self.add_user_arguments(info)
 
         for x in (list, info):
@@ -65,49 +78,74 @@ class UserControl(UserGroupControl):
             x.add_user_sorting_arguments()
 
         listgroups = parser.add(
-            sub, self.listgroups,
-            "List the groups of the user. Default to the context user")
+            sub,
+            self.listgroups,
+            "List the groups of the user. Default to the context user",
+        )
         self.add_user_arguments(listgroups)
         listgroups.add_style_argument()
         listgroups.add_user_print_arguments()
         listgroups.add_group_sorting_arguments()
 
-        password = parser.add(
-            sub, self.password, help="Set user's password")
+        password = parser.add(sub, self.password, help="Set user's password")
         password.add_argument(
-            "username", nargs="?", help="Username if not the current user")
+            "username", nargs="?", help="Username if not the current user"
+        )
 
-        email = parser.add(
-            sub, self.email, help="List users' email addresses")
+        email = parser.add(sub, self.email, help="List users' email addresses")
         email.add_argument(
-            "-n", "--names", action="store_true", default=False,
-            help="Print user names along with email addresses")
+            "-n",
+            "--names",
+            action="store_true",
+            default=False,
+            help="Print user names along with email addresses",
+        )
         email.add_argument(
-            "-1", "--one", action="store_true", default=False,
-            help="Print one user per line")
+            "-1",
+            "--one",
+            action="store_true",
+            default=False,
+            help="Print one user per line",
+        )
         email.add_argument(
-            "-i", "--ignore", action="store_true", default=False,
-            help="Ignore users without email addresses")
+            "-i",
+            "--ignore",
+            action="store_true",
+            default=False,
+            help="Ignore users without email addresses",
+        )
         email.add_argument(
-            "--all", action="store_true", default=False,
-            help="Include all users, including deactivated accounts")
+            "--all",
+            action="store_true",
+            default=False,
+            help="Include all users, including deactivated accounts",
+        )
 
         joingroup = parser.add(sub, self.joingroup, "Join one or more groups")
         self.add_id_name_arguments(
-            joingroup, "user. Default to the current user")
+            joingroup, "user. Default to the current user"
+        )
         group = self.add_group_arguments(joingroup, " to join")
         group.add_argument(
-            "--as-owner", action="store_true", default=False,
-            help="Join the group(s) as an owner")
+            "--as-owner",
+            action="store_true",
+            default=False,
+            help="Join the group(s) as an owner",
+        )
 
         leavegroup = parser.add(
-            sub, self.leavegroup, "Leave one or more groups")
+            sub, self.leavegroup, "Leave one or more groups"
+        )
         self.add_id_name_arguments(
-            leavegroup, "user. Default to the current user")
+            leavegroup, "user. Default to the current user"
+        )
         group = self.add_group_arguments(leavegroup, " to leave")
         group.add_argument(
-            "--as-owner", action="store_true", default=False,
-            help="Leave the owner list of the group(s)")
+            "--as-owner",
+            action="store_true",
+            default=False,
+            help="Leave the owner list of the group(s)",
+        )
 
         for x in (email, password, list, add, joingroup, leavegroup):
             x.add_login_arguments()
@@ -167,18 +205,21 @@ class UserControl(UserGroupControl):
     def password(self, args):
         import omero
         from omero.rtypes import rstring
+
         client = self.ctx.conn(args)
         own_name = self.ctx.get_event_context().userName
         admin = client.sf.getAdminService()
 
         # tickets 3202, 5841
-        own_pw = self._ask_for_password(" for your user (%s)"
-                                        % own_name, strict=False)
+        own_pw = self._ask_for_password(
+            " for your user (%s)" % own_name, strict=False
+        )
         try:
             client.sf.setSecurityPassword(own_pw)
             self.ctx.out("Verified password.\n")
         except omero.SecurityViolation as sv:
             import traceback
+
             self.ctx.die(456, "SecurityViolation: Bad credentials")
             self.ctx.dbg(traceback.format_exception(None, e, sys.exc_info()[2]))
 
@@ -188,8 +229,9 @@ class UserControl(UserGroupControl):
             except omero.ApiUsageException:
                 self.ctx.die(457, "Unknown user: %s" % args.username)
                 return  # Never reached
-            self.ctx.out("Changing password for %s (id:%s)" % (
-                args.username, e.id.val))
+            self.ctx.out(
+                "Changing password for %s (id:%s)" % (args.username, e.id.val)
+            )
         else:
             self.ctx.out("Changing password for %s" % own_name)
 
@@ -218,7 +260,7 @@ class UserControl(UserGroupControl):
         admin = c.sf.getAdminService()
         [uids, groups] = self.list_users(admin, args, use_context=True)
         if len(uids) != 1:
-            self.ctx.die(516, 'Too many user arguments')
+            self.ctx.die(516, "Too many user arguments")
         groups = admin.containedGroups(uids[0])
         self.output_groups_list(groups, args)
 
@@ -236,6 +278,7 @@ class UserControl(UserGroupControl):
         from omero.rtypes import rbool, rstring
         from omero_model_ExperimenterI import ExperimenterI as Exp
         from omero_model_ExperimenterGroupI import ExperimenterGroupI as Grp
+
         c = self.ctx.conn(args)
         e = Exp()
         e.omeName = rstring(login)
@@ -250,10 +293,13 @@ class UserControl(UserGroupControl):
         # empty passwords
         configService = c.getSession().getConfigService()
         password_required = configService.getConfigValue(
-            "omero.security.password_required").lower()
-        if args.no_password and password_required != 'false':
-            self.ctx.die(502, "Server does not allow user creation with empty"
-                         " passwords")
+            "omero.security.password_required"
+        ).lower()
+        if args.no_password and password_required != "false":
+            self.ctx.die(
+                502,
+                "Server does not allow user creation with empty" " passwords",
+            )
 
         # Check user existence
         admin = c.getSession().getAdminService()
@@ -261,12 +307,14 @@ class UserControl(UserGroupControl):
             usr = admin.lookupExperimenter(login)
             if usr:
                 if args.ignore_existing:
-                    self.ctx.out("User exists: %s (id=%s)"
-                                 % (login, usr.id.val))
+                    self.ctx.out(
+                        "User exists: %s (id=%s)" % (login, usr.id.val)
+                    )
                     return
                 else:
-                    self.ctx.die(3, "User exists: %s (id=%s)"
-                                 % (login, usr.id.val))
+                    self.ctx.die(
+                        3, "User exists: %s (id=%s)" % (login, usr.id.val)
+                    )
         except omero.ApiUsageException:
             pass  # Apparently no such user exists
 
@@ -282,23 +330,26 @@ class UserControl(UserGroupControl):
         try:
             if args.no_password:
                 id = admin.createExperimenter(e, group, groups)
-                self.ctx.out("Added user %s (id=%s) without password"
-                             % (login, id))
+                self.ctx.out(
+                    "Added user %s (id=%s) without password" % (login, id)
+                )
             else:
                 if pasw is None:
-                    pasw = self._ask_for_password(" for your new user (%s)"
-                                                  % login, strict=True)
-                id = admin.createExperimenterWithPassword(e, rstring(pasw),
-                                                          group, groups)
-                self.ctx.out("Added user %s (id=%s) with password"
-                             % (login, id))
+                    pasw = self._ask_for_password(
+                        " for your new user (%s)" % login, strict=True
+                    )
+                id = admin.createExperimenterWithPassword(
+                    e, rstring(pasw), group, groups
+                )
+                self.ctx.out(
+                    "Added user %s (id=%s) with password" % (login, id)
+                )
         except omero.ValidationException as ve:
             # Possible, though unlikely after previous check
             if self.exc.is_constraint_violation(ve):
                 self.ctx.die(66, "User already exists: %s" % login)
             else:
-                self.ctx.die(67, "Unknown ValidationException: %s"
-                             % ve.message)
+                self.ctx.die(67, "Unknown ValidationException: %s" % ve.message)
         except omero.SecurityViolation as se:
             self.ctx.die(68, "Security violation: %s" % se.message)
 
@@ -325,13 +376,16 @@ class UserControl(UserGroupControl):
 
             if join:
                 if uid in uid_list:
-                    self.ctx.out("%s is already %s group %s"
-                                 % (uid, relation, group.id.val))
+                    self.ctx.out(
+                        "%s is already %s group %s"
+                        % (uid, relation, group.id.val)
+                    )
                     groups.remove(group)
             else:
                 if uid not in uid_list:
-                    self.ctx.out("%s is not %s group %s"
-                                 % (uid, relation, group.id.val))
+                    self.ctx.out(
+                        "%s is not %s group %s" % (uid, relation, group.id.val)
+                    )
                     groups.remove(group)
         return groups
 
@@ -362,6 +416,8 @@ class UserControl(UserGroupControl):
                 self.removeownersbyid(a, group, [uid])
             else:
                 self.removeusersbyid(a, group, [uid])
+
+
 try:
     register("user", UserControl, HELP)
 except NameError:

--- a/src/omero/rtypes.py
+++ b/src/omero/rtypes.py
@@ -26,6 +26,7 @@ from past.builtins import basestring, long
 import omero
 import Ice
 import IceImport
+
 IceImport.load("omero_RTypes_ice")
 IceImport.load("omero_Scripts_ice")
 IceImport.load("omero_model_RTypes_ice")
@@ -71,8 +72,7 @@ def rtype(val):
     elif isinstance(val, dict):
         return rmap(val)
     else:
-        raise omero.ClientError("Cannot handle conversion from: %s"
-                                % type(val))
+        raise omero.ClientError("Cannot handle conversion from: %s" % type(val))
 
 
 def wrap(val, cache=None):
@@ -234,6 +234,7 @@ def rtime(val):
         return val
     return RTimeI(val)
 
+
 # Static factory methods (objects)
 # =========================================================================
 
@@ -309,6 +310,7 @@ def rstring(val):
     else:
         return rstring(str(val))
 
+
 # Static factory methods (collections)
 # =========================================================================
 
@@ -328,12 +330,12 @@ def rset(val=None, *args):
 def rmap(val=None, **kwargs):
     return RMapI(val, **kwargs)
 
+
 # Implementations (primitives)
 # =========================================================================
 
 
 class RBoolI(omero.RBool):
-
     def __init__(self, value):
         omero.RBool.__init__(self, value)
 
@@ -392,7 +394,6 @@ class RBoolI(omero.RBool):
 
 
 class RDoubleI(omero.RDouble):
-
     def __init__(self, value):
         omero.RDouble.__init__(self, float(value))
 
@@ -448,7 +449,6 @@ class RDoubleI(omero.RDouble):
 
 
 class RFloatI(omero.RFloat):
-
     def __init__(self, value):
         omero.RFloat.__init__(self, float(value))
 
@@ -504,7 +504,6 @@ class RFloatI(omero.RFloat):
 
 
 class RIntI(omero.RInt):
-
     def __init__(self, value):
         omero.RInt.__init__(self, int(value))
 
@@ -560,7 +559,6 @@ class RIntI(omero.RInt):
 
 
 class RLongI(omero.RLong):
-
     def __init__(self, value):
         omero.RLong.__init__(self, long(value))
 
@@ -616,7 +614,6 @@ class RLongI(omero.RLong):
 
 
 class RTimeI(omero.RTime):
-
     def __init__(self, value):
         omero.RTime.__init__(self, long(value))
 
@@ -670,12 +667,12 @@ class RTimeI(omero.RTime):
         """
         pass  # Currently unused
 
+
 # Implementations (objects)
 # =========================================================================
 
 
 class RInternalI(omero.RInternal):
-
     def __init__(self, value):
         omero.RInternal.__init__(self, value)
 
@@ -731,7 +728,6 @@ class RInternalI(omero.RInternal):
 
 
 class RObjectI(omero.RObject):
-
     def __init__(self, value):
         omero.RObject.__init__(self, value)
 
@@ -787,7 +783,6 @@ class RObjectI(omero.RObject):
 
 
 class RStringI(omero.RString):
-
     def __init__(self, value):
         omero.RString.__init__(self, value)
 
@@ -843,7 +838,6 @@ class RStringI(omero.RString):
 
 
 class RClassI(omero.RClass):
-
     def __init__(self, value):
         omero.RClass.__init__(self, value)
 
@@ -896,6 +890,7 @@ class RClassI(omero.RClass):
         Required due to __getattr__ implementation.
         """
         pass  # Currently unused
+
 
 # Implementations (collections)
 # =========================================================================
@@ -1151,7 +1146,6 @@ class RSetI(omero.RSet):
 
 
 class RMapI(omero.RMap):
-
     def __init__(self, arg=None, **kwargs):
         if arg is None:
             self._val = {}
@@ -1229,6 +1223,7 @@ class RMapI(omero.RMap):
         """
         pass  # Currently unused
 
+
 # Helpers
 # ========================================================================
 
@@ -1236,7 +1231,6 @@ class RMapI(omero.RMap):
 
 
 class ObjectFactory(Ice.ObjectFactory):
-
     def __init__(self, cls, f):
         self.id = cls.ice_staticId()
         self.f = f
@@ -1287,5 +1281,5 @@ ObjectFactories = {
     RArrayI: ObjectFactory(RArrayI, lambda: RArrayI()),
     RListI: ObjectFactory(RListI, lambda: RListI()),
     RSetI: ObjectFactory(RSetI, lambda: RSetI()),
-    RMapI: ObjectFactory(RMapI, lambda: RMapI())
-    }
+    RMapI: ObjectFactory(RMapI, lambda: RMapI()),
+}

--- a/src/omero/scripts.py
+++ b/src/omero/scripts.py
@@ -46,14 +46,22 @@ class Type(omero.grid.Param):
 
     kwargs
     """
+
     PROTOTYPE_FUNCTION = None
     PROTOTYPE_DEFAULT = None
     PROTOTYPE_MIN = None
     PROTOTYPE_MAX = None
     PROTOTYPE_VALUES = None
 
-    def __init__(self, name, optional=True, out=False, description=None,
-                 default=None, **kwargs):
+    def __init__(
+        self,
+        name,
+        optional=True,
+        out=False,
+        description=None,
+        default=None,
+        **kwargs
+    ):
 
         # Non-Param attributes
         omero.grid.Param.__init__(self)
@@ -171,6 +179,7 @@ class Object(Type):
     """
     Wraps an robject
     """
+
     PROTOTYPE_FUNCTION = robject
     PROTOTYPE_DEFAULT = None
 
@@ -179,6 +188,7 @@ class Long(Type):
     """
     Wraps an rlong
     """
+
     PROTOTYPE_FUNCTION = rlong
     PROTOTYPE_DEFAULT = 0
 
@@ -187,6 +197,7 @@ class Int(Type):
     """
     Wraps an rint
     """
+
     PROTOTYPE_FUNCTION = rint
     PROTOTYPE_DEFAULT = 0
 
@@ -195,6 +206,7 @@ class Double(Type):
     """
     Wraps an rdouble
     """
+
     PROTOTYPE_FUNCTION = rdouble
     PROTOTYPE_DEFAULT = 0.0
 
@@ -203,6 +215,7 @@ class Float(Type):
     """
     Wraps an rfloat
     """
+
     PROTOTYPE_FUNCTION = rfloat
     PROTOTYPE_DEFAULT = 0.0
 
@@ -211,6 +224,7 @@ class String(Type):
     """
     Wraps an rstring
     """
+
     PROTOTYPE_FUNCTION = rstring
     PROTOTYPE_DEFAULT = ""
 
@@ -219,6 +233,7 @@ class Bool(Type):
     """
     Wraps an rbool
     """
+
     PROTOTYPE_FUNCTION = rbool
     PROTOTYPE_DEFAULT = False
 
@@ -227,6 +242,7 @@ class Color(Type):
     """
     Wraps an rinternal(Color)
     """
+
     PROTOTYPE_FUNCTION = rinternal
     PROTOTYPE_DEFAULT = omero.Color
 
@@ -235,6 +251,7 @@ class Point(Type):
     """
     Wraps an rinternal(Point)
     """
+
     PROTOTYPE_FUNCTION = rinternal
     PROTOTYPE_DEFAULT = omero.Point
 
@@ -243,6 +260,7 @@ class Plane(Type):
     """
     Wraps an rinternal(Plane)
     """
+
     PROTOTYPE_FUNCTION = rinternal
     PROTOTYPE_DEFAULT = omero.Plane
 
@@ -252,6 +270,7 @@ class __Coll(Type):
     Base type providing the append and extend functionality.
     Not for user use.
     """
+
     PROTOTYPE_DEFAULT = list
 
     def append(self, *arg):
@@ -272,7 +291,8 @@ class __Coll(Type):
             if not isinstance(obj, self.prototype.val[0].__class__):
                 raise ValueError(
                     "ofType values doesn't match default value: %s <> %s"
-                    % (unwrap(obj), unwrap(self.prototype.val[0])))
+                    % (unwrap(obj), unwrap(self.prototype.val[0]))
+                )
         else:
             self.prototype.val.append(wrap(obj))
 
@@ -284,6 +304,7 @@ class Set(__Coll):
     Wraps an rset. To add values to the contents of the set,
     use "append" or "extend" since set.val is of type list.
     """
+
     PROTOTYPE_FUNCTION = rset
 
 
@@ -292,6 +313,7 @@ class List(__Coll):
     Wraps an rlist. To add values to the contents of the list,
     use "append" or "extend" since set.val is of type list.
     """
+
     PROTOTYPE_FUNCTION = rlist
 
 
@@ -300,6 +322,7 @@ class Map(Type):
     Wraps an rmap. To add values to the contents of the map,
     use "update" since map.val is of type dict.
     """
+
     PROTOTYPE_FUNCTION = rmap
     PROTOTYPE_DEFAULT = dict
 
@@ -446,6 +469,7 @@ def parse_file(filename):
     Do NOT use this on data you don't trust.
     """
     from omero_ext.path import path
+
     scriptText = path(filename).text()
     return parse_text(scriptText)
 
@@ -471,7 +495,8 @@ def parse_inputs(inputs_strings, params):
 
     missing = MissingInputs()
     for key in sorted(
-            params.inputs, key=lambda name: params.inputs.get(name).grouping):
+        params.inputs, key=lambda name: params.inputs.get(name).grouping
+    ):
         param = params.inputs.get(key)
         a = inputs.get(key, None)
         if not a:
@@ -507,8 +532,15 @@ def parse_input(input_string, params):
             val = rbool(True)
     elif isinstance(
         param.prototype,
-        (omero.RLong, omero.RString, omero.RInt,
-         omero.RTime, omero.RDouble, omero.RFloat)):
+        (
+            omero.RLong,
+            omero.RString,
+            omero.RInt,
+            omero.RTime,
+            omero.RDouble,
+            omero.RFloat,
+        ),
+    ):
         val = param.prototype.__class__(val)
     elif isinstance(param.prototype, (omero.RList, omero.RSet)):
         rmethod = omero.rtypes.rlist
@@ -529,11 +561,13 @@ def parse_input(input_string, params):
             kls = getattr(omero.model, kls)
         except:
             raise ValueError(
-                "Format for objects: Class:id or ClassI:id. Not:%s" % val)
+                "Format for objects: Class:id or ClassI:id. Not:%s" % val
+            )
         val = omero.rtypes.robject(kls(_id, False))
     else:
-        raise ValueError("No converter for: %s (type=%s)"
-                         % (key, param.prototype.__class__))
+        raise ValueError(
+            "No converter for: %s (type=%s)" % (key, param.prototype.__class__)
+        )
 
     return {key: val}
 
@@ -577,7 +611,7 @@ def group_params(params):
         previous = None
         current = groupings
         for idx, key in enumerate(parts):
-            if (idx+1) < len(parts):
+            if (idx + 1) < len(parts):
                 # We need to descend further
                 previous = current
                 current = current[key]
@@ -593,8 +627,8 @@ def group_params(params):
                     replacement = dict()
                     replacement[""] = current
                     replacement[key] = param_name
-                    assert previous[parts[idx-1]] == current
-                    previous[parts[idx-1]] = replacement
+                    assert previous[parts[idx - 1]] == current
+                    previous[parts[idx - 1]] = replacement
                 else:
                     raise Exception(current, type(current))
 
@@ -668,11 +702,13 @@ def check_boundaries(key, min, max, input):
     # Check
     for x in items:
         if min is not None and min > x:
-            errors += error_msg("Out of bounds", key, "%s is below min %s", x,
-                                min)
+            errors += error_msg(
+                "Out of bounds", key, "%s is below min %s", x, min
+            )
         if max is not None and max < x:
-            errors += error_msg("Out of bounds", key, "%s is above max %s", x,
-                                max)
+            errors += error_msg(
+                "Out of bounds", key, "%s is above max %s", x, max
+            )
     return errors
 
 
@@ -730,8 +766,10 @@ def set_input(svc, session, key, value):
         svc.setInput(session, key, value)
         return ""
     except Exception as e:
-        return error_msg("Failed to set intput", key, "%s=%s. Error: %s", key,
-                         value, e)
+        return error_msg(
+            "Failed to set intput", key, "%s=%s. Error: %s", key, value, e
+        )
+
 
 #
 # Importing into omero.scripts namespace

--- a/src/omero/sys/__init__.py
+++ b/src/omero/sys/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import IceImport
+
 IceImport.load("omero_System_ice")
 IceImport.load("omero_Collections_ice")
 IceImport.load("omero_sys_ParametersI")

--- a/src/omero/testlib/cli.py
+++ b/src/omero/testlib/cli.py
@@ -31,8 +31,8 @@ from omero.rtypes import rstring
 from omero.testlib import ITest
 from mox3 import mox
 
-class AbstractCLITest(ITest):
 
+class AbstractCLITest(ITest):
     @classmethod
     def setup_class(cls):
         super(AbstractCLITest, cls).setup_class()
@@ -48,21 +48,20 @@ class AbstractCLITest(ITest):
 
 
 class CLITest(AbstractCLITest):
-
     def setup_method(self, method):
         self.args = self.login_args()
 
     def create_object(self, object_type, name=""):
         # create object
-        if object_type == 'Dataset':
+        if object_type == "Dataset":
             new_object = omero.model.DatasetI()
-        elif object_type == 'Project':
+        elif object_type == "Project":
             new_object = omero.model.ProjectI()
-        elif object_type == 'Plate':
+        elif object_type == "Plate":
             new_object = omero.model.PlateI()
-        elif object_type == 'Screen':
+        elif object_type == "Screen":
             new_object = omero.model.ScreenI()
-        elif object_type == 'Image':
+        elif object_type == "Image":
             new_object = self.new_image()
         new_object.name = rstring(name)
         new_object = self.update.saveAndReturnObject(new_object)
@@ -84,7 +83,6 @@ class CLITest(AbstractCLITest):
 
 
 class RootCLITest(AbstractCLITest):
-
     def setup_method(self, method):
         self.args = self.root_login_args()
 
@@ -115,43 +113,43 @@ class ArgumentFixture(object):
 
 
 UserIdNameFixtures = (
-    ArgumentFixture('--id', 'id'),
-    ArgumentFixture('--name', 'omeName'),
-    )
+    ArgumentFixture("--id", "id"),
+    ArgumentFixture("--name", "omeName"),
+)
 
 UserFixtures = (
-    ArgumentFixture(None, 'id'),
-    ArgumentFixture(None, 'omeName'),
-    ArgumentFixture('--user-id', 'id'),
-    ArgumentFixture('--user-name', 'omeName'),
-    )
+    ArgumentFixture(None, "id"),
+    ArgumentFixture(None, "omeName"),
+    ArgumentFixture("--user-id", "id"),
+    ArgumentFixture("--user-name", "omeName"),
+)
 
 GroupIdNameFixtures = (
-    ArgumentFixture('--id', 'id'),
-    ArgumentFixture('--name', 'name'),
-    )
+    ArgumentFixture("--id", "id"),
+    ArgumentFixture("--name", "name"),
+)
 
 GroupFixtures = (
-    ArgumentFixture(None, 'id'),
-    ArgumentFixture(None, 'name'),
-    ArgumentFixture('--group-id', 'id'),
-    ArgumentFixture('--group-name', 'name'),
-    )
+    ArgumentFixture(None, "id"),
+    ArgumentFixture(None, "name"),
+    ArgumentFixture("--group-id", "id"),
+    ArgumentFixture("--group-name", "name"),
+)
 
 
 def get_user_ids(out, sort_key=None):
-    columns = {'login': 1, 'first-name': 2, 'last-name': 3, 'email': 4}
-    lines = out.split('\n')
+    columns = {"login": 1, "first-name": 2, "last-name": 3, "email": 4}
+    lines = out.split("\n")
     ids = []
     last_value = None
     for line in lines[2:]:
-        elements = line.split('|')
+        elements = line.split("|")
         if len(elements) < 8:
             continue
 
         ids.append(int(elements[0].strip()))
         if sort_key:
-            if sort_key == 'id':
+            if sort_key == "id":
                 new_value = ids[-1]
             else:
                 new_value = elements[columns[sort_key]].strip()
@@ -162,17 +160,17 @@ def get_user_ids(out, sort_key=None):
 
 
 def get_group_ids(out, sort_key=None):
-    lines = out.split('\n')
+    lines = out.split("\n")
     ids = []
     last_value = None
     for line in lines[2:]:
-        elements = line.split('|')
+        elements = line.split("|")
         if len(elements) < 4:
             continue
 
         ids.append(int(elements[0].strip()))
         if sort_key:
-            if sort_key == 'id':
+            if sort_key == "id":
                 new_value = ids[-1]
             else:
                 new_value = elements[1].strip()

--- a/src/omero/testlib/script.py
+++ b/src/omero/testlib/script.py
@@ -26,7 +26,6 @@ from omero.gateway import BlitzGateway
 
 
 class ScriptTest(ITest):
-
     def get_script(self, path):
         script_service = self.root.sf.getScriptService()
         script = _get_script(script_service, path)
@@ -43,17 +42,17 @@ def run_script(client, script_id, args, key=None):
         while not cb.block(1000):  # ms.
             pass
         cb.close()
-        results = proc.getResults(0)    # ms
+        results = proc.getResults(0)  # ms
     finally:
         proc.close(False)
 
-    if 'stdout' in results:
-        orig_file = results['stdout'].getValue()
+    if "stdout" in results:
+        orig_file = results["stdout"].getValue()
         v = "Script generated StdOut in file:", orig_file.getId().getValue()
         logging.debug(v)
         assert orig_file.id.val > 0
-    if 'stderr' in results:
-        orig_file = results['stderr'].getValue()
+    if "stderr" in results:
+        orig_file = results["stderr"].getValue()
         v = "Script generated StdErr in file:", orig_file.getId().getValue()
         logging.debug(v)
         assert orig_file.getId().getValue() > 0
@@ -63,7 +62,7 @@ def run_script(client, script_id, args, key=None):
 
 def _get_script(script_service, script_path):
     """ Utility method, return the script or None """
-    scripts = script_service.getScripts()     # returns list of OriginalFiles
+    scripts = script_service.getScripts()  # returns list of OriginalFiles
 
     # make sure path starts with a slash.
     # ** If you are a Windows client - will need to convert all path separators
@@ -72,8 +71,10 @@ def _get_script(script_service, script_path):
         script_path = "/" + script_path
 
     named_scripts = [
-        s for s in scripts if
-        s.getPath().getValue() + s.getName().getValue() == script_path]
+        s
+        for s in scripts
+        if s.getPath().getValue() + s.getName().getValue() == script_path
+    ]
 
     if len(named_scripts) == 0:
         return None
@@ -88,9 +89,9 @@ def points_to_string(points):
     return "points[%s] points1[%s] points2[%s]" % (csv, csv, csv)
 
 
-def check_file_annotation(client, file_annotation,
-                          parent_type="Image", is_linked=True,
-                          file_name=None):
+def check_file_annotation(
+    client, file_annotation, parent_type="Image", is_linked=True, file_name=None
+):
     """
     Check validity of file annotation. If hasFileAnnotation, check the size,
     name and number of objects linked to the original file.

--- a/src/omero/util/OmeroPopo.py
+++ b/src/omero/util/OmeroPopo.py
@@ -44,6 +44,7 @@ from omero.model import NamespaceI
 from omero.rtypes import rdouble, rint, rlong, rstring
 
 import warnings
+
 # Popo helpers #
 
 
@@ -54,13 +55,14 @@ def toCSV(list):
     @return See above.
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     lenList = len(list)
     cnt = 0
     str = ""
     for item in list:
         str = str + item
-        if(cnt < lenList - 1):
+        if cnt < lenList - 1:
             str = str + ","
         cnt = cnt + 1
     return str
@@ -73,11 +75,13 @@ def toList(csvString):
     @return See above.
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-    list = csvString.split(',')
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
+    list = csvString.split(",")
     for index in range(len(list)):
         list[index] = list[index].strip()
     return list
+
 
 ##
 # Create instance of data object this object wraps the basic OMERO types.
@@ -92,7 +96,8 @@ class DataObject(object):
 
     def __init__(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.value = None
         self.dirty = False
 
@@ -102,7 +107,7 @@ class DataObject(object):
     # @param value The value to set.
     #
     def setValue(self, value):
-        if(value is None):
+        if value is None:
             raise Exception("IObject delegate for DataObject cannot be null.")
         self.value = value
 
@@ -111,7 +116,7 @@ class DataObject(object):
     # @return See above.
     #
     def getId(self):
-        if(self.value.getId() is None):
+        if self.value.getId() is None:
             return -1
         return self.value.getId().getValue()
 
@@ -164,7 +169,7 @@ class ImageData(DataObject):
 
     def __init__(self, image=None):
         DataObject.__init__(self)
-        if(image is None):
+        if image is None:
             self.setValue(ImageI())
         else:
             self.setValue(image)
@@ -177,7 +182,7 @@ class ImageData(DataObject):
     #
     def setName(self, name):
         image = self.asIObject()
-        if(image is None):
+        if image is None:
             raise Exception("No Image specified.")
         image.setName(rstring(name))
         self.setDirty(True)
@@ -189,10 +194,10 @@ class ImageData(DataObject):
     #
     def getName(self):
         image = self.asIObject()
-        if(image is None):
+        if image is None:
             raise Exception("No Image specified.")
         name = image.getName()
-        if(name is None):
+        if name is None:
             return ""
         return name.getValue()
 
@@ -204,7 +209,7 @@ class ImageData(DataObject):
     #
     def setDescription(self, description):
         image = self.asIObject()
-        if(image is None):
+        if image is None:
             raise Exception("No Image specified.")
         image.setDescription(rstring(description))
         self.setDirty(True)
@@ -216,12 +221,13 @@ class ImageData(DataObject):
     #
     def getDescription(self):
         image = self.asIObject()
-        if(image is None):
+        if image is None:
             raise Exception("No Image specified.")
         description = image.getDescription()
-        if(description is None):
+        if description is None:
             return ""
         return description.getValue()
+
 
 ##
 # This class stores the ROI Coordinate (Z,T).
@@ -244,7 +250,7 @@ class ROICoordinate(object):
     # Overload the equals operator
     #
     def __eq__(self, obj):
-        if(self.theZ == obj.theZ and self.theT == obj.theT):
+        if self.theZ == obj.theZ and self.theT == obj.theT:
             return True
         return False
 
@@ -252,7 +258,7 @@ class ROICoordinate(object):
     # Overload the equals operator
     #
     def __ne__(self, obj):
-        if(self.theZ != obj.theZ or self.theT != obj.theT):
+        if self.theZ != obj.theZ or self.theT != obj.theT:
             return True
         return False
 
@@ -260,9 +266,9 @@ class ROICoordinate(object):
     # Overload the lessthan or equals operator
     #
     def __lt__(self, obj):
-        if(self.theT >= obj.theT):
+        if self.theT >= obj.theT:
             return False
-        if(self.theZ >= obj.theZ):
+        if self.theZ >= obj.theZ:
             return False
         return True
 
@@ -270,9 +276,9 @@ class ROICoordinate(object):
     # Overload the lessthan or equals operator
     #
     def __le__(self, obj):
-        if(self.theT < obj.theT):
+        if self.theT < obj.theT:
             return False
-        if(self.theZ < obj.theZ):
+        if self.theZ < obj.theZ:
             return False
         return True
 
@@ -280,9 +286,9 @@ class ROICoordinate(object):
     # Overload the greater than equals operator
     #
     def __gt__(self, obj):
-        if(self.theT <= obj.theT):
+        if self.theT <= obj.theT:
             return False
-        if(self.theZ <= obj.theZ):
+        if self.theZ <= obj.theZ:
             return False
         return True
 
@@ -290,9 +296,9 @@ class ROICoordinate(object):
     # Overload the greater than or equals operator
     #
     def __ge__(self, obj):
-        if(self.theT < obj.theT):
+        if self.theT < obj.theT:
             return False
-        if(self.theZ < obj.theZ):
+        if self.theZ < obj.theZ:
             return False
         return True
 
@@ -344,15 +350,16 @@ def shapeWrapper(serverSideShape):
     """
     print("ServerSideShape")
     print(serverSideShape.__class__.__name__)
-    if serverSideShape.__class__.__name__ == 'EllipseI':
+    if serverSideShape.__class__.__name__ == "EllipseI":
         return EllipseData(serverSideShape)
-    if serverSideShape.__class__.__name__ == 'RectangleI':
+    if serverSideShape.__class__.__name__ == "RectangleI":
         return RectData(serverSideShape)
-    if serverSideShape.__class__.__name__ == 'MaskI':
+    if serverSideShape.__class__.__name__ == "MaskI":
         return MaskData(serverSideShape)
-    if serverSideShape.__class__.__name__ == 'PolygonI':
+    if serverSideShape.__class__.__name__ == "PolygonI":
         return PolygonData(serverSideShape)
     return None
+
 
 ##
 # This class defines the python mapping of
@@ -368,13 +375,14 @@ class ROIData(DataObject):
 
     def __init__(self, roi=None):
         DataObject.__init__(self)
-        if(roi is None):
+        if roi is None:
             self.setValue(RoiI())
         else:
             self.setValue(roi)
         self.roiShapes = dict()
-        if(roi is not None):
+        if roi is not None:
             self.initialise()
+
     ##
     # Initialise the shape map of the ROIData object.
     #
@@ -386,9 +394,9 @@ class ROIData(DataObject):
         s = None
         for shape in shapes:
             s = shapeWrapper(shape)
-            if(s is not None):
+            if s is not None:
                 coord = ROICoordinate(s.getZ(), s.getT())
-                if(coord not in list(self.roiShapes.keys())):
+                if coord not in list(self.roiShapes.keys()):
                     self.roiShapes[coord] = list()
                 data = self.roiShapes[coord]
                 data.append(s)
@@ -399,7 +407,7 @@ class ROIData(DataObject):
     #
     def setImage(self, image):
         roi = self.asIObject()
-        if(roi is None):
+        if roi is None:
             raise Exception("No Roi specified.")
         roi.setImage(image)
         self.setDirty(True)
@@ -410,7 +418,7 @@ class ROIData(DataObject):
     #
     def getImage(self):
         roi = self.asIObject()
-        if(roi is None):
+        if roi is None:
             raise Exception("No Roi specified.")
         return roi.getImage()
 
@@ -420,11 +428,11 @@ class ROIData(DataObject):
     #
     def addShapeData(self, shape):
         roi = self.asIObject()
-        if(roi is None):
+        if roi is None:
             raise Exception("No Roi specified.")
         coord = shape.getROICoordinate()
         shapeList = None
-        if(coord not in list(self.roiShapes.keys())):
+        if coord not in list(self.roiShapes.keys()):
             shapeList = list()
             self.roiShapes[coord] = shapeList
         else:
@@ -439,7 +447,7 @@ class ROIData(DataObject):
     #
     def removeShapeData(self, shape):
         roi = self.asIObject()
-        if(roi is None):
+        if roi is None:
             raise Exception("No Roi specified.")
         coord = shape.getROICoordinate()
         shapeList = self.roiShapes[coord]
@@ -495,13 +503,12 @@ class ROIData(DataObject):
         coordList.sort()
         keyList = []
         for coord in coordList:
-            if(coord >= start and coord <= end):
+            if coord >= start and coord <= end:
                 keyList.append(coord)
         return self.roiShapes.from_keys(keyList)
 
 
 class ShapeData(DataObject):
-
     def __init__(self):
         DataObject.__init__(self)
         self.text = None
@@ -514,10 +521,10 @@ class ShapeData(DataObject):
     #
     def getZ(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         z = shape.getTheZ()
-        if(z is None):
+        if z is None:
             return 0
         else:
             return z.getValue()
@@ -528,7 +535,7 @@ class ShapeData(DataObject):
     #
     def setZ(self, theZ):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setTheZ(rint(theZ))
         self.coord.setZSection(theZ)
@@ -541,10 +548,10 @@ class ShapeData(DataObject):
     #
     def getT(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         t = shape.getTheT()
-        if(t is None):
+        if t is None:
             return 0
         else:
             return t.getValue()
@@ -555,7 +562,7 @@ class ShapeData(DataObject):
     #
     def setT(self, theT):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setTheT(rint(theT))
         self.coord.setTimePoint(theT)
@@ -567,7 +574,7 @@ class ShapeData(DataObject):
     #
     def setROICoordinate(self, coord):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         self.setZ(coord.getZSection())
         self.setT(coord.getTimePoint())
@@ -581,7 +588,7 @@ class ShapeData(DataObject):
     #
     def getROICoordinate(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         return self.coord
 
@@ -590,10 +597,10 @@ class ShapeData(DataObject):
     # @return See above.
     def getText(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         text = shape.getTextValue()
-        if(text is None):
+        if text is None:
             return ""
         else:
             return text.getValue()
@@ -603,7 +610,7 @@ class ShapeData(DataObject):
     # @param See above.
     def setText(self, text):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setTextValue(rstring(text))
         self.setDirty(True)
@@ -616,12 +623,12 @@ class ShapeData(DataObject):
     #
     def getTransform(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         transform = shape.getTransform()
-        if(transform is not None):
+        if transform is not None:
             transformValue = transform.getValue()
-            if(transformValue == "none"):
+            if transformValue == "none":
                 return ""
             else:
                 return transformValue
@@ -629,7 +636,7 @@ class ShapeData(DataObject):
 
     def setTransform(self, transform):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setTransform(rstring(transform))
         self.setDirty(True)
@@ -640,11 +647,11 @@ class ShapeData(DataObject):
     # numpy.array([m00 m01 m02], [m10 m11 m12]).
     #
     def transformToMatrix(self, str):
-        if (str == ""):
+        if str == "":
             return numpy.matrix([[1, 0, 0], [0, 1, 0]])
-        transformstr = str[str.find('(') + 1:len(str) - 1]
-        values = transformstr.split(' ')
-        b = numpy.matrix(numpy.array(values, dtype='double'))
+        transformstr = str[str.find("(") + 1 : len(str) - 1]
+        values = transformstr.split(" ")
+        b = numpy.matrix(numpy.array(values, dtype="double"))
         t = numpy.matrix(numpy.zeros((3, 3)))
         t[0, 0] = b[0, 0]
         t[0, 1] = b[0, 2]
@@ -668,6 +675,7 @@ class ShapeData(DataObject):
     def containsPoints(self):
         return []
 
+
 ##
 # Instance of the EllipseData Object
 #
@@ -681,7 +689,7 @@ class EllipseData(ShapeData):
 
     def __init__(self, shape=None):
         ShapeData.__init__(self)
-        if(shape is None):
+        if shape is None:
             self.setValue(EllipseI())
             self.setX(0)
             self.setY(0)
@@ -695,7 +703,7 @@ class EllipseData(ShapeData):
     # @param x See above.
     def setX(self, x):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setX(rdouble(x))
 
@@ -704,10 +712,10 @@ class EllipseData(ShapeData):
     # @return See Above.
     def getX(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         x = shape.getX()
-        if(x is None):
+        if x is None:
             return 0
         return x.getValue()
 
@@ -716,7 +724,7 @@ class EllipseData(ShapeData):
     # @param y See above.
     def setY(self, y):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setY(rdouble(y))
 
@@ -725,10 +733,10 @@ class EllipseData(ShapeData):
     # @return See Above.
     def getY(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         y = shape.getY()
-        if(y is None):
+        if y is None:
             return 0
         return y.getValue()
 
@@ -737,7 +745,7 @@ class EllipseData(ShapeData):
     # @param radiusx See above.
     def setRadiusX(self, radiusx):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setRadiusX(rdouble(radiusx))
 
@@ -746,10 +754,10 @@ class EllipseData(ShapeData):
     # @return See Above.
     def getRadiusX(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         radiusx = shape.getRadiusX()
-        if(radiusx is None):
+        if radiusx is None:
             return 0
         return radiusx.getValue()
 
@@ -758,7 +766,7 @@ class EllipseData(ShapeData):
     # @param radiusy See above.
     def setRadiusY(self, radiusy):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setRadiusY(rdouble(radiusy))
 
@@ -767,10 +775,10 @@ class EllipseData(ShapeData):
     # @return See Above.
     def getRadiusY(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         radiusy = shape.getRadiusY()
-        if(radiusy is None):
+        if radiusy is None:
             return 0
         return radiusy.getValue()
 
@@ -808,8 +816,8 @@ class EllipseData(ShapeData):
         rt = transform * TR
         majl = transform * MajorAxisLeft
         majr = transform * MajorAxisRight
-        o = (majr[1] - majl[1])
-        a = (majr[0] - majl[0])
+        o = majr[1] - majl[1]
+        a = majr[0] - majl[0]
         h = math.sqrt(o * o + a * a)
         majorAxisAngle = math.asin(old_div(o, h))
         boundingBoxMinX = min(lt[0], rt[0], lb[0], rb[0])
@@ -818,10 +826,12 @@ class EllipseData(ShapeData):
         boundingBoxMaxY = max(lt[1], rt[1], lb[1], rb[1])
         boundingBox = (
             (boundingBoxMinX, boundingBoxMinY),
-            (boundingBoxMaxX, boundingBoxMaxY))
+            (boundingBoxMaxX, boundingBoxMaxY),
+        )
         centredBoundingBox = (
             (boundingBox[0][0] - centre[0], boundingBox[0][1] - centre[1]),
-            (boundingBox[1][0] - centre[0], boundingBox[1][1] - centre[1]))
+            (boundingBox[1][0] - centre[0], boundingBox[1][1] - centre[1]),
+        )
         points = {}
         cx = float(centre[0])
         cy = float(centre[1])
@@ -829,15 +839,19 @@ class EllipseData(ShapeData):
         yrange = list(range(centredBoundingBox[0][1], centredBoundingBox[1][1]))
         for dx in xrange:
             for dy in yrange:
-                newX = dx * math.cos(majorAxisAngle) + dy * \
-                    math.sin(majorAxisAngle)
-                newY = -dx * math.sin(majorAxisAngle) + \
-                    dy * math.cos(majorAxisAngle)
-                val = old_div((newX * newX), (radiusx * radiusx)) + \
-                    old_div((newY * newY), (radiusy * radiusy))
-                if(val <= 1):
+                newX = dx * math.cos(majorAxisAngle) + dy * math.sin(
+                    majorAxisAngle
+                )
+                newY = -dx * math.sin(majorAxisAngle) + dy * math.cos(
+                    majorAxisAngle
+                )
+                val = old_div((newX * newX), (radiusx * radiusx)) + old_div(
+                    (newY * newY), (radiusy * radiusy)
+                )
+                if val <= 1:
                     points[(int(dx + cx), int(dy + cy))] = 1
         return points
+
 
 ##
 # Instance of Polygon object.
@@ -854,7 +868,7 @@ class PolygonData(ShapeData):
         ShapeData.__init__(self)
         self.NUMREGEX = "\\[.*\\]"
         # Regex for a data in block.
-        if(shape is None):
+        if shape is None:
             self.setValue(PolygonI())
             self.points = []
             self.points1 = []
@@ -902,7 +916,7 @@ class PolygonData(ShapeData):
     #
     def setPointsString(self, pts):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setPoints(pts)
         self.setDirty(True)
@@ -930,10 +944,10 @@ class PolygonData(ShapeData):
     # @return See above.
     def getPointsString(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         pts = shape.getPoints()
-        if(pts is None):
+        if pts is None:
             return ""
         else:
             return pts.getValue()
@@ -956,20 +970,20 @@ class PolygonData(ShapeData):
     #
     def getContents(self, string, start, end):
         lIndex = string.find(start)
-        if(lIndex == -1):
+        if lIndex == -1:
             return ""
         strFragment = string[lIndex:]
-        rIndex = strFragment.find(']')
-        if(rIndex == -1):
+        rIndex = strFragment.find("]")
+        if rIndex == -1:
             return ""
-        return string[lIndex + len(start):rIndex]
+        return string[lIndex + len(start) : rIndex]
 
     ##
     # Convert the pts string to a list
     # @return See above.
     #
     def parsePointsToList(self, pts):
-        numberList = pts.split(',')
+        numberList = pts.split(",")
         return numberList
 
     ##
@@ -980,7 +994,7 @@ class PolygonData(ShapeData):
         str = ""
         for index, pt in enumerate(pointsList):
             str = str + pt
-            if(index < len(pointsList) - 1):
+            if index < len(pointsList) - 1:
                 str = str + ","
         return str
 
@@ -1021,7 +1035,8 @@ class PolygonData(ShapeData):
         coords = []
         for index in range(old_div(len(ptsList), 2)):
             coords.append(
-                (int(ptsList[index * 2]), int(ptsList[index * 2 + 1])))
+                (int(ptsList[index * 2]), int(ptsList[index * 2 + 1]))
+            )
         return coords
 
     ##
@@ -1035,7 +1050,7 @@ class PolygonData(ShapeData):
         yrange = list(range(boundingRectangle[0][1], boundingRectangle[1][1]))
         for xx in xrange:
             for yy in yrange:
-                if(self.inPolygon((xx, yy))):
+                if self.inPolygon((xx, yy)):
                     points[(xx, yy)] = 1
         return points
 
@@ -1051,7 +1066,8 @@ class PolygonData(ShapeData):
         polygon = []
         for index in range(0, old_div(len(polypoints), 2)):
             polygon.append(
-                (int(polypoints[index * 2]), int(polypoints[index * 2 + 1])))
+                (int(polypoints[index * 2]), int(polypoints[index * 2 + 1]))
+            )
 
         n = len(polygon)
 
@@ -1073,7 +1089,7 @@ class PolygonData(ShapeData):
     # @param y2 The y of the second vector
     # @return see above.
     #
-    def Angle2D(self,  x1, y1, x2, y2):
+    def Angle2D(self, x1, y1, x2, y2):
         theta1 = math.atan2(y1, x1)
         theta2 = math.atan2(y2, x2)
         dtheta = theta2 - theta1
@@ -1082,6 +1098,7 @@ class PolygonData(ShapeData):
         while dtheta < -math.pi:
             dtheta += 2.0 * math.pi
         return dtheta
+
 
 ##
 # Instance of the Mask Object
@@ -1096,7 +1113,7 @@ class MaskData(ShapeData):
 
     def __init__(self, maskShape=None):
         ShapeData.__init__(self)
-        if(maskShape is None):
+        if maskShape is None:
             self.setValue(MaskI())
             self.setX(0)
             self.setY(0)
@@ -1111,7 +1128,7 @@ class MaskData(ShapeData):
     # @param x See above.
     def setX(self, x):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setX(rdouble(x))
 
@@ -1120,10 +1137,10 @@ class MaskData(ShapeData):
     # @return See Above.
     def getX(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         x = shape.getX()
-        if(x is None):
+        if x is None:
             return 0
         return x.getValue()
 
@@ -1132,7 +1149,7 @@ class MaskData(ShapeData):
     # @param y See above.
     def setY(self, y):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setY(rdouble(y))
 
@@ -1141,19 +1158,20 @@ class MaskData(ShapeData):
     # @return See Above.
     def getY(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         y = shape.getY()
-        if(y is None):
+        if y is None:
             return 0
         return y.getValue()
+
     ##
     # Set the width the Mask
     # @param width See above.
 
     def setWidth(self, width):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setWidth(rdouble(width))
 
@@ -1162,19 +1180,20 @@ class MaskData(ShapeData):
     # @return See Above.
     def getWidth(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         width = shape.getWidth()
-        if(width is None):
+        if width is None:
             return 0
         return width.getValue()
+
     ##
     # Set the height of the Mask
     # @param height See above.
 
     def setHeight(self, height):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setHeight(rdouble(height))
 
@@ -1183,19 +1202,20 @@ class MaskData(ShapeData):
     # @return See Above.
     def getHeight(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         height = shape.getHeight()
-        if(height is None):
+        if height is None:
             return 0
         return height.getValue()
+
     ##
     # Set the bitmask of the Mask
     # @param See Above.
 
     def setMask(self, mask):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setBytes(mask)
 
@@ -1204,10 +1224,10 @@ class MaskData(ShapeData):
     # @return See Above.
     def getMask(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         mask = shape.getBytes()
-        if(mask is None):  # ??
+        if mask is None:  # ??
             return 0
         return mask.getValue()
 
@@ -1223,7 +1243,7 @@ class RectData(ShapeData):
 
     def __init__(self, rectShape=None):
         ShapeData.__init__(self)
-        if (rectShape is None):
+        if rectShape is None:
             self.setValue(RectangleI())
             self.setX(0)
             self.setY(0)
@@ -1237,7 +1257,7 @@ class RectData(ShapeData):
     # @param x See above.
     def setX(self, x):
         shape = self.asIObject()
-        if (shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setX(rdouble(x))
 
@@ -1246,10 +1266,10 @@ class RectData(ShapeData):
     # @return See Above.
     def getX(self):
         shape = self.asIObject()
-        if (shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         x = shape.getX()
-        if (x is None):
+        if x is None:
             return 0
         return x.getValue()
 
@@ -1258,7 +1278,7 @@ class RectData(ShapeData):
     # @param y See above.
     def setY(self, y):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setY(rdouble(y))
 
@@ -1267,19 +1287,20 @@ class RectData(ShapeData):
     # @return See Above.
     def getY(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         y = shape.getY()
-        if(y is None):
+        if y is None:
             return 0
         return y.getValue()
+
     ##
     # Set the width the Rectangle
     # @param width See above.
 
     def setWidth(self, width):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setWidth(rdouble(width))
 
@@ -1288,19 +1309,20 @@ class RectData(ShapeData):
     # @return See Above.
     def getWidth(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         width = shape.getWidth()
-        if(width is None):
+        if width is None:
             return 0
         return width.getValue()
+
     ##
     # Set the height of the Rectangle
     # @param height See above.
 
     def setHeight(self, height):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         shape.setHeight(rdouble(height))
 
@@ -1309,10 +1331,10 @@ class RectData(ShapeData):
     # @return See Above.
     def getHeight(self):
         shape = self.asIObject()
-        if(shape is None):
+        if shape is None:
             raise Exception("No Shape specified.")
         height = shape.getHeight()
-        if(height is None):
+        if height is None:
             return 0
         return height.getValue()
 
@@ -1348,8 +1370,8 @@ class RectData(ShapeData):
         rt = transform * TR
         majl = lb
         majr = rb
-        o = (majr[1] - majl[1])
-        a = (majr[0] - majl[0])
+        o = majr[1] - majl[1]
+        a = majr[0] - majl[0]
         h = math.sqrt(o * o + a * a)
         angle = math.asin(old_div(o, h))
         boundingBoxMinX = min(lt[0], rt[0], lb[0], rb[0])
@@ -1358,7 +1380,8 @@ class RectData(ShapeData):
         boundingBoxMaxY = max(lt[1], rt[1], lb[1], rb[1])
         boundingBox = (
             (boundingBoxMinX, boundingBoxMinY),
-            (boundingBoxMaxX, boundingBoxMaxY))
+            (boundingBoxMaxX, boundingBoxMaxY),
+        )
         points = {}
         xrange = list(range(boundingBox[0][0], boundingBox[1][0]))
         yrange = list(range(boundingBox[0][1], boundingBox[1][1]))
@@ -1371,12 +1394,15 @@ class RectData(ShapeData):
                 newX = xx * math.cos(angle) + yy * math.sin(angle)
                 newY = -xx * math.sin(angle) + yy * math.cos(angle)
 
-                if (newX - transformedX < width
-                        and newY - transformedY < height
-                        and newX - transformedX > 0
-                        and newY - transformedY > 0):
+                if (
+                    newX - transformedX < width
+                    and newY - transformedY < height
+                    and newX - transformedX > 0
+                    and newY - transformedY > 0
+                ):
                     points[(int(x + cx), int(y + cy))] = 1
         return points
+
 
 ##
 # The workflow data object, which wraps the omero.mdoel.NamespaceI class
@@ -1384,10 +1410,9 @@ class RectData(ShapeData):
 
 
 class WorkflowData(DataObject):
-
     def __init__(self, workflow=None):
         DataObject.__init__(self)
-        if(workflow is None):
+        if workflow is None:
             self.setValue(NamespaceI())
             self.setNamespace("")
             self.setKeywords([])
@@ -1400,7 +1425,7 @@ class WorkflowData(DataObject):
     # @param namespace See above.
     def setNamespace(self, namespace):
         workflow = self.asIObject()
-        if(workflow is None):
+        if workflow is None:
             raise Exception("No workflow specified.")
         workflow.setName(rstring(namespace))
         self.setDirty(True)
@@ -1410,10 +1435,10 @@ class WorkflowData(DataObject):
     # @return See Above.
     def getNamespace(self):
         workflow = self.asIObject()
-        if(workflow is None):
+        if workflow is None:
             raise Exception("No Workflow specified.")
         namespace = workflow.getName()
-        if(namespace is None):
+        if namespace is None:
             return ""
         return namespace.getValue()
 
@@ -1422,7 +1447,7 @@ class WorkflowData(DataObject):
     # @param namespace See above.
     def setKeywords(self, keywords):
         workflow = self.asIObject()
-        if(workflow is None):
+        if workflow is None:
             raise Exception("No workflow specified.")
         workflow.setKeywords(keywords)
         self.setDirty(True)
@@ -1432,7 +1457,7 @@ class WorkflowData(DataObject):
     # @param namespace See above.
     def setKeywordsFromString(self, keywords):
         workflow = self.asIObject()
-        if(workflow is None):
+        if workflow is None:
             raise Exception("No workflow specified.")
         workflow.setKeywords(toList(keywords))
         self.setDirty(True)
@@ -1442,10 +1467,10 @@ class WorkflowData(DataObject):
     # @return See Above.
     def getKeywords(self):
         workflow = self.asIObject()
-        if(workflow is None):
+        if workflow is None:
             raise Exception("No Workflow specified.")
         keywords = workflow.getKeywords()
-        if(keywords is None):
+        if keywords is None:
             return []
         return keywords
 
@@ -1453,7 +1478,7 @@ class WorkflowData(DataObject):
     # Add a keyword to the workflow
     # @param keyword See Above.
     def addKeyword(self, keyword):
-        if(self.containsKeyword(keyword)):
+        if self.containsKeyword(keyword):
             return
         keywords = self.getKeywords()
         keywords.append(keyword)
@@ -1464,13 +1489,13 @@ class WorkflowData(DataObject):
     # @return See Above.
     def containsKeyword(self, keyword):
         keywords = self.getKeywords()
-        return (keyword in keywords)
+        return keyword in keywords
 
     ##
     # Remove the keyword from the workflow
     # @param keyword See Above.
     def removeKeyword(self, keyword):
-        if(not self.containsKeyword(keyword)):
+        if not self.containsKeyword(keyword):
             return
         newList = self.getKeywords()
         newList.remove(keyword)

--- a/src/omero/util/ROIDrawingUtils.py
+++ b/src/omero/util/ROIDrawingUtils.py
@@ -81,6 +81,7 @@ Example code to draw a polyline on an image an display it in PIL::
 
 
 from builtins import object
+
 try:
     from PIL import Image, ImageDraw  # see ticket:2597
 except ImportError:
@@ -106,7 +107,8 @@ class DrawingCanvas(object):
 
     def __init__(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.width = 0
         self.height = 0
         self.image = None
@@ -119,8 +121,9 @@ class DrawingCanvas(object):
     # @param height See above.
     def createImage(self, width, height):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        self.image = Image.new('RGBA', (width, height), (0, 0, 0, 0))
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        self.image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
         self.width = width
         self.height = height
 
@@ -131,7 +134,8 @@ class DrawingCanvas(object):
     # @param height See above.
     def setImage(self, image, width, height):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.image = image
         self.width = width
         self.height = height
@@ -141,8 +145,9 @@ class DrawingCanvas(object):
     # @param elementList See above.
     def drawElements(self, elementList):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        if(self.draw is None):
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        if self.draw is None:
             self.draw = ImageDraw.Draw(self.image)
         for element in elementList:
             element.acceptVisitor(self)
@@ -154,7 +159,8 @@ class DrawingCanvas(object):
     #
     def getFillColour(self, shapeSettings):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return shapeSettings[1][0]
 
     ##
@@ -163,7 +169,8 @@ class DrawingCanvas(object):
     #
     def getStrokeColour(self, shapeSettings):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return shapeSettings[0][0]
 
     ##
@@ -172,7 +179,8 @@ class DrawingCanvas(object):
     #
     def getStrokeWidth(self, shapeSettings):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return shapeSettings[0][1]
 
     ##
@@ -184,18 +192,21 @@ class DrawingCanvas(object):
     # @param shapeSettings The shapes display properties(colour,etc).
     # @param affineTransform The affine transform that the shape has to
     #                        undergo before drawing.
-    def drawEllipse(self, x, y, radiusx, radiusy, shapeSettings,
-                    affineTransform=None):
+    def drawEllipse(
+        self, x, y, radiusx, radiusy, shapeSettings, affineTransform=None
+    ):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         x0 = x - radiusx
         y0 = y - radiusy
         x1 = x0 + radiusx * 2
         y1 = y0 + radiusy * 2
         fillColour = self.getFillColour(shapeSettings)
         strokeColour = self.getStrokeColour(shapeSettings)
-        self.draw.ellipse((x0, y0, x1, y1), fill=fillColour,
-                          outline=strokeColour)
+        self.draw.ellipse(
+            (x0, y0, x1, y1), fill=fillColour, outline=strokeColour
+        )
 
     ##
     # Draw a rectangle at (x, y) with width, height (width, height).
@@ -208,19 +219,23 @@ class DrawingCanvas(object):
     #                        undergo before drawing.
     def drawRectangle(self, x, y, w, h, shapeSettings, affineTransform=None):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         fillColour = self.getFillColour(shapeSettings)
         strokeColour = self.getStrokeColour(shapeSettings)
-        if(affineTransform is None):
+        if affineTransform is None:
             self.draw.rectangle(
-                (x, y, w, h), fill=fillColour, outline=strokeColour)
+                (x, y, w, h), fill=fillColour, outline=strokeColour
+            )
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             newDraw = ImageDraw.Draw(im)
             newDraw.rectangle(
-                (x, y, w, h), fill=fillColour, outline=strokeColour)
+                (x, y, w, h), fill=fillColour, outline=strokeColour
+            )
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)
 
     ##
@@ -232,19 +247,23 @@ class DrawingCanvas(object):
     #                        undergo before drawing.
     def drawPolygon(self, pointTupleList, shapeSettings, affineTransform=None):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         fillColour = self.getFillColour(shapeSettings)
         strokeColour = self.getStrokeColour(shapeSettings)
-        if(affineTransform is None):
+        if affineTransform is None:
             self.draw.polygon(
-                pointTupleList, fill=fillColour, outline=strokeColour)
+                pointTupleList, fill=fillColour, outline=strokeColour
+            )
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             ImageDraw.Draw(im)
             self.draw.polygon(
-                pointTupleList, fill=fillColour, outline=strokeColour)
+                pointTupleList, fill=fillColour, outline=strokeColour
+            )
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)
 
     ##
@@ -258,19 +277,23 @@ class DrawingCanvas(object):
     #                        undergo before drawing.
     def drawLine(self, x1, y1, x2, y2, shapeSettings, affineTransform=None):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         strokeColour = self.getStrokeColour(shapeSettings)
         strokeWidth = self.getStrokeWidth(shapeSettings)
-        if(affineTransform is None):
+        if affineTransform is None:
             self.draw.line(
-                [(x1, y1), (x2, y2)], fill=strokeColour, width=strokeWidth)
+                [(x1, y1), (x2, y2)], fill=strokeColour, width=strokeWidth
+            )
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             ImageDraw.Draw(im)
             self.draw.line(
-                [(x1, y1), (x2, y2)], fill=strokeColour, width=strokeWidth)
+                [(x1, y1), (x2, y2)], fill=strokeColour, width=strokeWidth
+            )
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)
 
     ##
@@ -280,22 +303,24 @@ class DrawingCanvas(object):
     # @param shapeSettings The shapes display properties(colour,etc).
     # @param affineTransform The affine transform that the shape has to
     #                        undergo before drawing.
-    def drawPolyline(self, pointTupleList,
-                     shapeSettings, affineTransform=None):
+    def drawPolyline(self, pointTupleList, shapeSettings, affineTransform=None):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         fillColour = self.getFillColour(shapeSettings)
         strokeColour = self.getStrokeColour(shapeSettings)
         strokeWidth = self.getStrokeWidth(shapeSettings)
-        if(affineTransform is None):
+        if affineTransform is None:
             self.draw.line(pointTupleList, fill=fillColour, width=strokeWidth)
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             ImageDraw.Draw(im)
             self.draw.line(
-                pointTupleList, fill=strokeColour, width=strokeColour)
+                pointTupleList, fill=strokeColour, width=strokeColour
+            )
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)
 
     ##
@@ -308,20 +333,23 @@ class DrawingCanvas(object):
     # @param shapeSettings The shapes display properties(colour,etc).
     # @param affineTransform The affine transform that the shape has to
     #                        undergo before drawing.
-    def drawMask(self, x, y, width, height, bytes,
-                 shapeSettings, affineTransform=None):
+    def drawMask(
+        self, x, y, width, height, bytes, shapeSettings, affineTransform=None
+    ):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         fillColour = self.getFillColour(shapeSettings)
-        mask = Image.fromstring('1', (width, height), bytes)
-        if(affineTransform is None):
+        mask = Image.fromstring("1", (width, height), bytes)
+        if affineTransform is None:
             self.draw.bitmap(x, y, mask, fill=fillColour)
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             ImageDraw.Draw(im)
             self.draw.bitmap(x, y, mask, fill=fillColour)
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)
 
     ##
@@ -335,13 +363,15 @@ class DrawingCanvas(object):
     def drawText(self, x, y, text, shapeSettings, affineTransform=None):
         textColour = self.getStrokeColour(shapeSettings)
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        if(affineTransform is None):
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        if affineTransform is None:
             self.draw.text((x, y), text, fill=textColour)
         else:
-            im = Image.new('RGBA', (self.width, self.height), (0, 0, 0, 0))
+            im = Image.new("RGBA", (self.width, self.height), (0, 0, 0, 0))
             ImageDraw.Draw(im)
             self.draw.text((x, y), text, fill=textColour)
             newImage = im.transform(
-                (self.width, self.height), Image.AFFINE, affineTransform)
+                (self.width, self.height), Image.AFFINE, affineTransform
+            )
             self.image.paste(newImage)

--- a/src/omero/util/ROI_utils.py
+++ b/src/omero/util/ROI_utils.py
@@ -58,6 +58,7 @@ from omero.model import MaskI
 from omero.rtypes import rdouble, rint, rstring
 
 import warnings
+
 #
 # HELPERS
 #
@@ -72,12 +73,13 @@ def pointsStringToXYlist(string):
     or the new format: "309,427 366,503 190,491"
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     pointLists = string.strip().split("points")
     if len(pointLists) < 2:
         if len(pointLists) == 1 and pointLists[0]:
             xys = pointLists[0].split()
-            xyList = [tuple(map(int, xy.split(','))) for xy in xys]
+            xyList = [tuple(map(int, xy.split(","))) for xy in xys]
             return xyList
 
         msg = "Unrecognised ROI shape 'points' string: %s" % string
@@ -97,14 +99,19 @@ def xyListToBbox(xyList):
     represented by the XY points list
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     xList, yList = [], []
     for xy in xyList:
         x, y = xy
         xList.append(x)
         yList.append(y)
-    return (min(xList), min(yList), max(xList)-min(xList),
-            max(yList)-min(yList))
+    return (
+        min(xList),
+        min(yList),
+        max(xList) - min(xList),
+        max(yList) - min(yList),
+    )
 
 
 #
@@ -117,8 +124,10 @@ def xyListToBbox(xyList):
 #
 def abstract():
     import inspect
+
     caller = inspect.getouterframes(inspect.currentframe())[1][3]
-    raise NotImplementedError(caller + ' must be implemented in subclass')
+    raise NotImplementedError(caller + " must be implemented in subclass")
+
 
 ##
 # ShapeSettingsData contains all the display information about
@@ -136,7 +145,8 @@ class ShapeSettingsData(object):
 
     def __init__(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.WHITE = 16777215
         self.BLACK = 0
         self.GREY = 11184810
@@ -144,9 +154,9 @@ class ShapeSettingsData(object):
         self.strokeWidth = LengthI()
         self.strokeWidth.setValue(1)
         self.strokeWidth.setUnit(UnitsLength.POINT)
-        self.strokeDashArray = rstring('')
+        self.strokeDashArray = rstring("")
         self.fillColour = rint(self.GREY)
-        self.fillRule = rstring('')
+        self.fillRule = rstring("")
 
     ##
     # Applies the settings in the ShapeSettingsData to the ROITypeI
@@ -155,7 +165,8 @@ class ShapeSettingsData(object):
     #
     def setROIShapeSettings(self, shape):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         shape.setStrokeColor(self.strokeColour)
         shape.setStrokeWidth(self.strokeWidth)
         shape.setStrokeDashArray(self.strokeDashArray)
@@ -169,7 +180,8 @@ class ShapeSettingsData(object):
     #
     def setStrokeSettings(self, colour, width=1):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.strokeColour = rint(colour)
         self.strokeWidth = LengthI()
         self.strokeWidth.setValue(width)
@@ -180,7 +192,8 @@ class ShapeSettingsData(object):
     # @param colour The fill colour of the shape.
     def setFillSettings(self, colour):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.fillColour = rstring(colour)
 
     ##
@@ -189,7 +202,8 @@ class ShapeSettingsData(object):
     #
     def getStrokeSettings(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return (self.strokeColour.getValue(), self.strokeWidth.getValue())
 
     ##
@@ -198,8 +212,9 @@ class ShapeSettingsData(object):
     #
     def getFillSettings(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        return (self.fillColour.getValue())
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        return self.fillColour.getValue()
 
     ##
     # Get the tuple ((stokeColor, strokeWidth), (fillColour)).
@@ -207,7 +222,8 @@ class ShapeSettingsData(object):
     #
     def getSettings(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return (self.getStrokeSettings(), self.getFillSettings())
 
     ##
@@ -216,12 +232,14 @@ class ShapeSettingsData(object):
     #
     def getShapeSettingsFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.strokeColour = roi.getStrokeColor()
         self.strokeWidth = roi.getStrokeWidth()
         self.strokeDashArray = roi.getStrokeDashArray()
         self.fillColour = roi.getFillColor()
         self.fillRule = roi.getFillRule()
+
 
 ##
 # This class stores the ROI Coordinate (Z,T).
@@ -237,7 +255,8 @@ class ROICoordinate(object):
 
     def __init__(self, z=0, t=0):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.theZ = rint(z)
         self.theT = rint(t)
 
@@ -247,7 +266,8 @@ class ROICoordinate(object):
     #
     def setROICoord(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         roi.setTheZ(self.theZ)
         roi.setTheT(self.theT)
 
@@ -257,9 +277,11 @@ class ROICoordinate(object):
     #
     def setCoordFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.theZ = roi.getTheZ()
         self.theT = roi.getTheT()
+
 
 ##
 # Interface to inherit for accepting ROIDrawing as a visitor.
@@ -268,11 +290,12 @@ class ROICoordinate(object):
 
 
 class ROIDrawingI(object):
-
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         abstract()
+
 
 ##
 # The base class for all ROIShapeData objects.
@@ -287,7 +310,8 @@ class ShapeData(object):
 
     def __init__(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.coord = ROICoordinate()
         self.shapeSettings = ShapeSettingsData()
         self.ROI = None
@@ -298,7 +322,8 @@ class ShapeData(object):
     #
     def setCoord(self, coord):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.coord = coord
 
     ##
@@ -307,7 +332,8 @@ class ShapeData(object):
     #
     def setROICoord(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.coord.setROICoord(roi)
 
     ##
@@ -316,7 +342,8 @@ class ShapeData(object):
     #
     def setROIGeometry(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         abstract()
 
     ##
@@ -325,7 +352,8 @@ class ShapeData(object):
     #
     def setShapeSettings(self, settings):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.shapeSettings = settings
 
     ##
@@ -334,7 +362,8 @@ class ShapeData(object):
     #
     def setROIShapeSettings(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.shapeSettings.setROIShapeSettings(roi)
 
     ##
@@ -343,7 +372,8 @@ class ShapeData(object):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         abstract()
 
     ##
@@ -351,7 +381,8 @@ class ShapeData(object):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         abstract()
 
     ##
@@ -361,8 +392,9 @@ class ShapeData(object):
     #
     def getROI(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        if(self.roi is not None):
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        if self.roi is not None:
             return self.roi
         self.roi = self.createBaseType()
         self.setROICoord(self.roi)
@@ -376,7 +408,8 @@ class ShapeData(object):
     #
     def getShapeSettingsFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.shapeSettings.getShapeSettingsFromROI(roi)
 
     ##
@@ -385,7 +418,8 @@ class ShapeData(object):
     #
     def getCoordFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.coord.setCoordFromROI(roi)
 
     ##
@@ -394,7 +428,8 @@ class ShapeData(object):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         abstract()
 
     ##
@@ -403,11 +438,13 @@ class ShapeData(object):
     #
     def fromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.roi = roi
         self.getShapeSettingsFromROI(roi)
         self.getCoordFromROI(roi)
         self.getGeometryFromROI(roi)
+
 
 ##
 # The EllispeData class contains all the manipulation and create of EllipseI
@@ -426,10 +463,12 @@ class EllipseData(ShapeData, ROIDrawingI):
     # @param radiusX The major axis of the ellipse.
     # @param radiusY The minor axis of the ellipse.
 
-    def __init__(self, roicoord=ROICoordinate(), x=0, y=0, radiusX=0,
-                 radiusY=0):
+    def __init__(
+        self, roicoord=ROICoordinate(), x=0, y=0, radiusX=0, radiusY=0
+    ):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.x = rdouble(x)
         self.y = rdouble(y)
@@ -442,7 +481,8 @@ class EllipseData(ShapeData, ROIDrawingI):
     #
     def setROIGeometry(self, ellipse):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ellipse.setTheZ(self.coord.theZ)
         ellipse.setTheT(self.coord.theT)
         ellipse.setX(self.x)
@@ -455,7 +495,8 @@ class EllipseData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.x = roi.getX()
         self.y = roi.getY()
         self.radiusX = roi.getRadiusX()
@@ -466,7 +507,8 @@ class EllipseData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return EllipseI()
 
     ##
@@ -474,10 +516,16 @@ class EllipseData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         visitor.drawEllipse(
-            self.x.getValue(), self.y.getValue(), self.radiusX.getValue(),
-            self.radiusY.getValue(), self.shapeSettings.getSettings())
+            self.x.getValue(),
+            self.y.getValue(),
+            self.radiusX.getValue(),
+            self.radiusY.getValue(),
+            self.shapeSettings.getSettings(),
+        )
+
 
 ##
 # The RectangleData class contains all the manipulation and creation of
@@ -498,7 +546,8 @@ class RectangleData(ShapeData, ROIDrawingI):
 
     def __init__(self, roicoord=ROICoordinate(), x=0, y=0, width=0, height=0):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.x = rdouble(x)
         self.y = rdouble(y)
@@ -511,7 +560,8 @@ class RectangleData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, rectangle):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         rectangle.setTheZ(self.coord.theZ)
         rectangle.setTheT(self.coord.theT)
         rectangle.setX(self.x)
@@ -524,7 +574,8 @@ class RectangleData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.x = roi.getX()
         self.y = roi.getY()
         self.width = roi.getWidth()
@@ -535,7 +586,8 @@ class RectangleData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return RectangleI()
 
     ##
@@ -543,10 +595,17 @@ class RectangleData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         visitor.drawRectangle(
-            self.x, self.y, self.width, self.height,
-            self.shapeSettings.getSettings())
+            self.x,
+            self.y,
+            self.width,
+            self.height,
+            self.shapeSettings.getSettings(),
+        )
+
+
 ##
 # The LineData class contains all the manipulation and create of LineI
 # types.
@@ -566,7 +625,8 @@ class LineData(ShapeData, ROIDrawingI):
 
     def __init__(self, roicoord=ROICoordinate(), x1=0, y1=0, x2=0, y2=0):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.x1 = rdouble(x1)
         self.y1 = rdouble(y1)
@@ -579,7 +639,8 @@ class LineData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, line):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         line.setTheZ(self.coord.theZ)
         line.setTheT(self.coord.theT)
         line.setX1(self.x1)
@@ -592,7 +653,8 @@ class LineData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.x1 = roi.getX1()
         self.y1 = roi.getY1()
         self.x2 = roi.getX2()
@@ -603,7 +665,8 @@ class LineData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return LineI()
 
     ##
@@ -611,10 +674,16 @@ class LineData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         visitor.drawLine(
-            self.x1.getValue(), self.y1.getValue(), self.x2.getValue(),
-            self.y2.getValue(), self.shapeSettings.getSettings())
+            self.x1.getValue(),
+            self.y1.getValue(),
+            self.x2.getValue(),
+            self.y2.getValue(),
+            self.shapeSettings.getSettings(),
+        )
+
 
 ##
 # The MaskData class contains all the manipulation and create of MaskI
@@ -634,10 +703,12 @@ class MaskData(ShapeData, ROIDrawingI):
     # @param width The width of the shape.
     # @param height The height of the shape.
 
-    def __init__(self, roicoord=ROICoordinate(), bytes=None,
-                 x=0, y=0, width=0, height=0):
+    def __init__(
+        self, roicoord=ROICoordinate(), bytes=None, x=0, y=0, width=0, height=0
+    ):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.x = rdouble(x)
         self.y = rdouble(y)
@@ -651,7 +722,8 @@ class MaskData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, mask):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         mask.setTheZ(self.coord.theZ)
         mask.setTheT(self.coord.theT)
         mask.setX(self.x)
@@ -665,7 +737,8 @@ class MaskData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.x = roi.getX()
         self.y = roi.getY()
         self.width = roi.getWidth()
@@ -677,7 +750,8 @@ class MaskData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return MaskI()
 
     ##
@@ -685,11 +759,17 @@ class MaskData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         visitor.drawMask(
-            self.x.getValue(), self.y.getValue(),
-            self.width.getValue(), self.height.getValue(),
-            self.bytesdata, self.shapeSettings.getSettings())
+            self.x.getValue(),
+            self.y.getValue(),
+            self.width.getValue(),
+            self.height.getValue(),
+            self.bytesdata,
+            self.shapeSettings.getSettings(),
+        )
+
 
 ##
 # The PointData class contains all the manipulation and create of PointI
@@ -708,7 +788,8 @@ class PointData(ShapeData, ROIDrawingI):
 
     def __init__(self, roicoord=ROICoordinate(), x=0, y=0):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.x = rdouble(x)
         self.y = rdouble(y)
@@ -719,7 +800,8 @@ class PointData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, point):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         point.setTheZ(self.coord.theZ)
         point.setTheT(self.coord.theT)
         point.setX(self.x)
@@ -730,7 +812,8 @@ class PointData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.x = roi.getX()
         self.y = roi.getY()
 
@@ -739,7 +822,8 @@ class PointData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return PointI()
 
     ##
@@ -747,10 +831,16 @@ class PointData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         visitor.drawEllipse(
-            self.x.getValue(), self.y.getValue(), 3, 3,
-            self.shapeSettings.getSettings())
+            self.x.getValue(),
+            self.y.getValue(),
+            3,
+            3,
+            self.shapeSettings.getSettings(),
+        )
+
 
 ##
 # The PolygonData class contains all the manipulation and create of PolygonI
@@ -769,7 +859,8 @@ class PolygonData(ShapeData, ROIDrawingI):
 
     def __init__(self, roicoord=ROICoordinate(), pointsList=(0, 0)):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.points = rstring(self.listToString(pointsList))
         self.setCoord(roicoord)
@@ -779,7 +870,8 @@ class PolygonData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, polygon):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         polygon.setTheZ(self.coord.theZ)
         polygon.setTheT(self.coord.theT)
         polygon.setPoints(self.points)
@@ -789,7 +881,8 @@ class PolygonData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.points = roi.getPoints()
 
     ##
@@ -798,12 +891,13 @@ class PolygonData(ShapeData, ROIDrawingI):
     # @return The pointsList converted to a string.
     def listToString(self, pointsList):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        string = ''
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        string = ""
         cnt = 0
         for element in pointsList:
-            if(cnt != 0):
-                string = string + ','
+            if cnt != 0:
+                string = string + ","
             cnt += 1
             string = string + str(element)
         return string
@@ -814,13 +908,15 @@ class PolygonData(ShapeData, ROIDrawingI):
     # @return The tuple list converted from a string.
     def stringToTupleList(self, pointString):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         elements = []
-        list = pointString.split(',')
+        list = pointString.split(",")
         numTokens = len(list)
         for tokenPair in range(0, old_div(numTokens, 2)):
             elements.append(
-                (int(list[tokenPair * 2]), int(list[tokenPair * 2 + 1])))
+                (int(list[tokenPair * 2]), int(list[tokenPair * 2 + 1]))
+            )
         return elements
 
     ##
@@ -828,7 +924,8 @@ class PolygonData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return PolygonI()
 
     ##
@@ -836,9 +933,13 @@ class PolygonData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        visitor.drawPolygon(self.stringToTupleList(
-            self.points.getValue()), self.shapeSettings.getSettings())
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        visitor.drawPolygon(
+            self.stringToTupleList(self.points.getValue()),
+            self.shapeSettings.getSettings(),
+        )
+
 
 ##
 # The PolylineData class contains all the manipulation and create of PolylineI
@@ -857,7 +958,8 @@ class PolylineData(ShapeData, ROIDrawingI):
 
     def __init__(self, roicoord=ROICoordinate(), pointsList=(0, 0)):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         ShapeData.__init__(self)
         self.points = rstring(self.listToString(pointsList))
         self.setCoord(roicoord)
@@ -867,7 +969,8 @@ class PolylineData(ShapeData, ROIDrawingI):
     #
     def setGeometry(self, point):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         point.setTheZ(self.coord.theZ)
         point.setTheT(self.coord.theT)
         point.setPoints(self.points)
@@ -877,7 +980,8 @@ class PolylineData(ShapeData, ROIDrawingI):
     #
     def getGeometryFromROI(self, roi):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         self.points = roi.getPoints()
 
     ##
@@ -886,12 +990,13 @@ class PolylineData(ShapeData, ROIDrawingI):
     # @return The pointsList converted to a string.
     def listToString(self, pointsList):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        string = ''
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        string = ""
         cnt = 0
         for element in pointsList:
-            if(cnt > 0):
-                string = string + ','
+            if cnt > 0:
+                string = string + ","
             string = string + str(element)
             cnt += 1
         return string
@@ -902,13 +1007,15 @@ class PolylineData(ShapeData, ROIDrawingI):
     # @return The tuple list converted from a string.
     def stringToTupleList(self, pointString):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         elements = []
-        list = pointString.split(',')
+        list = pointString.split(",")
         numTokens = len(list)
         for tokenPair in range(0, old_div(numTokens, 2)):
             elements.append(
-                (int(list[tokenPair * 2]), int(list[tokenPair * 2 + 1])))
+                (int(list[tokenPair * 2]), int(list[tokenPair * 2 + 1]))
+            )
         return elements
 
     ##
@@ -916,7 +1023,8 @@ class PolylineData(ShapeData, ROIDrawingI):
     #
     def createBaseType(self):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
         return PolylineI()
 
     ##
@@ -924,6 +1032,9 @@ class PolylineData(ShapeData, ROIDrawingI):
     #
     def acceptVisitor(self, visitor):
         warnings.warn(
-            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
-        visitor.drawPolyline(self.stringToTupleList(
-            self.points.getValue()), self.shapeSettings.getSettings())
+            "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+        )
+        visitor.drawPolyline(
+            self.stringToTupleList(self.points.getValue()),
+            self.shapeSettings.getSettings(),
+        )

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -32,8 +32,10 @@ from omero.util.decorators import locked
 import omero_ext.path as path
 
 LOGDIR = os.path.join("var", "log")
-LOGFORMAT = "%(asctime)s %(levelname)-5.5s [%(name)40s] " \
-            "(%(threadName)-10s) %(message)s"
+LOGFORMAT = (
+    "%(asctime)s %(levelname)-5.5s [%(name)40s] "
+    "(%(threadName)-10s) %(message)s"
+)
 LOGLEVEL = logging.INFO
 LOGSIZE = 500000000
 LOGNUM = 9
@@ -52,19 +54,29 @@ def make_logname(self):
     return log_name
 
 
-def configure_logging(logdir=None, logfile=None, loglevel=LOGLEVEL,
-                      format=LOGFORMAT, filemode=LOGMODE, maxBytes=LOGSIZE,
-                      backupCount=LOGNUM, time_rollover=False):
+def configure_logging(
+    logdir=None,
+    logfile=None,
+    loglevel=LOGLEVEL,
+    format=LOGFORMAT,
+    filemode=LOGMODE,
+    maxBytes=LOGSIZE,
+    backupCount=LOGNUM,
+    time_rollover=False,
+):
 
     if logdir is None or logfile is None:
         handler = logging.StreamHandler()
     elif not time_rollover:
         handler = logging.handlers.RotatingFileHandler(
-            os.path.join(logdir, logfile), maxBytes=maxBytes,
-            backupCount=backupCount)
+            os.path.join(logdir, logfile),
+            maxBytes=maxBytes,
+            backupCount=backupCount,
+        )
     else:
         handler = logging.handlers.TimedRotatingFileHandler(
-            os.path.join(logdir, logfile), 'midnight', 1)
+            os.path.join(logdir, logfile), "midnight", 1
+        )
         # Windows will not allow renaming (or deleting) a file that's open.
         # There's nothing the logging package can do about that.
         try:
@@ -89,19 +101,33 @@ def configure_server_logging(props):
     # Using Ice.ProgramName on Windows failed
     log_dir = props.getPropertyWithDefault("omero.logging.directory", LOGDIR)
     log_name = program_name + ".log"
-    log_timed = props.getPropertyWithDefault(
-        "omero.logging.timedlog", "False")[0] in ('T', 't')
+    log_timed = props.getPropertyWithDefault("omero.logging.timedlog", "False")[
+        0
+    ] in ("T", "t")
     log_num = int(
-        props.getPropertyWithDefault("omero.logging.lognum", native_str(LOGNUM)))
+        props.getPropertyWithDefault("omero.logging.lognum", native_str(LOGNUM))
+    )
     log_size = int(
-        props.getPropertyWithDefault("omero.logging.logsize", native_str(LOGSIZE)))
+        props.getPropertyWithDefault(
+            "omero.logging.logsize", native_str(LOGSIZE)
+        )
+    )
     log_num = int(
-        props.getPropertyWithDefault("omero.logging.lognum", native_str(LOGNUM)))
+        props.getPropertyWithDefault("omero.logging.lognum", native_str(LOGNUM))
+    )
     log_level = int(
-        props.getPropertyWithDefault("omero.logging.level", native_str(LOGLEVEL)))
-    configure_logging(log_dir, log_name, loglevel=log_level,
-                      maxBytes=log_size, backupCount=log_num,
-                      time_rollover=log_timed)
+        props.getPropertyWithDefault(
+            "omero.logging.level", native_str(LOGLEVEL)
+        )
+    )
+    configure_logging(
+        log_dir,
+        log_name,
+        loglevel=log_level,
+        maxBytes=log_size,
+        backupCount=log_num,
+        time_rollover=log_timed,
+    )
 
     sys.stdout = StreamRedirect(logging.getLogger("stdout"))
     sys.stderr = StreamRedirect(logging.getLogger("stderr"))
@@ -166,8 +192,15 @@ class Dependency(object):
             return False
 
 
-def internal_service_factory(communicator, user="root", group=None, retries=6,
-                             interval=10, client_uuid=None, stop_event=None):
+def internal_service_factory(
+    communicator,
+    user="root",
+    group=None,
+    retries=6,
+    interval=10,
+    client_uuid=None,
+    stop_event=None,
+):
     """
     Try to return a ServiceFactory from the grid.
 
@@ -187,7 +220,8 @@ def internal_service_factory(communicator, user="root", group=None, retries=6,
     log = logging.getLogger("omero.utils")
     if stop_event is None:
         stop_event = omero.util.concurrency.get_event(
-            name="internal_service_factory")
+            name="internal_service_factory"
+        )
 
     tryCount = 0
     excpt = None
@@ -228,7 +262,7 @@ def create_admin_session(communicator):
     """
     reg = communicator.stringToProxy("IceGrid/Registry")
     reg = IceGrid.RegistryPrx.checkedCast(reg)
-    adm = reg.createAdminSession('null', '')
+    adm = reg.createAdminSession("null", "")
     return adm
 
 
@@ -267,7 +301,7 @@ def long_to_path(id, root=""):
     if id < 0:
         raise Exception("Expecting a non-negative id.")
 
-    while (remaining > 999):
+    while remaining > 999:
         remaining /= 1000
 
         if remaining > 0:
@@ -292,8 +326,11 @@ def load_dotted_class(dotted_class):
         got = getattr(got, mod)
         return getattr(got, kls)
     except Exception as e:
-        raise Exception("""Failed to load: %s
-        previous excetion: %s""" % (dotted_class, e))
+        raise Exception(
+            """Failed to load: %s
+        previous excetion: %s"""
+            % (dotted_class, e)
+        )
 
 
 class ServerContext(object):
@@ -317,8 +354,7 @@ class ServerContext(object):
     server shutdown, so should be infrequent)
     """
 
-    def __init__(self, server_id, communicator, stop_event,
-                 on_newsession=None):
+    def __init__(self, server_id, communicator, stop_event, on_newsession=None):
         self._lock = threading.RLock()
         self.logger = logging.getLogger("omero.util.ServerContext")
         self.server_id = server_id
@@ -343,7 +379,8 @@ class ServerContext(object):
 
     def newSession(self):
         self.session = internal_service_factory(
-            self.communicator, stop_event=self.stop_event)
+            self.communicator, stop_event=self.stop_event
+        )
         if callable(self.on_newsession):
             self.on_newsession(self.session)
 
@@ -368,7 +405,8 @@ class ServerContext(object):
         """
         if not self.hasSession():
             raise omero.ApiUsageException(
-                "Not configured for server connection")
+                "Not configured for server connection"
+            )
 
         if self.session:
             try:
@@ -438,8 +476,9 @@ class Server(Ice.Application):
 
     """
 
-    def __init__(self, impl_class, adapter_name, identity, logdir=LOGDIR,
-                 dependencies=()):
+    def __init__(
+        self, impl_class, adapter_name, identity, logdir=LOGDIR, dependencies=()
+    ):
 
         self.impl_class = impl_class
         self.adapter_name = adapter_name
@@ -492,10 +531,14 @@ class Server(Ice.Application):
                 of.register(self.communicator())
 
             try:
-                serverid = self.communicator().getProperties().getProperty(
-                    "Ice.ServerId")
+                serverid = (
+                    self.communicator()
+                    .getProperties()
+                    .getProperty("Ice.ServerId")
+                )
                 ctx = ServerContext(
-                    serverid, self.communicator(), self.stop_event)
+                    serverid, self.communicator(), self.stop_event
+                )
                 self.impl = self.impl_class(ctx)
                 getattr(self.impl, "cleanup")  # Required per docs
             except:
@@ -504,7 +547,8 @@ class Server(Ice.Application):
 
             try:
                 self.adapter = self.communicator().createObjectAdapter(
-                    self.adapter_name)
+                    self.adapter_name
+                )
                 self.adapter.activate()
                 # calls setProxy
                 ctx.add_servant(self.adapter, self.impl, self.identity)
@@ -580,7 +624,8 @@ class Servant(SimpleServant):
     def __init__(self, ctx, needs_session=False):
         SimpleServant.__init__(self, ctx)
         self.resources = omero.util.Resources(
-            sleeptime=60, stop_event=self.stop_event)
+            sleeptime=60, stop_event=self.stop_event
+        )
         if needs_session:
             self.ctx.newSession()
             self.resources.add(self.ctx)
@@ -631,12 +676,12 @@ class Resources(object):
         self.logger = logging.getLogger("omero.util.Resources")
         self.stop_event = stop_event
         if not self.stop_event:
-            self.stop_event = omero.util.concurrency.get_event(
-                name="Resources")
+            self.stop_event = omero.util.concurrency.get_event(name="Resources")
 
         if sleeptime < 5:
             raise Exception(
-                "Sleep time should be greater than 5: %s" % sleeptime)
+                "Sleep time should be greater than 5: %s" % sleeptime
+            )
 
         self.sleeptime = sleeptime
 
@@ -657,7 +702,8 @@ class Resources(object):
                         ctx.removeAll(remove)
                     except:
                         ctx.logger.error(
-                            "Exception during execution", exc_info=True)
+                            "Exception during execution", exc_info=True
+                        )
 
                     ctx.logger.debug("Sleeping %s" % ctx.sleeptime)
                     # ticket:1531 - Attempting to catch threading issues
@@ -666,8 +712,9 @@ class Resources(object):
                     except ValueError:
                         pass
 
-                if isinstance(ctx.stop_event,
-                              omero.util.concurrency.AtExitEvent):
+                if isinstance(
+                    ctx.stop_event, omero.util.concurrency.AtExitEvent
+                ):
                     if ctx.stop_event.atexit:
                         return  # Skipping log. See #3260
 
@@ -798,6 +845,7 @@ class Environment(object):
         else:
             self.set(key, addition)
 
+
 #
 # Miscellaneious utilities
 #
@@ -819,11 +867,13 @@ def get_user(default=None):
     rv = None
     try:
         import getpass
+
         rv = getpass.getuser()  # Uses environment variable or pwd
     except KeyError:  # 6307, probably system
         pass
     except ImportError:  # No pwd on Windows
         import win32api
+
         rv = win32api.GetUserName()
 
     if not rv:
@@ -834,7 +884,7 @@ def get_user(default=None):
 
 def get_omero_userdir():
     """Returns the OMERO user directory"""
-    omero_userdir = os.environ.get('OMERO_USERDIR', None)
+    omero_userdir = os.environ.get("OMERO_USERDIR", None)
     if omero_userdir:
         return path.path(omero_userdir)
     else:
@@ -842,10 +892,11 @@ def get_omero_userdir():
 
 
 def get_user_dir():
-    exceptions_to_handle = (ImportError)
+    exceptions_to_handle = ImportError
     try:
         from pywintypes import com_error
         from win32com.shell import shellcon, shell
+
         exceptions_to_handle = (ImportError, com_error)
         homeprop = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
     except exceptions_to_handle:
@@ -881,15 +932,16 @@ def edit_path(path_or_obj, start_text):
         editor_parts[0] = editor
     else:
         from omero_ext.which import which
+
         editor_parts[0] = which(editor)
     editor_parts.append(f)
 
     pid = os.spawnl(os.P_WAIT, editor_parts[0], *tuple(editor_parts))
     if pid:
-        re = RuntimeError(
-            "Couldn't spawn editor: %s" % editor_parts[0])
+        re = RuntimeError("Couldn't spawn editor: %s" % editor_parts[0])
         re.pid = pid
         raise re
+
 
 # From: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/157035
 
@@ -905,7 +957,7 @@ def tail_lines(filename, linesback=10, returnlist=0):
     """
     avgcharsperline = 75
 
-    file = open(filename, 'r')
+    file = open(filename, "r")
     while 1:
         try:
             file.seek(-1 * avgcharsperline * linesback, 2)
@@ -928,9 +980,9 @@ def tail_lines(filename, linesback=10, returnlist=0):
     else:
         start = 0
     if returnlist:
-        return lines[start:len(lines) - 1]
+        return lines[start : len(lines) - 1]
 
     out = ""
-    for l in lines[start:len(lines) - 1]:
+    for l in lines[start : len(lines) - 1]:
         out = out + l + "\n"
     return out

--- a/src/omero/util/decorators.py
+++ b/src/omero/util/decorators.py
@@ -20,6 +20,7 @@ perf_log = logging.getLogger("omero.perf")
 
 def perf(func):
     """ Decorator for (optionally) printing performance statistics """
+
     def handler(*args, **kwargs):
 
         # Early Exit. Can't do this in up a level
@@ -45,7 +46,9 @@ def perf(func):
             startMillis = int(start * 1000)
             timeMillis = int(diff * 1000)
             perf_log.debug(
-                "start[%d] time[%d] tag[%s]", startMillis, timeMillis, tag)
+                "start[%d] time[%d] tag[%s]", startMillis, timeMillis, tag
+            )
+
     handler = wraps(func)(handler)
     return handler
 
@@ -75,15 +78,18 @@ def remoted(func):
                 raise
             else:
                 log.warn(
-                    "%s raised a non-ServerError (%s): %s", func, type(e), e)
+                    "%s raised a non-ServerError (%s): %s", func, type(e), e
+                )
                 msg = traceback.format_exc()
                 raise omero.InternalException(msg, None, "Internal exception")
+
     exc_handler = wraps(func)(exc_handler)
     return exc_handler
 
 
 def locked(func):
     """ Decorator for using the self._lock argument of the calling instance """
+
     def with_lock(*args, **kwargs):
         self = args[0]
         self._lock.acquire()
@@ -91,11 +97,12 @@ def locked(func):
             return func(*args, **kwargs)
         finally:
             self._lock.release()
+
     with_lock = wraps(func)(with_lock)
     return with_lock
 
 
-class TimeIt (object):
+class TimeIt(object):
 
     """
     Decorator to measure the execution time of a function. Assumes that a
@@ -105,7 +112,8 @@ class TimeIt (object):
     @param level: the level to use for logging
     @param name: the name to use when logging, function name is used if None
     """
-    logger = logging.getLogger('omero.timeit')
+
+    logger = logging.getLogger("omero.timeit")
 
     def __init__(self, level=logging.DEBUG, name=None):
         self._level = level
@@ -117,9 +125,11 @@ class TimeIt (object):
             self.logger.log(self._level, "timing %s" % (name))
             now = time.time()
             rv = func(*args, **kwargs)
-            self.logger.log(self._level, "timed %s: %f" %
-                            (name, time.time() - now))
+            self.logger.log(
+                self._level, "timed %s: %f" % (name, time.time() - now)
+            )
             return rv
+
         return wrapped
 
 
@@ -128,13 +138,16 @@ def timeit(func):
     Shortcut version of the :class:`TimeIt` decorator class.
     Logs at logging.DEBUG level.
     """
+
     def wrapped(*args, **kwargs):
         TimeIt.logger.log(logging.DEBUG, "timing %s" % (func.__name__))
         now = time.time()
         rv = func(*args, **kwargs)
-        TimeIt.logger.log(logging.DEBUG, "timed %s: %f" %
-                          (func.__name__, time.time() - now))
+        TimeIt.logger.log(
+            logging.DEBUG, "timed %s: %f" % (func.__name__, time.time() - now)
+        )
         return rv
+
     return TimeIt()(func)
 
 
@@ -146,10 +159,12 @@ def setsessiongroup(func):
 
     def wrapped(self, *args, **kwargs):
         rev = self._conn.setGroupForSession(
-            self.getDetails().getGroup().getId())
+            self.getDetails().getGroup().getId()
+        )
         try:
             return func(self, *args, **kwargs)
         finally:
             if rev:
                 self._conn.revertGroupForSession()
+
     return wrapped

--- a/src/omero/util/figureUtil.py
+++ b/src/omero/util/figureUtil.py
@@ -39,6 +39,7 @@ from __future__ import division
 from builtins import str
 from builtins import range
 from past.utils import old_div
+
 try:
     from PIL import Image, ImageDraw  # see ticket:2597
 except ImportError:
@@ -55,8 +56,16 @@ MINS_SECS = "MINS_SECS"
 HOURS_MINS = "HOURS_MINS"
 HOURS_MINS_SECS = "HOURS_MINS_SECS"
 HOURS_MINS_SECS_MILLIS = "HOURS_MINS_SECS_MILLIS"
-TIME_UNITS = [SECS_MILLIS, SECS, MINS, HOURS, MINS_SECS,
-              HOURS_MINS, HOURS_MINS_SECS, HOURS_MINS_SECS_MILLIS]
+TIME_UNITS = [
+    SECS_MILLIS,
+    SECS,
+    MINS,
+    HOURS,
+    MINS_SECS,
+    HOURS_MINS,
+    HOURS_MINS_SECS,
+    HOURS_MINS_SECS_MILLIS,
+]
 
 
 def getDatasetsProjectsFromImages(queryService, imageIds):
@@ -72,14 +81,16 @@ def getDatasetsProjectsFromImages(queryService, imageIds):
     """
     ids = ",".join([str(i) for i in imageIds])
 
-    query_string = "select i from Image i join fetch i.datasetLinks idl join " \
-                   "fetch idl.parent d join fetch d.projectLinks pl join " \
-                   "fetch pl.parent where i.id in (%s)" % ids
+    query_string = (
+        "select i from Image i join fetch i.datasetLinks idl join "
+        "fetch idl.parent d join fetch d.projectLinks pl join "
+        "fetch pl.parent where i.id in (%s)" % ids
+    )
 
     images = queryService.findAllByQuery(query_string, None)
     results = {}
 
-    for i in images:    # order of images not same as imageIds
+    for i in images:  # order of images not same as imageIds
         pdList = []
         imageId = i.getId().getValue()
         for link in i.iterateDatasetLinks():
@@ -111,7 +122,8 @@ def getTagsFromImages(metadataService, imageIds):
 
     types = ["ome.model.annotations.TagAnnotation"]
     annotations = metadataService.loadAnnotations(
-        "Image", imageIds, types, None, None)
+        "Image", imageIds, types, None, None
+    )
 
     tagsMap = {}
     for i in imageIds:
@@ -139,9 +151,11 @@ def getTimes(queryService, pixelsId, tIndexes, theZ=None, theC=None):
     if theC is None:
         theC = 0
     indexes = ",".join([str(t) for t in tIndexes])
-    query = "from PlaneInfo as Info where Info.theT in (%s) and Info.theZ "\
-            "in (%d) and Info.theC in (%d) and pixels.id='%d'" \
-            % (indexes, theZ, theC, pixelsId)
+    query = (
+        "from PlaneInfo as Info where Info.theT in (%s) and Info.theZ "
+        "in (%d) and Info.theC in (%d) and pixels.id='%d'"
+        % (indexes, theZ, theC, pixelsId)
+    )
     infoList = queryService.findAllByQuery(query, None)
     timeMap = {}
     for info in infoList:
@@ -193,15 +207,21 @@ def formatTime(seconds, timeUnits):
     elif timeUnits == "HOURS_MINS_SECS_MILLIS":
         hrs = old_div(seconds, 3600)
         mins = old_div((seconds % 3600), 60)
-        secs = (seconds % (3600 * 60))
+        secs = seconds % (3600 * 60)
         label = "%d:%02d:%05.2f" % (hrs, mins, secs)
     else:
         label = "%.2f sec" % seconds
     return neg and "-%s" % label or label
 
 
-def getTimeLabels(queryService, pixelsId, tIndexes, sizeT,
-                  timeUnits=None, showRoiDuration=False):
+def getTimeLabels(
+    queryService,
+    pixelsId,
+    tIndexes,
+    sizeT,
+    timeUnits=None,
+    showRoiDuration=False,
+):
     """
     Returns a list of time labels e.g. "10", "20" for the first plane at
     each t-index (C=0 and Z=0). If no planeInfo is available,
@@ -269,14 +289,19 @@ def addScalebar(scalebar, xIndent, yIndent, image, pixels, colour):
     scaleBarY = iHeight - yIndent
     scaleBarX = iWidth - scalebar // pixelSizeX - xIndent
     scaleBarX2 = iWidth - xIndent
-    if (scaleBarX <= 0 or scaleBarX2 <= 0
-            or scaleBarY <= 0 or scaleBarX2 > iWidth):
+    if (
+        scaleBarX <= 0
+        or scaleBarX2 <= 0
+        or scaleBarY <= 0
+        or scaleBarX2 > iWidth
+    ):
         return False, "  Failed to add scale bar: Scale bar is too large."
     for l in range(lineThickness):
         draw.line(
-            [(scaleBarX, scaleBarY), (scaleBarX2, scaleBarY)], fill=colour)
+            [(scaleBarX, scaleBarY), (scaleBarX2, scaleBarY)], fill=colour
+        )
         scaleBarY -= 1
-    return True,  "  Scalebar added to the image."
+    return True, "  Scalebar added to the image."
 
 
 def getVerticalLabels(labels, font, textGap):

--- a/src/omero/util/imageUtil.py
+++ b/src/omero/util/imageUtil.py
@@ -37,8 +37,10 @@ used for making figures.
 from __future__ import division
 
 from future import standard_library
+
 standard_library.install_aliases()
 from past.utils import old_div
+
 try:
     from PIL import Image, ImageDraw, ImageFont  # see ticket:2597
 except ImportError:
@@ -64,12 +66,13 @@ def getFont(fontsize):
     @return: 	A PIL Font
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     fontPath = os.path.join(GATEWAYPATH, "pilfonts", "FreeSans.ttf")
     try:
         font = ImageFont.truetype(fontPath, fontsize)
     except:
-        font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (GATEWAYPATH, 24))
+        font = ImageFont.load("%s/pilfonts/B%0.2d.pil" % (GATEWAYPATH, 24))
     return font
 
 
@@ -84,7 +87,8 @@ def pasteImage(image, canvas, x, y):
     @param y: 			Y coordinate (top) to paste
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     xRight = image.size[0] + x
     yBottom = image.size[1] + y
     # make a tuple of topleft-x, topleft-y, bottomRight-x, bottomRight-y
@@ -104,7 +108,8 @@ def getThumbnail(thumbnailStore, pixelsId, length):
                             or None if not found (invalid image)
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     if not thumbnailStore.setPixelsId(pixelsId):
         thumbnailStore.needDefaults()
         thumbnailStore.setPixelsId(pixelsId)
@@ -126,18 +131,29 @@ def getThumbnailSet(thumbnailStore, length, pixelIds):
     @return:                See above
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     try:
         # returns string (api says Ice::ByteSeq)
         return thumbnailStore.getThumbnailByLongestSideSet(
-            rint(length), pixelIds)
+            rint(length), pixelIds
+        )
     except:
         return None
 
 
-def paintThumbnailGrid(thumbnailStore, length, spacing, pixelIds, colCount,
-                       bg=(255, 255, 255), leftLabel=None,
-                       textColour=(0, 0, 0), fontsize=None, topLabel=None):
+def paintThumbnailGrid(
+    thumbnailStore,
+    length,
+    spacing,
+    pixelIds,
+    colCount,
+    bg=(255, 255, 255),
+    leftLabel=None,
+    textColour=(0, 0, 0),
+    fontsize=None,
+    topLabel=None,
+):
     """
     Retrieves thumbnails for each pixelId, and places them in a grid,
     with White background.
@@ -161,12 +177,13 @@ def paintThumbnailGrid(thumbnailStore, length, spacing, pixelIds, colCount,
     @return: 			    The PIL Image canvas.
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     mode = "RGB"
     # work out how many rows and columns are needed for all the images
     imgCount = len(pixelIds)
 
-    rowCount = (old_div(imgCount, colCount))
+    rowCount = old_div(imgCount, colCount)
     # check that we have enough rows and cols...
     while (colCount * rowCount) < imgCount:
         rowCount += 1
@@ -262,7 +279,8 @@ def checkRGBRange(value):
     @return:			An integer between 0 and 255
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     try:
         v = int(value)
         if 0 <= v <= 255:
@@ -280,7 +298,8 @@ def RGBIntToRGBA(RGB):
     @return:		A tuple of (r,g,b,a)
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     r = checkRGBRange((RGB >> 16) & 0xFF)
     g = checkRGBRange((RGB >> 8) & 0xFF)
     b = checkRGBRange((RGB >> 0) & 0xFF)
@@ -299,7 +318,8 @@ def RGBIntToRGB(RGB):
     @return:		A tuple of (r,g,b)
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     r, g, b, a = RGBIntToRGBA(RGB)
     return (r, g, b)
 
@@ -317,7 +337,8 @@ def getZoomFactor(imageSize, maxW, maxH):
                             within max width and height
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     imageW, imageH = imageSize
     zoomW = old_div(float(imageW), float(maxW))
     zoomH = old_div(float(imageH), float(maxH))
@@ -335,7 +356,8 @@ def resizeImage(image, maxW, maxH):
     @return:		The zoomed image. PIL Image.
     """
     warnings.warn(
-        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     imageW, imageH = image.size
     if imageW == maxW and imageH == maxH:
         return image

--- a/src/omero/util/image_utils.py
+++ b/src/omero/util/image_utils.py
@@ -24,8 +24,10 @@ Utility methods for dealing with scripts.
 from __future__ import division
 
 from future import standard_library
+
 standard_library.install_aliases()
 from past.utils import old_div
+
 try:
     from PIL import Image, ImageDraw, ImageFont  # see ticket:2597
 except ImportError:
@@ -54,7 +56,7 @@ def get_font(fontsize):
     try:
         font = ImageFont.truetype(font_path, fontsize)
     except:
-        font = ImageFont.load('%s/pilfonts/B%0.2d.pil' % (GATEWAYPATH, 24))
+        font = ImageFont.load("%s/pilfonts/B%0.2d.pil" % (GATEWAYPATH, 24))
     return font
 
 
@@ -76,9 +78,18 @@ def paste_image(image, canvas, x, y):
     canvas.paste(image, pastebox)
 
 
-def paint_thumbnail_grid(thumbnail_store, length, spacing, pixel_ids,
-                         col_count, bg=(255, 255, 255), left_label=None,
-                         text_color=(0, 0, 0), fontsize=None, top_label=None):
+def paint_thumbnail_grid(
+    thumbnail_store,
+    length,
+    spacing,
+    pixel_ids,
+    col_count,
+    bg=(255, 255, 255),
+    left_label=None,
+    text_color=(0, 0, 0),
+    fontsize=None,
+    top_label=None,
+):
     """
     Retrieves thumbnails for each pixelId, and places them in a grid,
     with White background.
@@ -105,7 +116,7 @@ def paint_thumbnail_grid(thumbnail_store, length, spacing, pixel_ids,
     # work out how many rows and columns are needed for all the images
     img_count = len(pixel_ids)
 
-    row_count = (old_div(img_count, col_count))
+    row_count = old_div(img_count, col_count)
     # check that we have enough rows and cols...
     while (col_count * row_count) < img_count:
         row_count += 1
@@ -167,8 +178,9 @@ def paint_thumbnail_grid(thumbnail_store, length, spacing, pixel_ids,
     # and column
     r = 0
     c = 0
-    thumbnail_map = thumbnail_store.getThumbnailByLongestSideSet(rint(length),
-                                                                 pixel_ids)
+    thumbnail_map = thumbnail_store.getThumbnailByLongestSideSet(
+        rint(length), pixel_ids
+    )
     for pixels_id in pixel_ids:
         if pixels_id in thumbnail_map:
             thumbnail = thumbnail_map[pixels_id]

--- a/src/omero/util/import_candidates.py
+++ b/src/omero/util/import_candidates.py
@@ -40,8 +40,11 @@ def as_stdout(path, readers=""):
         cli.invoke(["import", "-f"] + path)
     if cli.rv != 0:
         raise omero.InternalException(
-            None, None, "'import -f' exited with a rc=%s. "
-            "See console for more information" % cli.rv)
+            None,
+            None,
+            "'import -f' exited with a rc=%s. "
+            "See console for more information" % cli.rv,
+        )
 
 
 def as_dictionary(path, readers=""):
@@ -94,4 +97,5 @@ def as_dictionary(path, readers=""):
 
 if __name__ == "__main__":
     import sys
+
     as_stdout(sys.argv[1:])

--- a/src/omero/util/importperf.py
+++ b/src/omero/util/importperf.py
@@ -38,7 +38,8 @@ from getopt import getopt, GetoptError
 def usage(error):
     """Prints usage so that we don't have to. :)"""
     cmd = sys.argv[0]
-    print("""%s
+    print(
+        """%s
 Usage: %s [options...] <importer_log_file>
 Generate performance metrics from an OMERO.importer log file.
 
@@ -50,14 +51,16 @@ Examples:
   %s importer.log
   %s --series_report importer.log > series_report.csv
 
-Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % \
-        (error, cmd, cmd, cmd))
+Report bugs to ome-devel@lists.openmicroscopy.org.uk"""
+        % (error, cmd, cmd, cmd)
+    )
     sys.exit(2)
 
 
 class ParsingError(Exception):
 
     """Raised whenever there is an error parsing a log file."""
+
     pass
 
 
@@ -107,15 +110,16 @@ class ImporterLog(object):
 
     # Regular expression for matching log4j log lines
     log_regex = re.compile(
-        r'^(?P<date_time>\S+\s+\S+)\s+(?P<ms_elapsed>\d+)\s+'
-        '(?P<thread>\[.*?\])\s+(?P<level>\S+)\s+(?P<class>\S+)\s+-\s+'
-        '(?P<message>.*)$')
+        r"^(?P<date_time>\S+\s+\S+)\s+(?P<ms_elapsed>\d+)\s+"
+        "(?P<thread>\[.*?\])\s+(?P<level>\S+)\s+(?P<class>\S+)\s+-\s+"
+        "(?P<message>.*)$"
+    )
 
     # Regular expression for matching possible OMERO.importer status messages
-    status_regex = re.compile(r'^[A-Z_]*')
+    status_regex = re.compile(r"^[A-Z_]*")
 
     # Format string for matching log4j date/time strings
-    date_time_fmt = '%Y-%m-%d %H:%M:%S'
+    date_time_fmt = "%Y-%m-%d %H:%M:%S"
 
     def __init__(self, log_file):
         self.log_file = log_file
@@ -135,49 +139,49 @@ class ImporterLog(object):
 
     def handle_match(self, match):
         """Handles cases where the log_regex is matched."""
-        message = match.group('message')
+        message = match.group("message")
         if not self.status_regex.match(message):
             return
-        date_time = match.group('date_time')
-        date_time, ms = date_time.split(',')
+        date_time = match.group("date_time")
+        date_time, ms = date_time.split(",")
         date_time = DateTime.strptime(date_time, self.date_time_fmt)
         ms = DateTimeDelta(0, 0, 0, old_div(int(ms), 1000.0))
         date_time = date_time + ms
-        if message.startswith('LOADING_IMAGE'):
-            name = message[message.find(':') + 2:]
+        if message.startswith("LOADING_IMAGE"):
+            name = message[message.find(":") + 2 :]
             self.last_import = Import(date_time, name)
             self.imports.append(self.last_import)
-        elif not hasattr(self, 'last_import') or self.last_import is None:
+        elif not hasattr(self, "last_import") or self.last_import is None:
             return
-        elif message.startswith('LOADED_IMAGE'):
+        elif message.startswith("LOADED_IMAGE"):
             self.last_import.setid_end = date_time
-        elif message.startswith('BEGIN_POST_PROCESS'):
+        elif message.startswith("BEGIN_POST_PROCESS"):
             self.last_import.post_process_start = date_time
-        elif message.startswith('END_POST_PROCESS'):
+        elif message.startswith("END_POST_PROCESS"):
             self.last_import.post_process_end = date_time
-        elif message.startswith('BEGIN_SAVE_TO_DB'):
+        elif message.startswith("BEGIN_SAVE_TO_DB"):
             self.last_import.save_to_db_start = date_time
-        elif message.startswith('END_SAVE_TO_DB'):
+        elif message.startswith("END_SAVE_TO_DB"):
             self.last_import.save_to_db_end = date_time
-        elif message.startswith('IMPORT_OVERLAYS'):
+        elif message.startswith("IMPORT_OVERLAYS"):
             self.last_import.overlays_start = date_time
-        elif message.startswith('IMPORT_THUMBNAILING'):
+        elif message.startswith("IMPORT_THUMBNAILING"):
             self.last_import.thumbnailing_start = date_time
-        elif message.startswith('IMPORT_DONE'):
+        elif message.startswith("IMPORT_DONE"):
             self.last_import.end = date_time
             self.last_import = None
-        elif message.startswith('DATASET_STORED'):
+        elif message.startswith("DATASET_STORED"):
             self.last_series = Series(date_time)
             self.last_import.series.append(self.last_series)
-        elif message.startswith('DATA_STORED'):
+        elif message.startswith("DATA_STORED"):
             self.last_import.series[-1].end = date_time
-        elif message.startswith('IMPORT_STEP'):
+        elif message.startswith("IMPORT_STEP"):
             self.last_series.planes.append(Plane(date_time))
 
     def elapsed(self, start, end):
         if start is not None and end is not None:
             return str((end - start).seconds) + "sec"
-        return 'Unknown'
+        return "Unknown"
 
     def report(self):
         """
@@ -186,62 +190,91 @@ class ImporterLog(object):
         """
         for import_n, i in enumerate(self.imports):
             elapsed = self.elapsed(i.start, i.end)
-            print("Import(%s) %d start: %s end: %s elapsed: %s" % \
-                (i.name, import_n, i.start, i.end, elapsed))
+            print(
+                "Import(%s) %d start: %s end: %s elapsed: %s"
+                % (i.name, import_n, i.start, i.end, elapsed)
+            )
             elapsed = self.elapsed(i.setid_start, i.setid_end)
-            print("setId() start: %s end: %s elapsed: %s" % \
-                (i.setid_start, i.setid_end, elapsed))
+            print(
+                "setId() start: %s end: %s elapsed: %s"
+                % (i.setid_start, i.setid_end, elapsed)
+            )
             elapsed = self.elapsed(i.post_process_start, i.post_process_end)
-            print("Post process start: %s end: %s elapsed: %s" % \
-                (i.post_process_start, i.post_process_end, elapsed))
+            print(
+                "Post process start: %s end: %s elapsed: %s"
+                % (i.post_process_start, i.post_process_end, elapsed)
+            )
             elapsed = self.elapsed(i.save_to_db_start, i.save_to_db_end)
-            print("Save to DB start: %s end: %s elapsed: %s" % \
-                (i.save_to_db_start, i.save_to_db_end, elapsed))
+            print(
+                "Save to DB start: %s end: %s elapsed: %s"
+                % (i.save_to_db_start, i.save_to_db_end, elapsed)
+            )
             if len(i.series) > 0:
                 elapsed = self.elapsed(i.series[0].start, i.series[-1].end)
-                print("Image I/O start: %s end: %s elapsed: %s" % \
-                    (i.series[0].start, i.series[-1].end, elapsed))
+                print(
+                    "Image I/O start: %s end: %s elapsed: %s"
+                    % (i.series[0].start, i.series[-1].end, elapsed)
+                )
                 elapsed = self.elapsed(i.overlays_start, i.thumbnailing_start)
-                print("Overlays start: %s end: %s elapsed: %s" % \
-                    (i.overlays_start, i.thumbnailing_start, elapsed))
+                print(
+                    "Overlays start: %s end: %s elapsed: %s"
+                    % (i.overlays_start, i.thumbnailing_start, elapsed)
+                )
                 elapsed = self.elapsed(i.thumbnailing_start, i.end)
-                print("Thumbnailing start: %s end: %s elapsed: %s" % \
-                    (i.thumbnailing_start, i.end, elapsed))
+                print(
+                    "Thumbnailing start: %s end: %s elapsed: %s"
+                    % (i.thumbnailing_start, i.end, elapsed)
+                )
 
     def series_report_csv(self):
         """
         Prints a CSV report to STDOUT with timings for the I/O operations
         of each import's set of image series.
         """
-        print(','.join(['import', 'series', 'series_start', 'series_end',
-                        'series_elapsed']))
+        print(
+            ",".join(
+                [
+                    "import",
+                    "series",
+                    "series_start",
+                    "series_end",
+                    "series_elapsed",
+                ]
+            )
+        )
         for import_n, i in enumerate(self.imports):
             for series_n, series in enumerate(i.series):
                 if series.start is None or series.end is None:
                     continue
                 elapsed = (series.end - series.start).seconds
-                values = [import_n, series_n, series.start, series.end,
-                          elapsed * 1000]
-                print(','.join([str(v) for v in values]))
+                values = [
+                    import_n,
+                    series_n,
+                    series.start,
+                    series.end,
+                    elapsed * 1000,
+                ]
+                print(",".join([str(v) for v in values]))
+
 
 if __name__ == "__main__":
     try:
-        options, args = getopt(sys.argv[1:], "", ['series_report', 'help'])
+        options, args = getopt(sys.argv[1:], "", ["series_report", "help"])
     except GetoptError as xxx_todo_changeme:
         (msg, opt) = xxx_todo_changeme.args
         usage(msg)
 
     try:
-        log_file, = args
+        (log_file,) = args
     except ValueError:
-        usage('Must specify at least one log file.')
+        usage("Must specify at least one log file.")
     log = ImporterLog(open(log_file))
 
     do_default_report = True
     for option, argument in options:
-        if option == '--help':
-            usage('')
-        if option == '--series_report':
+        if option == "--help":
+            usage("")
+        if option == "--series_report":
             do_default_report = False
             log.series_report_csv()
 

--- a/src/omero/util/metadata_utils.py
+++ b/src/omero/util/metadata_utils.py
@@ -36,6 +36,7 @@ import re
 # TODO: Make jinja2 mandatory?
 try:
     import jinja2
+
     JINJA2_MISSING = None
 except ImportError as j2exc:
     JINJA2_MISSING = j2exc
@@ -49,14 +50,15 @@ NSBULKANNOTATIONSRAW = namespaces.NSBULKANNOTATIONS + "/raw"
 
 
 class GroupConfig(object):
-
     def __init__(self, namespace, column_cfg):
         self.namespace = namespace
         self.columns = column_cfg
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-                and self.__dict__ == other.__dict__)
+        return (
+            isinstance(other, self.__class__)
+            and self.__dict__ == other.__dict__
+        )
 
 
 class BulkAnnotationConfiguration(object):
@@ -65,17 +67,19 @@ class BulkAnnotationConfiguration(object):
     """
 
     REQUIRED = set(["name"])
-    OPTIONAL = set([
-        "clientname",
-        "clientvalue",
-        "includeclient",
-        "position",
-        "include",
-        "split",
-        "type",
-        "visible",
-        "omitempty",
-        ])
+    OPTIONAL = set(
+        [
+            "clientname",
+            "clientvalue",
+            "includeclient",
+            "position",
+            "include",
+            "split",
+            "type",
+            "visible",
+            "omitempty",
+        ]
+    )
     GROUPREQUIRED = set(["namespace", "columns"])
 
     def __init__(self, default_cfg, column_cfgs):
@@ -108,7 +112,7 @@ class BulkAnnotationConfiguration(object):
             "visible": True,
             "position": -1,
             "clientname": None,
-            "omitempty": False
+            "omitempty": False,
         }
         if not cfg:
             cfg = {}
@@ -116,7 +120,8 @@ class BulkAnnotationConfiguration(object):
         invalid = set(cfg.keys()).difference(list(default_defaults.keys()))
         if invalid:
             raise Exception(
-                "Invalid key(s) in column defaults: %s" % list(invalid))
+                "Invalid key(s) in column defaults: %s" % list(invalid)
+            )
 
         defaults = default_defaults.copy()
         defaults.update(cfg)
@@ -133,8 +138,9 @@ class BulkAnnotationConfiguration(object):
         missing = cls.REQUIRED.difference(keys)
         if missing:
             raise Exception(
-                "Required key(s) missing from column configuration: %s" %
-                list(missing))
+                "Required key(s) missing from column configuration: %s"
+                % list(missing)
+            )
 
         if not cfg["name"]:
             raise Exception("Empty name in column configuration: %s" % cfg)
@@ -142,7 +148,8 @@ class BulkAnnotationConfiguration(object):
         invalid = keys.difference(cls.OPTIONAL.union(cls.REQUIRED))
         if invalid:
             raise Exception(
-                "Invalid key(s) in column configuration: %s" % list(invalid))
+                "Invalid key(s) in column configuration: %s" % list(invalid)
+            )
 
     @classmethod
     def validate_filled_column_config(cls, cfg):
@@ -156,8 +163,10 @@ class BulkAnnotationConfiguration(object):
 
         missing = allfields.difference(keys)
         if missing:
-            raise Exception("Required key(s) missing from column+defaults "
-                            "configuration: %s" % list(missing))
+            raise Exception(
+                "Required key(s) missing from column+defaults "
+                "configuration: %s" % list(missing)
+            )
 
         if cfg["includeclient"] and not cfg["include"]:
             raise Exception("Option `includeclient` requires option `include`")
@@ -166,11 +175,12 @@ class BulkAnnotationConfiguration(object):
             raise Exception("Option `position` must be an int")
 
         if cfg["clientvalue"]:
-            subbed = re.sub(r"\{\{\s*value\s*\}\}", '', cfg["clientvalue"])
+            subbed = re.sub(r"\{\{\s*value\s*\}\}", "", cfg["clientvalue"])
             m = re.search(r"\{\{[\s\w]*}\}", subbed)
             if m:
                 raise Exception(
-                    "clientvalue template parameter not found: %s" % m.group())
+                    "clientvalue template parameter not found: %s" % m.group()
+                )
 
     @classmethod
     def validate_group_config(cls, cfg):
@@ -184,8 +194,9 @@ class BulkAnnotationConfiguration(object):
         missing = cls.GROUPREQUIRED.difference(keys)
         if missing:
             raise Exception(
-                "Required key(s) missing from group configuration: %s" %
-                list(missing))
+                "Required key(s) missing from group configuration: %s"
+                % list(missing)
+            )
 
         if not cfg["namespace"]:
             raise Exception("Empty name in group configuration: %s" % cfg)
@@ -196,19 +207,19 @@ class BulkAnnotationConfiguration(object):
         invalid = keys.difference(cls.GROUPREQUIRED)
         if invalid:
             raise Exception(
-                "Invalid key(s) in group configuration: %s" % list(invalid))
+                "Invalid key(s) in group configuration: %s" % list(invalid)
+            )
 
     def get_column_config(self, cfg):
         """
         Replace unspecified fields in a column config with defaults
         If this is a group return a GroupConfig object
         """
-        if 'group' in cfg:
-            gcfg = cfg['group']
+        if "group" in cfg:
+            gcfg = cfg["group"]
             self.validate_group_config(gcfg)
-            column_cfgs = [
-                self.get_column_config(gc) for gc in gcfg['columns']]
-            return GroupConfig(gcfg['namespace'], column_cfgs)
+            column_cfgs = [self.get_column_config(gc) for gc in gcfg["columns"]]
+            return GroupConfig(gcfg["namespace"], column_cfgs)
 
         self.validate_column_config(cfg)
         column_cfg = self.default_cfg.copy()
@@ -250,11 +261,11 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
         :param headers: A list of table headers
         """
         # TODO: decide what to do with unmentioned columns
-        super(KeyValueGroupList, self).__init__(
-            default_cfg, column_cfgs)
+        super(KeyValueGroupList, self).__init__(default_cfg, column_cfgs)
         self.headers = headers
         self.headerindexmap = OrderedDict(
-            (b, a) for (a, b) in enumerate(self.headers))
+            (b, a) for (a, b) in enumerate(self.headers)
+        )
         self.checked = set()
         self.output_configs = self.get_output_configs()
 
@@ -272,7 +283,7 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
             output_configs.append(GroupConfig(gcfg.namespace, output_cfg))
 
         output_defcfg = self.get_group_output_configs(self.column_cfgs, True)
-        output_configs.append(GroupConfig('', output_defcfg))
+        output_configs.append(GroupConfig("", output_defcfg))
         return output_configs
 
     def get_group_output_configs(self, column_cfgs, isdefault):
@@ -303,7 +314,8 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
             if pos > 0:
                 if pos in positioned:
                     raise Exception(
-                        "Multiple columns specified for position: %d" % pos)
+                        "Multiple columns specified for position: %d" % pos
+                    )
                 positioned[pos] = (cfg, self.headerindexmap[cfg["name"]])
             else:
                 unpositioned.append((cfg, self.headerindexmap[cfg["name"]]))
@@ -315,8 +327,7 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
                 if name not in self.checked:
                     cfg = self.get_column_config({"name": name})
                     assert not isinstance(cfg, GroupConfig)
-                    unpositioned.append(
-                        (cfg, self.headerindexmap[cfg["name"]]))
+                    unpositioned.append((cfg, self.headerindexmap[cfg["name"]]))
 
         # The dance- put positioned columns in the right place and fill
         # any gaps with unpositioned columns (otherwise append to end)
@@ -336,9 +347,10 @@ class KeyValueGroupList(BulkAnnotationConfiguration):
         """
         Return a set of KeyValueListTransformer objects, one for each group
         """
-        transformers = [KeyValueListTransformer(
-            self.headers, gc.columns, gc.namespace)
-            for gc in self.output_configs]
+        transformers = [
+            KeyValueListTransformer(self.headers, gc.columns, gc.namespace)
+            for gc in self.output_configs
+        ]
         return transformers
 
 
@@ -386,8 +398,12 @@ class KeyValueListTransformer(object):
             values = [value]
 
         if cfg["omitempty"]:
-            values = [v for v in values if v is not None and (
-                not isinstance(v, basestring) or v.strip())]
+            values = [
+                v
+                for v in values
+                if v is not None
+                and (not isinstance(v, basestring) or v.strip())
+            ]
 
         if cfg["clientvalue"] is not None:
             values = [valuesub(v, cfg["clientvalue"]) for v in values]
@@ -404,6 +420,7 @@ class KeyValueListTransformer(object):
                  - 1+ if `split` option is enabled
         """
         assert len(rowvalues) == len(self.headers)
-        rowkvs = [self.transform1(rowvalues[i], c)
-                  for (c, i) in self.output_configs]
+        rowkvs = [
+            self.transform1(rowvalues[i], c) for (c, i) in self.output_configs
+        ]
         return rowkvs

--- a/src/omero/util/pixelstypetopython.py
+++ b/src/omero/util/pixelstypetopython.py
@@ -47,77 +47,78 @@ DOUBLE = PixelsTypedouble
 
 
 def toPython(pixelType):
-    if(pixelType == INT_8):
-        return 'b'
-    if(pixelType == UINT_8):
-        return 'B'
-    if(pixelType == INT_16):
-        return 'h'
-    if(pixelType == UINT_16):
-        return 'H'
-    if(pixelType == INT_32):
-        return 'i'
-    if(pixelType == UINT_32):
-        return 'I'
-    if(pixelType == FLOAT):
-        return 'f'
-    if(pixelType == DOUBLE):
-        return 'd'
+    if pixelType == INT_8:
+        return "b"
+    if pixelType == UINT_8:
+        return "B"
+    if pixelType == INT_16:
+        return "h"
+    if pixelType == UINT_16:
+        return "H"
+    if pixelType == INT_32:
+        return "i"
+    if pixelType == UINT_32:
+        return "I"
+    if pixelType == FLOAT:
+        return "f"
+    if pixelType == DOUBLE:
+        return "d"
 
 
 def toNumpy(pixelType):
     import numpy
-    if(pixelType == INT_8):
+
+    if pixelType == INT_8:
         return numpy.int8
-    if(pixelType == UINT_8):
+    if pixelType == UINT_8:
         return numpy.uint8
-    if(pixelType == INT_16):
+    if pixelType == INT_16:
         return numpy.int16
-    if(pixelType == UINT_16):
+    if pixelType == UINT_16:
         return numpy.uint16
-    if(pixelType == INT_32):
+    if pixelType == INT_32:
         return numpy.int32
-    if(pixelType == UINT_32):
+    if pixelType == UINT_32:
         return numpy.uint32
-    if(pixelType == FLOAT):
+    if pixelType == FLOAT:
         return numpy.float
-    if(pixelType == DOUBLE):
+    if pixelType == DOUBLE:
         return numpy.double
 
 
 def toArray(pixelType):
-    if(pixelType == INT_8):
-        return 'b'
-    if(pixelType == UINT_8):
-        return 'B'
-    if(pixelType == INT_16):
-        return 'i2'
-    if(pixelType == UINT_16):
-        return 'H2'
-    if(pixelType == INT_32):
-        return 'i4'
-    if(pixelType == UINT_32):
-        return 'I4'
-    if(pixelType == FLOAT):
-        return 'f'
-    if(pixelType == DOUBLE):
-        return 'd'
+    if pixelType == INT_8:
+        return "b"
+    if pixelType == UINT_8:
+        return "B"
+    if pixelType == INT_16:
+        return "i2"
+    if pixelType == UINT_16:
+        return "H2"
+    if pixelType == INT_32:
+        return "i4"
+    if pixelType == UINT_32:
+        return "I4"
+    if pixelType == FLOAT:
+        return "f"
+    if pixelType == DOUBLE:
+        return "d"
 
 
 def toPIL(pixelType):
-    if(pixelType == INT_8):
-        return 'L'
-    if(pixelType == UINT_8):
-        return 'L'
-    if(pixelType == INT_16):
-        return 'I;16'
-    if(pixelType == UINT_16):
-        return 'I;16'
-    if(pixelType == INT_32):
-        return 'I'
-    if(pixelType == UINT_32):
-        return 'I'
-    if(pixelType == FLOAT):
-        return 'F'
-    if(pixelType == DOUBLE):
-        return 'F'
+    if pixelType == INT_8:
+        return "L"
+    if pixelType == UINT_8:
+        return "L"
+    if pixelType == INT_16:
+        return "I;16"
+    if pixelType == UINT_16:
+        return "I;16"
+    if pixelType == INT_32:
+        return "I"
+    if pixelType == UINT_32:
+        return "I"
+    if pixelType == FLOAT:
+        return "F"
+    if pixelType == DOUBLE:
+        return "F"

--- a/src/omero/util/pydict_text_io.py
+++ b/src/omero/util/pydict_text_io.py
@@ -30,6 +30,7 @@ from omero.rtypes import unwrap
 
 try:
     import yaml
+
     YAML_ENABLED = True
 except ImportError:
     YAML_ENABLED = False
@@ -40,8 +41,8 @@ def get_supported_formats():
     Return the supported formats
     """
     if YAML_ENABLED:
-        return ('json', 'yaml')
-    return ('json',)
+        return ("json", "yaml")
+    return ("json",)
 
 
 def load(fileobj, filetype=None, single=True, session=None):
@@ -57,7 +58,8 @@ def load(fileobj, filetype=None, single=True, session=None):
 
     if not isinstance(fileobj, basestring):
         raise Exception(
-            'Invalid type: fileobj must be a filename or json string')
+            "Invalid type: fileobj must be a filename or json string"
+        )
 
     try:
         data = json.loads(fileobj)
@@ -68,26 +70,27 @@ def load(fileobj, filetype=None, single=True, session=None):
     except ValueError:
         pass
 
-    m = re.match(r'originalfile:(\d+)$', fileobj, re.I)
+    m = re.match(r"originalfile:(\d+)$", fileobj, re.I)
     if m:
         rawdata, filetype = get_format_originalfileid(
-            int(m.group(1)), filetype, session)
+            int(m.group(1)), filetype, session
+        )
     else:
         rawdata, filetype = get_format_filename(fileobj, filetype)
 
-    if filetype == 'yaml':
+    if filetype == "yaml":
         if not YAML_ENABLED:
             raise ImportError("yaml (PyYAML) module required")
         data = list(yaml.load_all(rawdata))
         if single:
             if len(data) != 1:
                 raise Exception(
-                    "Expected YAML file with one document, found %d" %
-                    len(data))
+                    "Expected YAML file with one document, found %d" % len(data)
+                )
             return data[0]
         return data
 
-    if filetype == 'json':
+    if filetype == "json":
         data = json.loads(rawdata)
         if single:
             return data
@@ -102,33 +105,33 @@ def dump(data, formattype):
     formattype: The output format
     """
 
-    if formattype == 'yaml':
+    if formattype == "yaml":
         if not YAML_ENABLED:
             raise ImportError("yaml (PyYAML) module required")
         return yaml.dump(data)
 
-    if formattype == 'json':
+    if formattype == "json":
         return json.dumps(data)
 
-    raise ValueError('Unknown format: %s' % formattype)
+    raise ValueError("Unknown format: %s" % formattype)
 
 
 def _format_from_name(filename):
     # splitext includes the dot on the extension
     ext = os.path.splitext(filename)[1].lower()[1:]
-    if ext in ('yml', 'yaml'):
-        return 'yaml'
-    if ext in ('js', 'json'):
-        return 'json'
+    if ext in ("yml", "yaml"):
+        return "yaml"
+    if ext in ("js", "json"):
+        return "json"
 
 
 def get_format_filename(filename, filetype):
     """Returns bytes from the named json or yaml file."""
     if not filetype:
         filetype = _format_from_name(filename)
-    if filetype not in ('json', 'yaml'):
-        raise ValueError('Unknown file format: %s' % filename)
-    with open(filename, 'rb') as f:
+    if filetype not in ("json", "yaml"):
+        raise ValueError("Unknown file format: %s" % filename)
+    with open(filename, "rb") as f:
         rawdata = f.read()
     return rawdata, filetype
 
@@ -136,22 +139,24 @@ def get_format_filename(filename, filetype):
 def get_format_originalfileid(originalfileid, filetype, session):
     if not session:
         raise ValueError(
-            'OMERO session required: OriginalFile:%d' % originalfileid)
-    f = session.getQueryService().get('OriginalFile', originalfileid)
+            "OMERO session required: OriginalFile:%d" % originalfileid
+        )
+    f = session.getQueryService().get("OriginalFile", originalfileid)
     if not filetype:
         try:
             mt = unwrap(f.getMimetype()).lower()
         except AttributeError:
-            mt = ''
-        if mt == 'application/x-yaml':
-            filetype = 'yaml'
-        if mt == 'application/json':
-            filetype = 'json'
+            mt = ""
+        if mt == "application/x-yaml":
+            filetype = "yaml"
+        if mt == "application/json":
+            filetype = "json"
     if not filetype:
         filetype = _format_from_name(unwrap(f.getName()))
-    if filetype not in ('json', 'yaml'):
+    if filetype not in ("json", "yaml"):
         raise ValueError(
-            'Unknown file format: OriginalFile:%d' % originalfileid)
+            "Unknown file format: OriginalFile:%d" % originalfileid
+        )
 
     rfs = session.createRawFileStore()
     try:

--- a/src/omero/util/roi_handling_utils.py
+++ b/src/omero/util/roi_handling_utils.py
@@ -48,15 +48,15 @@ def get_line_data(pixels, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
     size_x = pixels.getSizeX()
     size_y = pixels.getSizeY()
 
-    line_x = x2-x1
-    line_y = y2-y1
+    line_x = x2 - x1
+    line_y = y2 - y1
 
-    rads = math.atan(old_div(float(line_x),line_y))
+    rads = math.atan(old_div(float(line_x), line_y))
 
     # How much extra Height do we need, top and bottom?
     extra_h = abs(math.sin(rads) * line_w)
-    bottom = int(max(y1, y2) + old_div(extra_h,2))
-    top = int(min(y1, y2) - old_div(extra_h,2))
+    bottom = int(max(y1, y2) + old_div(extra_h, 2))
+    top = int(min(y1, y2) - old_div(extra_h, 2))
 
     # How much extra width do we need, left and right?
     extra_w = abs(math.cos(rads) * line_w)
@@ -74,11 +74,11 @@ def get_line_data(pixels, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
         top = 0
     y = top
     if right > size_x:
-        pad_right = right-size_x
+        pad_right = right - size_x
         right = size_x
     w = int(right - left)
     if bottom > size_y:
-        pad_bottom = bottom-size_y
+        pad_bottom = bottom - size_y
         bottom = size_y
     h = int(bottom - top)
     tile = (x, y, w, h)
@@ -119,9 +119,9 @@ def get_line_data(pixels, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
     # finally we need to crop to the length of the line
     length = int(math.sqrt(math.pow(line_x, 2) + math.pow(line_y, 2)))
     rot_w, rot_h = rotated.size
-    crop_x = old_div((rot_w - length),2)
+    crop_x = old_div((rot_w - length), 2)
     crop_x2 = crop_x + length
-    crop_y = old_div((rot_h - line_w),2)
+    crop_y = old_div((rot_h - line_w), 2)
     crop_y2 = crop_y + line_w
     cropped = rotated.crop((crop_x, crop_y, crop_x2, crop_y2))
     return asarray(cropped)
@@ -137,7 +137,7 @@ def points_string_to_xy_list(string):
     if len(point_lists) < 2:
         if len(point_lists) == 1 and point_lists[0]:
             xys = point_lists[0].split()
-            xy_list = [tuple(map(float, xy.split(','))) for xy in xys]
+            xy_list = [tuple(map(float, xy.split(","))) for xy in xys]
             return xy_list
         raise ValueError("Unrecognised ROI shape 'points' string: %s" % string)
 

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -44,9 +44,11 @@ import omero.util.pixelstypetopython as pixelstypetopython
 
 try:
     import hashlib
+
     hash_sha1 = hashlib.sha1
 except:
     import sha
+
     hash_sha1 = sha.new
 
 try:
@@ -55,29 +57,31 @@ except:  # pragma: nocover
     try:
         import Image  # see ticket:2597
     except:
-        logging.error('No Pillow installed')
+        logging.error("No Pillow installed")
 
 # r,g,b,a colours for use in scripts.
 COLOURS = {
-    'Red': (255, 0, 0, 255),
-    'Green': (0, 255, 0, 255),
-    'Blue': (0, 0, 255, 255),
-    'Yellow': (255, 255, 0, 255),
-    'White': (255, 255, 255, 255), }
+    "Red": (255, 0, 0, 255),
+    "Green": (0, 255, 0, 255),
+    "Blue": (0, 0, 255, 255),
+    "Yellow": (255, 255, 0, 255),
+    "White": (255, 255, 255, 255),
+}
 
 EXTRA_COLOURS = {
-    'Violet': (238, 133, 238, 255),
-    'Indigo': (79, 6, 132, 255),
-    'Black': (0, 0, 0, 255),
-    'Orange': (254, 200, 6, 255),
-    'Gray': (130, 130, 130, 255), }
+    "Violet": (238, 133, 238, 255),
+    "Indigo": (79, 6, 132, 255),
+    "Black": (0, 0, 0, 255),
+    "Orange": (254, 200, 6, 255),
+    "Gray": (130, 130, 130, 255),
+}
 
-CSV_NS = 'text/csv'
-CSV_FORMAT = 'text/csv'
+CSV_NS = "text/csv"
+CSV_FORMAT = "text/csv"
 SU_LOG = logging.getLogger("omero.util.script_utils")
 
 
-def drawTextOverlay(draw, x, y, text, colour='0xffffff'):
+def drawTextOverlay(draw, x, y, text, colour="0xffffff"):
     """
     Draw test on image.
     @param draw The PIL Draw class.
@@ -87,11 +91,12 @@ def drawTextOverlay(draw, x, y, text, colour='0xffffff'):
     @param colour The colour as a PIL colour string to draw the text in.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     draw.text((x, y), text, fill=colour)
 
 
-def drawLineOverlay(draw, x0, y0, x1, y1, colour='0xffffff'):
+def drawLineOverlay(draw, x0, y0, x1, y1, colour="0xffffff"):
     """
     Draw line on image.
     @param draw The PIL Draw class.
@@ -102,7 +107,8 @@ def drawLineOverlay(draw, x0, y0, x1, y1, colour='0xffffff'):
     @param colour The colour as a PIL colour fill in the line.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     draw.line([(x0, y0), (x1, y1)], fill=colour)
 
 
@@ -115,7 +121,8 @@ def rgbToRGBInt(red, green, blue):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     RGBInt = (red << 16) + (green << 8) + blue
     return int(RGBInt)
 
@@ -127,9 +134,10 @@ def RGBToPIL(RGB):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     hexval = hex(int(RGB))
-    return '#' + (6 - len(hexval[2:])) * '0' + hexval[2:]
+    return "#" + (6 - len(hexval[2:])) * "0" + hexval[2:]
 
 
 def rangeToStr(range):
@@ -139,21 +147,23 @@ def rangeToStr(range):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     first = 1
     string = ""
     for value in range:
-        if(first == 1):
+        if first == 1:
             string = str(value)
             first = 0
         else:
-            string = string + ',' + str(value)
+            string = string + "," + str(value)
     return string
 
 
 def rmdir_recursive(dir):
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     for name in os.listdir(dir):
         full_name = os.path.join(dir, name)
         # on Windows, if we don't have write permission we can't remove
@@ -170,7 +180,8 @@ def rmdir_recursive(dir):
 def calcSha1(filename):
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0. Use calc_sha1 instead",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     """
     Returns a hash of the file identified by filename
 
@@ -189,7 +200,7 @@ def calc_sha1(filename):
     @return:            The hash of the file
     """
 
-    with open(filename, 'rb') as file_handle:
+    with open(filename, "rb") as file_handle:
         h = hash_sha1()
         h.update(file_handle.read())
         hash = h.hexdigest()
@@ -198,7 +209,8 @@ def calc_sha1(filename):
 
 def calcSha1FromData(data):
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     """
     Calculate the Sha1 Hash from a data array
     @param data The data array.
@@ -212,9 +224,11 @@ def calcSha1FromData(data):
 
 def getFormat(queryService, format):
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     return queryService.findByQuery(
-        "from Format as f where f.value='" + format + "'", None)
+        "from Format as f where f.value='" + format + "'", None
+    )
 
 
 def createFile(updateService, filename, mimetype=None, origFilePathName=None):
@@ -233,13 +247,14 @@ def createFile(updateService, filename, mimetype=None, origFilePathName=None):
     """
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0. Use create_file instead",
-        DeprecationWarning)
-    return create_file(updateService, filename, mimetype,
-                       origFilePathName)
+        DeprecationWarning,
+    )
+    return create_file(updateService, filename, mimetype, origFilePathName)
 
 
-def create_file(update_service, filename, mimetype=None,
-                orig_file_path_name=None):
+def create_file(
+    update_service, filename, mimetype=None, orig_file_path_name=None
+):
     """
     Creates an original file, saves it to the server and returns the result
 
@@ -282,7 +297,8 @@ def uploadFile(rawFileStore, originalFile, filePath=None):
     """
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0, Use upload_file instead",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     upload_file(rawFileStore, originalFile, filePath)
 
 
@@ -302,7 +318,7 @@ def upload_file(raw_file_store, original_file, file_path=None):
     if file_path is None:
         file_path = original_file.getName().getValue()
 
-    with open(file_path, 'rb') as file_handle:
+    with open(file_path, "rb") as file_handle:
         done = 0
         while done != 1:
             if increment + cnt < file_size:
@@ -327,7 +343,9 @@ def downloadFile(rawFileStore, originalFile, filePath=None):
     """
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0.\
-        Use download_file instead.", DeprecationWarning)
+        Use download_file instead.",
+        DeprecationWarning,
+    )
     return download_file(rawFileStore, originalFile, filePath)
 
 
@@ -356,7 +374,7 @@ def download_file(raw_file_store, original_file, file_path=None):
     file_size = original_file.getSize().getValue()
     block_size = min(max_block_size, file_size)
     cnt = 0
-    with open(file_path, 'wb') as file_handle:
+    with open(file_path, "wb") as file_handle:
         while cnt < file_size:
             block = raw_file_store.read(cnt, block_size)
             cnt = cnt + block_size
@@ -365,8 +383,9 @@ def download_file(raw_file_store, original_file, file_path=None):
     return file_path
 
 
-def attachFileToParent(updateService, parent, originalFile,
-                       description=None, namespace=None):
+def attachFileToParent(
+    updateService, parent, originalFile, description=None, namespace=None
+):
     """
     Attaches the original file (file) to a Project, Dataset or Image (parent)
 
@@ -381,7 +400,8 @@ def attachFileToParent(updateService, parent, originalFile,
                                 (* = Project, Dataset or Image)
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     fa = omero.model.FileAnnotationI()
     fa.setFile(originalFile)
     if description:
@@ -403,9 +423,17 @@ def attachFileToParent(updateService, parent, originalFile,
     return updateService.saveAndReturnObject(l)
 
 
-def uploadAndAttachFile(queryService, updateService, rawFileStore, parent,
-                        localName, mimetype, description=None,
-                        namespace=None, origFilePathName=None):
+def uploadAndAttachFile(
+    queryService,
+    updateService,
+    rawFileStore,
+    parent,
+    localName,
+    mimetype,
+    description=None,
+    namespace=None,
+    origFilePathName=None,
+):
     """
     Uploads a local file to the server, as an Original File and attaches it to
     the parent (Project, Dataset or Image)
@@ -426,21 +454,32 @@ def uploadAndAttachFile(queryService, updateService, rawFileStore, parent,
     @return:                The originalFileLink child. (FileAnnotationI)
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     filename = localName
     if origFilePathName is None:
         origFilePathName = localName
     originalFile = createFile(
-        updateService, filename, mimetype, origFilePathName)
+        updateService, filename, mimetype, origFilePathName
+    )
     uploadFile(rawFileStore, originalFile, localName)
     fileLink = attachFileToParent(
-        updateService, parent, originalFile, description, namespace)
+        updateService, parent, originalFile, description, namespace
+    )
     return fileLink.getChild()
 
 
-def createLinkFileAnnotation(conn, localPath, parent, output="Output",
-                             parenttype="Image", mimetype=None,
-                             desc=None, ns=None, origFilePathAndName=None):
+def createLinkFileAnnotation(
+    conn,
+    localPath,
+    parent,
+    output="Output",
+    parenttype="Image",
+    mimetype=None,
+    desc=None,
+    ns=None,
+    origFilePathAndName=None,
+):
     """
     Uploads a local file to the server, as an Original File and attaches it to
     the parent (Project, Dataset or Image)
@@ -463,15 +502,31 @@ def createLinkFileAnnotation(conn, localPath, parent, output="Output",
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0. \
         Use create_link_file_annotation instead",
-        DeprecationWarning)
-    return create_link_file_annotation(conn, localPath, parent, output,
-                                       parenttype, mimetype, desc, ns,
-                                       origFilePathAndName)
+        DeprecationWarning,
+    )
+    return create_link_file_annotation(
+        conn,
+        localPath,
+        parent,
+        output,
+        parenttype,
+        mimetype,
+        desc,
+        ns,
+        origFilePathAndName,
+    )
 
 
-def create_link_file_annotation(conn, local_path, parent, output="Output",
-                                mimetype=None, description=None,
-                                namespace=None, orig_file_path_and_name=None):
+def create_link_file_annotation(
+    conn,
+    local_path,
+    parent,
+    output="Output",
+    mimetype=None,
+    description=None,
+    namespace=None,
+    orig_file_path_and_name=None,
+):
     """
     Uploads a local file to the server, as an Original File and attaches it to
     the parent (Project, Dataset or Image)
@@ -492,15 +547,21 @@ def create_link_file_annotation(conn, local_path, parent, output="Output",
     """
     if os.path.exists(local_path):
         file_annotation = conn.createFileAnnfromLocalFile(
-            local_path, origFilePathAndName=orig_file_path_and_name,
-            mimetype=mimetype, ns=namespace, desc=description)
+            local_path,
+            origFilePathAndName=orig_file_path_and_name,
+            mimetype=mimetype,
+            ns=namespace,
+            desc=description,
+        )
         message = "%s created" % output
         if parent is not None:
             if parent.canAnnotate():
                 parent_class = parent.OMERO_CLASS
                 message += " and attached to %s%s %s." % (
-                    parent_class[0].lower(), parent_class[1:],
-                    parent.getName())
+                    parent_class[0].lower(),
+                    parent_class[1:],
+                    parent.getName(),
+                )
                 parent.linkAnnotation(file_annotation)
             else:
                 message += " but could not be attached."
@@ -521,7 +582,8 @@ def getObjects(conn, params):
     """
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0. Use get_objects instead",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     return get_objects(conn, params)
 
 
@@ -545,7 +607,11 @@ def get_objects(conn, params):
     else:
         if not len(objects) == len(ids):
             message += "Found %s out of %s %s%s(s). " % (
-                len(objects), len(ids), data_type[0].lower(), data_type[1:])
+                len(objects),
+                len(ids),
+                data_type[0].lower(),
+                data_type[1:],
+            )
 
         # Sort the objects according to the order of IDs
         id_map = dict([(o.id, o) for o in objects])
@@ -563,7 +629,8 @@ def addAnnotationToImage(updateService, image, annotation):
     @return The new annotationlink object
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     l = omero.model.ImageAnnotationLinkI()
     l.setParent(image)
     l.setChild(annotation)
@@ -580,14 +647,16 @@ def readFromOriginalFile(rawFileService, iQuery, fileId, maxBlockSize=10000):
     @return The OriginalFile object contents as a string
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     fileDetails = iQuery.findByQuery(
-        "from OriginalFile as o where o.id = " + str(fileId), None)
+        "from OriginalFile as o where o.id = " + str(fileId), None
+    )
     rawFileService.setFileId(fileId)
-    data = ''
+    data = ""
     cnt = 0
     fileSize = fileDetails.getSize().getValue()
-    while(cnt < fileSize):
+    while cnt < fileSize:
         blockSize = min(maxBlockSize, fileSize)
         block = rawFileService.read(cnt, blockSize)
         data = data + block
@@ -595,7 +664,7 @@ def readFromOriginalFile(rawFileService, iQuery, fileId, maxBlockSize=10000):
     return data[0:fileSize]
 
 
-def readFileAsArray(rawFileService, iQuery, fileId, row, col, separator=' '):
+def readFileAsArray(rawFileService, iQuery, fileId, row, col, separator=" "):
     """
     Read an OriginalFile with id and column separator
     and return it as an array.
@@ -608,7 +677,8 @@ def readFileAsArray(rawFileService, iQuery, fileId, row, col, separator=' '):
     @return The file as an NumPy array.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     textBlock = readFromOriginalFile(rawFileService, iQuery, fileId)
     arrayFromFile = fromstring(textBlock, sep=separator)
     return reshape(arrayFromFile, (row, col))
@@ -622,7 +692,8 @@ def readFlimImageFile(rawPixelsStore, pixels):
     @return The Contents of the image for z = 0, t = 0, all channels;
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     sizeC = pixels.getSizeC().getValue()
     sizeX = pixels.getSizeX().getValue()
     sizeY = pixels.getSizeY().getValue()
@@ -631,7 +702,8 @@ def readFlimImageFile(rawPixelsStore, pixels):
     rawPixelsStore.setPixelsId(id, False)
     cRange = list(range(0, sizeC))
     stack = zeros(
-        (sizeC, sizeX, sizeY), dtype=pixelstypetopython.toNumpy(pixelsType))
+        (sizeC, sizeX, sizeY), dtype=pixelstypetopython.toNumpy(pixelsType)
+    )
     for c in cRange:
         plane = downloadPlane(rawPixelsStore, pixels, 0, c, 0)
         stack[c, :, :] = plane
@@ -653,7 +725,8 @@ def downloadPlane(rawPixelsStore, pixels, z, c, t):
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0.\
         Use download_plane instead",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     return download_plane(rawPixelsStore, pixels, z, c, t)
 
 
@@ -673,8 +746,11 @@ def download_plane(raw_pixels_store, pixels, z, c, t):
     size_x = pixels.getSizeX().getValue()
     size_y = pixels.getSizeY().getValue()
     pixel_type = pixels.getPixelsType().getValue().getValue()
-    convert_type = '>' + native_str(size_x * size_y) + \
-        pixelstypetopython.toPython(pixel_type)
+    convert_type = (
+        ">"
+        + native_str(size_x * size_y)
+        + pixelstypetopython.toPython(pixel_type)
+    )
     converted_plane = unpack(convert_type, raw_plane)
     numpy_type = pixelstypetopython.toNumpy(pixel_type)
     remapped_plane = array(converted_plane, numpy_type)
@@ -690,7 +766,8 @@ def getPlaneFromImage(imagePath, rgbIndex=None):
     @param imagePath   Path to image.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     i = Image.open(imagePath)
     a = asarray(i)
     if rgbIndex is None:
@@ -699,8 +776,9 @@ def getPlaneFromImage(imagePath, rgbIndex=None):
         return a[:, :, rgbIndex]
 
 
-def uploadDirAsImages(sf, queryService, updateService,
-                      pixelsService, path, dataset=None):
+def uploadDirAsImages(
+    sf, queryService, updateService, pixelsService, path, dataset=None
+):
     """
     Reads all the images in the directory specified by 'path' and
     uploads them to OMERO as a single
@@ -713,13 +791,14 @@ def uploadDirAsImages(sf, queryService, updateService,
                     omero.model.DatasetI
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     import re
 
-    regex_token = re.compile(r'(?P<Token>.+)\.')
-    regex_time = re.compile(r'T(?P<T>\d+)')
-    regex_channel = re.compile(r'_C(?P<C>.+?)(_|$)')
-    regex_zslice = re.compile(r'_Z(?P<Z>\d+)')
+    regex_token = re.compile(r"(?P<Token>.+)\.")
+    regex_time = re.compile(r"T(?P<T>\d+)")
+    regex_channel = re.compile(r"_C(?P<C>.+?)(_|$)")
+    regex_zslice = re.compile(r"_Z(?P<Z>\d+)")
 
     # assume 1 image in this folder for now.
     # Make a single map of all images. key is (z,c,t). Value is image path.
@@ -731,7 +810,7 @@ def uploadDirAsImages(sf, queryService, updateService,
     sizeZ = 1
     sizeC = 1
     sizeT = 1
-    zStart = 1      # could be 0 or 1 ?
+    zStart = 1  # could be 0 or 1 ?
     tStart = 1
 
     fullpath = None
@@ -751,17 +830,17 @@ def uploadDirAsImages(sf, queryService, updateService,
         if tSearch is None:
             theT = 0
         else:
-            theT = int(tSearch.group('T'))
+            theT = int(tSearch.group("T"))
 
         if cSearch is None:
             cName = "0"
         else:
-            cName = cSearch.group('C')
+            cName = cSearch.group("C")
 
         if zSearch is None:
             theZ = 0
         else:
-            theZ = int(zSearch.group('Z'))
+            theZ = int(zSearch.group("Z"))
 
         channelSet.add(cName)
         sizeZ = max(sizeZ, theZ)
@@ -769,7 +848,7 @@ def uploadDirAsImages(sf, queryService, updateService,
         sizeT = max(sizeT, theT)
         tStart = min(tStart, theT)
         if tokSearch is not None:
-            tokens.append(tokSearch.group('Token'))
+            tokens.append(tokSearch.group("Token"))
         imageMap[(theZ, cName, theT)] = fullpath
 
     colourMap = {}
@@ -778,9 +857,9 @@ def uploadDirAsImages(sf, queryService, updateService,
         # see if we can guess what colour the channels should be, based on
         # name.
         for i, c in enumerate(channels):
-            if c == 'rfp':
+            if c == "rfp":
                 colourMap[i] = COLOURS["Red"]
-            if c == 'gfp':
+            if c == "gfp":
                 colourMap[i] = COLOURS["Green"]
     else:
         channels = ("red", "green", "blue")
@@ -791,7 +870,7 @@ def uploadDirAsImages(sf, queryService, updateService,
     sizeC = len(channels)
 
     # use the common stem as the image name
-    imageName = os.path.commonprefix(tokens).strip('0T_')
+    imageName = os.path.commonprefix(tokens).strip("0T_")
     description = "Imported from images in %s" % path
     SU_LOG.info("Creating image: %s" % imageName)
 
@@ -804,30 +883,41 @@ def uploadDirAsImages(sf, queryService, updateService,
     # look up the PixelsType object from DB
     # omero::model::PixelsType
     pixelsType = queryService.findByQuery(
-        "from PixelsType as p where p.value='%s'" % pType, None)
-    if pixelsType is None and pType.startswith("float"):    # e.g. float32
+        "from PixelsType as p where p.value='%s'" % pType, None
+    )
+    if pixelsType is None and pType.startswith("float"):  # e.g. float32
         # omero::model::PixelsType
         pixelsType = queryService.findByQuery(
-            "from PixelsType as p where p.value='%s'" % PixelsTypefloat, None)
+            "from PixelsType as p where p.value='%s'" % PixelsTypefloat, None
+        )
     if pixelsType is None:
         SU_LOG.warn("Unknown pixels type for: %s" % pType)
         return
     sizeY, sizeX = plane.shape
 
-    SU_LOG.debug("sizeX: %s  sizeY: %s sizeZ: %s  sizeC: %s  sizeT: %s"
-                 % (sizeX, sizeY, sizeZ, sizeC, sizeT))
+    SU_LOG.debug(
+        "sizeX: %s  sizeY: %s sizeZ: %s  sizeC: %s  sizeT: %s"
+        % (sizeX, sizeY, sizeZ, sizeC, sizeT)
+    )
 
     # code below here is very similar to combineImages.py
     # create an image in OMERO and populate the planes with numpy 2D arrays
     channelList = list(range(sizeC))
     imageId = pixelsService.createImage(
-        sizeX, sizeY, sizeZ, sizeT, channelList,
-        pixelsType, imageName, description)
+        sizeX,
+        sizeY,
+        sizeZ,
+        sizeT,
+        channelList,
+        pixelsType,
+        imageName,
+        description,
+    )
     params = omero.sys.ParametersI()
     params.addId(imageId)
     pixelsId = queryService.projection(
-        "select p.id from Image i join i.pixels p where i.id = :id",
-        params)[0][0].val
+        "select p.id from Image i join i.pixels p where i.id = :id", params
+    )[0][0].val
 
     rawPixelStore = sf.createRawPixelsStore()
     rawPixelStore.setPixelsId(pixelsId, True)
@@ -847,7 +937,8 @@ def uploadDirAsImages(sf, queryService, updateService,
                         imagePath = imageMap[(zIndex, c, tIndex)]
                         if rgb:
                             SU_LOG.debug(
-                                "Getting rgb plane from: %s" % imagePath)
+                                "Getting rgb plane from: %s" % imagePath
+                            )
                             plane2D = getPlaneFromImage(imagePath, theC)
                         else:
                             SU_LOG.debug("Getting plane from: %s" % imagePath)
@@ -855,24 +946,30 @@ def uploadDirAsImages(sf, queryService, updateService,
                     else:
                         SU_LOG.debug(
                             "Creating blank plane for .",
-                            theZ, channels[theC], theT)
+                            theZ,
+                            channels[theC],
+                            theT,
+                        )
                         plane2D = zeros((sizeY, sizeX))
                     SU_LOG.debug(
                         "Uploading plane: theZ: %s, theC: %s, theT: %s"
-                        % (theZ, theC, theT))
+                        % (theZ, theC, theT)
+                    )
 
                     uploadPlane(rawPixelStore, plane2D, theZ, theC, theT)
                     minValue = min(minValue, plane2D.min())
                     maxValue = max(maxValue, plane2D.max())
             pixelsService.setChannelGlobalMinMax(
-                pixelsId, theC, float(minValue), float(maxValue))
+                pixelsId, theC, float(minValue), float(maxValue)
+            )
             rgba = None
             if theC in colourMap:
                 rgba = colourMap[theC]
             try:
                 renderingEngine = sf.createRenderingEngine()
                 resetRenderingSettings(
-                    renderingEngine, pixelsId, theC, minValue, maxValue, rgba)
+                    renderingEngine, pixelsId, theC, minValue, maxValue, rgba
+                )
             finally:
                 renderingEngine.close()
     finally:
@@ -899,9 +996,13 @@ def uploadDirAsImages(sf, queryService, updateService,
     return imageId
 
 
-def split_image(client, imageId, dir,
-                unformattedImageName="tubulin_P037_T%05d_C%s_Z%d_S1.tif",
-                dims=('T', 'C', 'Z')):
+def split_image(
+    client,
+    imageId,
+    dir,
+    unformattedImageName="tubulin_P037_T%05d_C%s_Z%d_S1.tif",
+    dims=("T", "C", "Z"),
+):
     """
     Splits the image into component planes,
     which are saved as local tiffs according to unformattedImageName
@@ -924,12 +1025,14 @@ def split_image(client, imageId, dir,
     pixels_service = session.getPixelsService()
 
     try:
-        from PIL import Image   # see ticket:2597
+        from PIL import Image  # see ticket:2597
     except:
-        import Image        # see ticket:2597
+        import Image  # see ticket:2597
 
-    query_string = "select p from Pixels p join fetch p.image " \
-                   "as i join fetch p.pixelsType where i.id='%s'" % imageId
+    query_string = (
+        "select p from Pixels p join fetch p.image "
+        "as i join fetch p.pixelsType where i.id='%s'" % imageId
+    )
     pixels = query_service.findByQuery(query_string, None)
     size_z = pixels.getSizeZ().getValue()
     size_c = pixels.getSizeC().getValue()
@@ -941,13 +1044,14 @@ def split_image(client, imageId, dir,
     pixels = pixels_service.retrievePixDescription(pixels.id.val)
     for c in pixels.iterateChannels():
         lc = c.getLogicalChannel()
-        channel_map[
-            c_index] = lc.getName() and lc.getName().getValue() or str(c_index)
+        channel_map[c_index] = (
+            lc.getName() and lc.getName().getValue() or str(c_index)
+        )
         c_index += 1
 
     def format_name(unformatted, z, c, t):
         # need to turn dims e.g. ('T', 'C', 'Z') into tuple e.g. (t, c, z)
-        dim_map = {'T': t, 'C': channel_map[c], 'Z': z}
+        dim_map = {"T": t, "C": channel_map[c], "Z": z}
         dd = tuple([dim_map[d] for d in dims])
         return unformatted % dd
 
@@ -960,12 +1064,13 @@ def split_image(client, imageId, dir,
         for z in range(size_z):
             for c in range(size_c):
                 for t in range(size_t):
-                    imageName = format_name(unformatted_image_name,
-                                            z + z_start, c,
-                                            t + t_start)
+                    imageName = format_name(
+                        unformatted_image_name, z + z_start, c, t + t_start
+                    )
                     SU_LOG.debug(
                         "downloading plane z: %s c: %s t: %s  to  %s"
-                        % (z, c, t, imageName))
+                        % (z, c, t, imageName)
+                    )
                     plane = download_plane(raw_pixels_store, pixels, z, c, t)
                     i = Image.fromarray(plane)
                     i.save(imageName)
@@ -984,7 +1089,8 @@ def createFileFromData(updateService, queryService, filename, data):
     @return The newly created OriginalFile.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     tempFile = omero.model.OriginalFileI()
     tempFile.setName(omero.rtypes.rstring(filename))
     tempFile.setPath(omero.rtypes.rstring(filename))
@@ -1004,7 +1110,8 @@ def attachArrayToImage(updateService, image, file, nameSpace):
     @return
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     fa = omero.model.FileAnnotationI()
     fa.setFile(file)
     fa.setNs(omero.rtypes.rstring(nameSpace))
@@ -1015,8 +1122,9 @@ def attachArrayToImage(updateService, image, file, nameSpace):
     return l.getChild()
 
 
-def uploadArray(rawFileStore, updateService, queryService, image,
-                filename, namespace, array):
+def uploadArray(
+    rawFileStore, updateService, queryService, image, filename, namespace, array
+):
     """
     Upload the data to the server, creating the OriginalFile Object
     and attaching it to the image.
@@ -1029,7 +1137,8 @@ def uploadArray(rawFileStore, updateService, queryService, image,
     @return The newly created file.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     data = arrayToCSV(array)
     file = createFileFromData(updateService, queryService, filename, data)
     rawFileStore.setFileId(file.getId().getValue())
@@ -1037,13 +1146,13 @@ def uploadArray(rawFileStore, updateService, queryService, image,
     increment = 10000
     cnt = 0
     done = 0
-    while(done != 1):
-        if(increment + cnt < fileSize):
+    while done != 1:
+        if increment + cnt < fileSize:
             blockSize = increment
         else:
             blockSize = fileSize - cnt
             done = 1
-        block = data[cnt:cnt + blockSize]
+        block = data[cnt : cnt + blockSize]
         rawFileStore.write(block, cnt, blockSize)
         cnt = cnt + blockSize
     return attachArrayToImage(updateService, image, file, namespace)
@@ -1056,7 +1165,8 @@ def arrayToCSV(data):
     @return The CSV string.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     size = data.shape
     row = size[0]
     col = size[1]
@@ -1064,9 +1174,9 @@ def arrayToCSV(data):
     for r in range(0, row):
         for c in range(0, col):
             strdata = strdata + str(data[r, c])
-            if(c < col - 1):
-                strdata = strdata + ','
-        strdata = strdata + '\n'
+            if c < col - 1:
+                strdata = strdata + ","
+        strdata = strdata + "\n"
     return strdata
 
 
@@ -1084,7 +1194,8 @@ def uploadPlane(rawPixelsStore, plane, z, c, t):
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0.\
         Use upload_plane instead",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     upload_plane(rawPixelsStore, plane, z, c, t)
 
 
@@ -1118,7 +1229,8 @@ def uploadPlaneByRow(rawPixelsStore, plane, z, c, t):
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0.\
         Use upload_plane_by_row",
-        DeprecationWarning)
+        DeprecationWarning,
+    )
     upload_plane_by_row(rawPixelsStore, plane, z, c, t)
 
 
@@ -1138,7 +1250,7 @@ def upload_plane_by_row(raw_pixels_store, plane, z, c, t):
 
     row_count, col_count = plane.shape
     for y in range(row_count):
-        row = byte_swapped_plane[y:y+1, :]        # slice y axis into rows
+        row = byte_swapped_plane[y : y + 1, :]  # slice y axis into rows
         converted_row = row.tostring()
         raw_pixels_store.setRow(converted_row, y, z, c, t)
 
@@ -1150,10 +1262,11 @@ def getRenderingEngine(session, pixelsId):
     @return The renderingEngine Service for the pixels.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     renderingEngine = session.createRenderingEngine()
     renderingEngine.lookupPixels(pixelsId)
-    if(renderingEngine.lookupRenderingDef(pixelsId) == 0):
+    if renderingEngine.lookupRenderingDef(pixelsId) == 0:
         renderingEngine.resetDefaultSettings(True)
     renderingEngine.lookupRenderingDef(pixelsId)
     renderingEngine.load()
@@ -1168,7 +1281,8 @@ def createPlaneDef(z, t):
     @return The RenderingDef Object.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     planeDef = omero.romio.PlaneDef()
     planeDef.t = t
     planeDef.z = z
@@ -1186,7 +1300,8 @@ def getPlaneAsPackedInt(renderingEngine, z, t):
     @param t The Timepoint.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     planeDef = createPlaneDef(z, t)
     return renderingEngine.renderAsPackedInt(planeDef)
 
@@ -1198,7 +1313,8 @@ def getRawPixelsStore(session, pixelsId):
     @return The rawPixelsStore service.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     rawPixelsStore = session.createRawPixelsStore()
     rawPixelsStore.setPixelsId(pixelsId)
     return rawPixelsStore
@@ -1211,7 +1327,8 @@ def getRawFileStore(session, fileId):
     @return The rawFileStore service.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     rawFileStore = session.createRawFileStore()
     rawFileStore.setFileId(fileId)
     return rawFileStore
@@ -1226,16 +1343,26 @@ def getPlaneInfo(iQuery, pixelsId, asOrderedList=True):
     @return list of planeInfoTimes or map[z:t:c:]
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
-    query = "from PlaneInfo as Info where pixels.id='" + \
-        str(pixelsId) + "' orderby info.deltaT"
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
+    query = (
+        "from PlaneInfo as Info where pixels.id='"
+        + str(pixelsId)
+        + "' orderby info.deltaT"
+    )
     infoList = iQuery.findAllByQuery(query, None)
 
-    if(asOrderedList):
+    if asOrderedList:
         map = {}
         for info in infoList:
-            key = "z:" + str(info.theZ.getValue()) + "t:" + \
-                str(info.theT.getValue()) + "c:" + str(info.theC.getValue())
+            key = (
+                "z:"
+                + str(info.theZ.getValue())
+                + "t:"
+                + str(info.theT.getValue())
+                + "c:"
+                + str(info.theC.getValue())
+            )
             map[key] = info.deltaT.getValue()
         return map
     else:
@@ -1246,8 +1373,9 @@ def IdentityFn(commandArgs):
     return commandArgs
 
 
-def resetRenderingSettings(renderingEngine, pixelsId, cIndex,
-                           minValue, maxValue, rgba=None):
+def resetRenderingSettings(
+    renderingEngine, pixelsId, cIndex, minValue, maxValue, rgba=None
+):
     """
     Simply resests the rendering settings for a pixel set,
     according to the min and max values
@@ -1264,13 +1392,16 @@ def resetRenderingSettings(renderingEngine, pixelsId, cIndex,
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0. \
         Use reset_rendering_settings",
-        DeprecationWarning)
-    reset_rendering_settings(renderingEngine, pixelsId, cIndex,
-                             minValue, maxValue, rgba)
+        DeprecationWarning,
+    )
+    reset_rendering_settings(
+        renderingEngine, pixelsId, cIndex, minValue, maxValue, rgba
+    )
 
 
-def reset_rendering_settings(rendering_engine, pixels_id, c_index,
-                             min_value, max_value, rgba=None):
+def reset_rendering_settings(
+    rendering_engine, pixels_id, c_index, min_value, max_value, rgba=None
+):
     """
     Simply resets the rendering settings for a pixel set,
     according to the min and max values
@@ -1296,8 +1427,9 @@ def reset_rendering_settings(rendering_engine, pixels_id, c_index,
         raise Exception("Still No Rendering Def")
 
     rendering_engine.load()
-    rendering_engine.setChannelWindow(c_index, float(min_value),
-                                      float(max_value))
+    rendering_engine.setChannelWindow(
+        c_index, float(min_value), float(max_value)
+    )
     if rgba:
         red, green, blue, alpha = rgba
         rendering_engine.setRGBA(c_index, red, green, blue, alpha)
@@ -1321,7 +1453,8 @@ def createNewImage(session, plane2Dlist, imageName, description, dataset=None):
     @return The new OMERO image: omero.model.ImageI
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     queryService = session.getQueryService()
     pixelsService = session.getPixelsService()
     rawPixelStore = session.createRawPixelsStore()
@@ -1331,7 +1464,8 @@ def createNewImage(session, plane2Dlist, imageName, description, dataset=None):
     pType = plane2Dlist[0].dtype.name
     # omero::model::PixelsType
     pixelsType = queryService.findByQuery(
-        "from PixelsType as p where p.value='%s'" % pType, None)
+        "from PixelsType as p where p.value='%s'" % pType, None
+    )
 
     theC, theT = (0, 0)
 
@@ -1345,8 +1479,15 @@ def createNewImage(session, plane2Dlist, imageName, description, dataset=None):
     channelList = [theC]  # omero::sys::IntList
     sizeZ, sizeT = (len(plane2Dlist), 1)
     iId = pixelsService.createImage(
-        sizeX, sizeY, sizeZ, sizeT, channelList,
-        pixelsType, imageName, description)
+        sizeX,
+        sizeY,
+        sizeZ,
+        sizeT,
+        channelList,
+        pixelsType,
+        imageName,
+        description,
+    )
     imageId = iId.getValue()
     image = containerService.getImages("Image", [imageId], None)[0]
 
@@ -1361,7 +1502,8 @@ def createNewImage(session, plane2Dlist, imageName, description, dataset=None):
         else:
             uploadPlane(rawPixelStore, plane2D, theZ, theC, theT)
     pixelsService.setChannelGlobalMinMax(
-        pixelsId, theC, float(minValue), float(maxValue))
+        pixelsId, theC, float(minValue), float(maxValue)
+    )
     resetRenderingSettings(renderingEngine, pixelsId, theC, minValue, maxValue)
 
     # put the image in dataset, if specified.
@@ -1386,11 +1528,14 @@ def parseInputs(client, session=None, processFn=IdentityFn):
     @return Parsed inputs as defined by ProcessFn.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     if session:
         warnings.warn(
             "argument `session' is no longer required and may be removed from "
-            "future versions of OMERO", DeprecationWarning)
+            "future versions of OMERO",
+            DeprecationWarning,
+        )
     return processFn(client.getInputs(unwrap=True))
 
 
@@ -1403,7 +1548,8 @@ def getROIFromImage(iROIService, imageId):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     roiOpts = omero.api.RoiOptions()
     return iROIService.findByImage(imageId, roiOpts)
 
@@ -1415,13 +1561,14 @@ def toCSV(list):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     lenList = len(list)
     cnt = 0
     str = ""
     for item in list:
         str = str + item
-        if(cnt < lenList - 1):
+        if cnt < lenList - 1:
             str = str + ","
         cnt = cnt + 1
     return str
@@ -1434,8 +1581,9 @@ def toList(csvString):
     @return See above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
-    list = csvString.split(',')
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
+    list = csvString.split(",")
     for index in range(len(list)):
         list[index] = list[index].strip()
     return list
@@ -1453,22 +1601,26 @@ def registerNamespace(iQuery, iUpdate, namespace, keywords):
     @return see above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     from omero.util.OmeroPopo import WorkflowData as WorkflowData
+
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     # Support rstring and str namespaces
     namespace = unwrap(namespace)
     keywords = unwrap(keywords)
 
     workflow = iQuery.findByQuery(
-        "from Namespace as n where n.name = '" + namespace + "'", None)
+        "from Namespace as n where n.name = '" + namespace + "'", None
+    )
     workflowData = WorkflowData()
-    if(workflow is not None):
+    if workflow is not None:
         workflowData = WorkflowData(workflow)
     else:
         workflowData.setNamespace(namespace)
-    splitKeywords = keywords.split(',')
+    splitKeywords = keywords.split(",")
 
     SU_LOG.debug(workflowData.asIObject())
     for keyword in splitKeywords:
@@ -1488,10 +1640,13 @@ def findROIByImage(roiService, image, namespace):
     @return see above.
     """
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     from omero.util.OmeroPopo import ROIData as ROIData
+
     warnings.warn(
-        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
+        "This method is deprecated as of OMERO 5.3.0", DeprecationWarning
+    )
     roiOptions = omero.api.RoiOptions()
     roiOptions.namespace = omero.rtypes.rstring(namespace)
     results = roiService.findByImage(image, roiOptions)
@@ -1511,7 +1666,7 @@ def numpy_to_image(plane, min_max, dtype):
 
     conv_array = convert_numpy_array(plane, min_max, dtype)
     if plane.dtype.name not in (PixelsTypeint8, PixelsTypeuint8):
-        return Image.frombytes('I', plane.shape, conv_array)
+        return Image.frombytes("I", plane.shape, conv_array)
     else:
         return Image.fromarray(conv_array)
 
@@ -1530,11 +1685,10 @@ def numpy_save_as_image(plane, min_max, dtype, name):
     try:
         image.save(name)
     except (IOError, KeyError, ValueError) as e:
-        msg = "Cannot save the array as an image: %s: %s" % (
-            name, e)
+        msg = "Cannot save the array as an image: %s: %s" % (name, e)
         logging.error(msg)
         # delete the file
-        if (exists(name)):
+        if exists(name):
             os.remove(name)
 
 
@@ -1550,7 +1704,7 @@ def convert_numpy_array(plane, min_max, type):
         # we need to scale...
         min_val, max_val = min_max
         val_range = max_val - min_val
-        if (val_range == 0):
+        if val_range == 0:
             val_range = 1
         scaled = (plane - min_val) * (old_div(float(255), val_range))
         conv_array = zeros(plane.shape, dtype=type)

--- a/src/omero/util/sessions.py
+++ b/src/omero/util/sessions.py
@@ -26,6 +26,7 @@ from __future__ import division
 from __future__ import print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import object
@@ -62,7 +63,7 @@ from path import path
 
 
 def _escape_host(host):
-    return quote(host, safe='')
+    return quote(host, safe="")
 
 
 class SessionsStore(object):
@@ -127,8 +128,9 @@ class SessionsStore(object):
 
         (old_div(dhn, id)).write_lines(lines)
 
-    def conflicts(self, host, name, id, new_props, ignore_nulls=False,
-                  check_group=True):
+    def conflicts(
+        self, host, name, id, new_props, ignore_nulls=False, check_group=True
+    ):
         """
         Compares if the passed properties are compatible with
         with those for the host, name, id tuple
@@ -148,8 +150,9 @@ class SessionsStore(object):
             new = new_props.get(key, None)
             if ignore_nulls and new is None:
                 continue
-            elif (key == "omero.port" and
-                  set((old, new)) == set((None, default_port))):
+            elif key == "omero.port" and set((old, new)) == set(
+                (None, default_port)
+            ):
                 continue
             elif old != new:
                 if conflicts != "":
@@ -212,7 +215,7 @@ class SessionsStore(object):
         if host is not None:
             self.host_file().write_text(host)
         if props is not None:
-            port = props.get('omero.port', str(omero.constants.GLACIER2PORT))
+            port = props.get("omero.port", str(omero.constants.GLACIER2PORT))
             self.port_file().write_text(port)
         if name is not None:
             self.user_file(host).write_text(name)
@@ -285,7 +288,8 @@ class SessionsStore(object):
             else:
                 raise Exception(
                     "Multiple names found for uuid=%s: %s"
-                    % (uuid, ", ".join(n)))
+                    % (uuid, ", ".join(n))
+                )
 
     def contents(self):
         """
@@ -316,8 +320,10 @@ class SessionsStore(object):
         """
         Returns the sum of all files visited by walk()
         """
+
         def f(h, n, s):
             f.i += 1
+
         f.i = 0
         self.walk(f, host, name)
         return f.i
@@ -345,8 +351,9 @@ class SessionsStore(object):
         the logic of client.joinSession()
         """
         props = self.get(server, name, sess)
-        return self.create(sess, sess, props, new=False,
-                           set_current=set_current)
+        return self.create(
+            sess, sess, props, new=False, set_current=set_current
+        )
 
     def create(self, name, pasw, props, new=True, set_current=True, sudo=None):
         """
@@ -354,6 +361,7 @@ class SessionsStore(object):
         (cilent, session_id, timeToIdle, timeToLive)
         """
         import omero.clients
+
         props = dict(props)
         host = props["omero.host"]
         client = omero.client(props)
@@ -373,7 +381,8 @@ class SessionsStore(object):
                 timeToIdle = sess.getTimeToIdle().getValue()
 
                 sess = sf.getSessionService().createSessionWithTimeouts(
-                    principal, 0, timeToIdle)
+                    principal, 0, timeToIdle
+                )
                 client.closeSession()
                 sf = client.joinSession(sess.getUuid().getValue())
             else:
@@ -407,6 +416,7 @@ class SessionsStore(object):
                 self.ctx.dbg(str(ce.err))
             except:
                 import traceback
+
                 self.ctx.dbg(traceback.format_exc())
 
             # Reload session
@@ -439,6 +449,7 @@ class SessionsStore(object):
                 self.logger.debug("Exception on killSession: %s" % e)
             s.remove()
             removed.append(s)
+
         self.walk(f, host, name, sess)
         return removed
 
@@ -473,8 +484,9 @@ class SessionsStore(object):
         Only returns the files (not directories)
         contained in d that don't start with a dot
         """
-        return [f for f in d.files("*")
-                if not str(f.basename()).startswith(".")]
+        return [
+            f for f in d.files("*") if not str(f.basename()).startswith(".")
+        ]
 
     def props(self, f):
         """
@@ -491,6 +503,7 @@ class SessionsStore(object):
                 parts.append("")
             props[parts[0]] = parts[1]
         return props
+
 
 if __name__ == "__main__":
     SessionsStore().report()

--- a/src/omero/util/temp_files.py
+++ b/src/omero/util/temp_files.py
@@ -27,6 +27,7 @@ from omero_ext.path import path
 # Activating logging at a static level
 if "DEBUG" in os.environ:
     from omero.util import configure_logging
+
     configure_logging(loglevel=logging.DEBUG)
 
 # TODO:
@@ -52,11 +53,12 @@ class TempFileManager(object):
         an atexit callback to call self.cleanup() on exit.
         """
         self.logger = logging.getLogger("omero.util.TempFileManager")
-        self.is_win32 = (sys.platform == "win32")
+        self.is_win32 = sys.platform == "win32"
         self.prefix = prefix
 
-        self.userdir = old_div(self.tmpdir(), ("%s_%s" %
-                                        (self.prefix, self.username())))
+        self.userdir = old_div(
+            self.tmpdir(), ("%s_%s" % (self.prefix, self.username()))
+        )
         """
         User-accessible directory of the form $TMPDIR/omero_$USERNAME.
         If the given directory is not writable, an attempt is made
@@ -70,7 +72,8 @@ class TempFileManager(object):
                     self.userdir = t
                     break
             raise Exception(
-                "Failed to create temporary directory: %s" % self.userdir)
+                "Failed to create temporary directory: %s" % self.userdir
+            )
         self.dir = old_div(self.userdir, self.pid())
         """
         Directory under which all temporary files and folders will be created.
@@ -94,7 +97,8 @@ class TempFileManager(object):
             """
             try:
                 portalocker.lock(
-                    self.lock, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                    self.lock, portalocker.LOCK_EX | portalocker.LOCK_NB
+                )
                 atexit.register(self.cleanup)
             except:
                 lock = self.lock
@@ -138,18 +142,20 @@ class TempFileManager(object):
         locktest = None
 
         # Read temporary  files directory from deprecated OMERO_TEMPDIR envvar
-        custom_tmpdir_deprecated = os.environ.get('OMERO_TEMPDIR', None)
-        if 'OMERO_TEMPDIR' in os.environ:
+        custom_tmpdir_deprecated = os.environ.get("OMERO_TEMPDIR", None)
+        if "OMERO_TEMPDIR" in os.environ:
             import warnings
+
             warnings.warn(
                 "OMERO_TEMPDIR is deprecated. Use OMERO_TMPDIR instead.",
-                DeprecationWarning)
+                DeprecationWarning,
+            )
 
         # Read temporary files directory from OMERO_TMPDIR envvar
         default_tmpdir = None
         if custom_tmpdir_deprecated:
             default_tmpdir = path(custom_tmpdir_deprecated) / "omero" / "tmp"
-        custom_tmpdir = os.environ.get('OMERO_TMPDIR', default_tmpdir)
+        custom_tmpdir = os.environ.get("OMERO_TMPDIR", default_tmpdir)
 
         # List target base directories by order of precedence
         targets = []
@@ -177,10 +183,12 @@ class TempFileManager(object):
                 try:
                     self.create(target)
                     name = self.mkstemp(
-                        prefix=".lock_test", suffix=".tmp", dir=target)
+                        prefix=".lock_test", suffix=".tmp", dir=target
+                    )
                     locktest = open(name, "a+")
                     portalocker.lock(
-                        locktest, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                        locktest, portalocker.LOCK_EX | portalocker.LOCK_NB
+                    )
                     locktest.close()
                     locktest = None
                     choice = target
@@ -192,7 +200,9 @@ class TempFileManager(object):
                         except:
                             self.logger.warn(
                                 "Failed to close locktest: %s",
-                                name, exc_info=True)
+                                name,
+                                exc_info=True,
+                            )
 
                     if name is not None:
                         try:
@@ -201,16 +211,18 @@ class TempFileManager(object):
                             self.logger.debug("Failed os.remove(%s)", name)
 
             except Exception as e:
-                if "Operation not permitted" in str(e) or \
-                   "Operation not supported" in str(e):
+                if "Operation not permitted" in str(
+                    e
+                ) or "Operation not supported" in str(e):
 
                     # This is the issue described in ticket:1653
                     # To prevent printing the warning, we just continue
                     # here.
                     self.logger.debug("%s does not support locking.", target)
                 else:
-                    self.logger.warn("Invalid tmp dir: %s" %
-                                     target, exc_info=True)
+                    self.logger.warn(
+                        "Invalid tmp dir: %s" % target, exc_info=True
+                    )
 
         if choice is None:
             raise Exception("Could not find lockable tmp dir")
@@ -261,7 +273,8 @@ class TempFileManager(object):
         This prevents various Windows issues.
         """
         fd, name = tempfile.mkstemp(
-            prefix=prefix, suffix=suffix, dir=dir, text=text)
+            prefix=prefix, suffix=suffix, dir=dir, text=text
+        )
         self.logger.debug("Added file %s", name)
         try:
             os.close(fd)
@@ -333,7 +346,8 @@ class TempFileManager(object):
                 f = open(str(lock), "r")
                 try:
                     portalocker.lock(
-                        f, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                        f, portalocker.LOCK_EX | portalocker.LOCK_NB
+                    )
                     # Must close for Windows, otherwise "...other process"
                     f.close()
                 except:
@@ -344,7 +358,9 @@ class TempFileManager(object):
 
     def on_rmtree(self, func, name, exc):
         self.logger.error(
-            "rmtree error: %s('%s') => %s", func.__name__, name, exc[1])
+            "rmtree error: %s('%s') => %s", func.__name__, name, exc[1]
+        )
+
 
 manager = TempFileManager()
 """
@@ -374,6 +390,7 @@ def gettempdir():
     Returns the dir value for the global TempFileManager.
     """
     return manager.gettempdir()
+
 
 if __name__ == "__main__":
 

--- a/src/omero/util/tiles.py
+++ b/src/omero/util/tiles.py
@@ -12,10 +12,13 @@ from __future__ import division
 from builtins import range
 from past.utils import old_div
 from builtins import object
+
+
 class TileLoopIteration(object):
     """
     "Interface" which must be passed to forEachTile
     """
+
     def run(self, rps, z, c, t, x, y, tileWidth, tileHeight, tileCount):
         raise NotImplemented()
 
@@ -55,7 +58,6 @@ class TileData(object):
 
 
 class TileLoop(object):
-
     def createData(self):
         """
         Subclasses must provide a fresh instance of {@link TileData}.
@@ -65,8 +67,17 @@ class TileLoop(object):
         """
         raise NotImplementedError()
 
-    def forEachTile(self, sizeX, sizeY, sizeZ, sizeC, sizeT,
-                    tileWidth, tileHeight, iteration):
+    def forEachTile(
+        self,
+        sizeX,
+        sizeY,
+        sizeZ,
+        sizeC,
+        sizeT,
+        tileWidth,
+        tileHeight,
+        iteration,
+    ):
         """
         Iterates over every tile in a given Pixels object based on the
         over arching dimensions and a requested maximum tile width and height.
@@ -97,24 +108,27 @@ class TileLoop(object):
                     for z in range(0, sizeZ):
 
                         for tileOffsetY in range(
-                                0, (old_div((sizeY + tileHeight - 1), tileHeight))):
+                            0, (old_div((sizeY + tileHeight - 1), tileHeight))
+                        ):
 
                             for tileOffsetX in range(
-                                    0, (old_div((sizeX + tileWidth - 1), tileWidth))):
+                                0, (old_div((sizeX + tileWidth - 1), tileWidth))
+                            ):
 
                                 x = tileOffsetX * tileWidth
                                 y = tileOffsetY * tileHeight
                                 w = tileWidth
 
-                                if (w + x > sizeX):
+                                if w + x > sizeX:
                                     w = sizeX - x
 
                                 h = tileHeight
-                                if (h + y > sizeY):
+                                if h + y > sizeY:
                                     h = sizeY - y
 
-                                iteration.run(data, z, c, t,
-                                              x, y, w, h, tileCount)
+                                iteration.run(
+                                    data, z, c, t, x, y, w, h, tileCount
+                                )
                                 tileCount += 1
             return tileCount
 
@@ -125,6 +139,7 @@ class TileLoop(object):
 class RPSTileData(TileData):
     """
     """
+
     def __init__(self, loop, rps):
         self.loop = loop
         self.rps = rps
@@ -143,7 +158,6 @@ class RPSTileData(TileData):
 
 
 class RPSTileLoop(TileLoop):
-
     def __init__(self, session, pixels):
         self.session = session
         self.pixels = pixels
@@ -190,6 +204,7 @@ class RPSTileLoop(TileLoop):
 
         if self.pixels is None or self.pixels.id is None:
             import omero
+
             raise omero.ClientError("pixels instance must be managed!")
         elif not self.pixels.loaded:
             try:
@@ -197,8 +212,10 @@ class RPSTileLoop(TileLoop):
                 self.pixels = srv.retrievePixDescription(self.pixels.id.val)
             except Exception as e:
                 import omero
+
                 raise omero.ClientError(
-                    "Failed to load %s\n%s" % (self.pixels.id.val, e))
+                    "Failed to load %s\n%s" % (self.pixels.id.val, e)
+                )
 
         sizeX = self.pixels.getSizeX().getValue()
         sizeY = self.pixels.getSizeY().getValue()
@@ -207,5 +224,13 @@ class RPSTileLoop(TileLoop):
         sizeT = self.pixels.getSizeT().getValue()
 
         return TileLoop.forEachTile(
-            self, sizeX, sizeY, sizeZ, sizeC, sizeT,
-            tileWidth, tileHeight, iteration)
+            self,
+            sizeX,
+            sizeY,
+            sizeZ,
+            sizeC,
+            sizeT,
+            tileWidth,
+            tileHeight,
+            iteration,
+        )

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -6,6 +6,7 @@
 """
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import object
@@ -52,8 +53,13 @@ class UpgradeCheck(object):
     #
     DEFAULT_TIMEOUT = 6.0
 
-    def __init__(self, agent, url="http://upgrade.openmicroscopy.org.uk/",
-                 version=omero_version, timeout=DEFAULT_TIMEOUT):
+    def __init__(
+        self,
+        agent,
+        url="http://upgrade.openmicroscopy.org.uk/",
+        version=omero_version,
+        timeout=DEFAULT_TIMEOUT,
+    ):
         """
         ::
             agent   := Name of the agent which is accessing the registry.
@@ -98,8 +104,7 @@ class UpgradeCheck(object):
     def getOSVersion(self):
         try:
             if len(platform.mac_ver()[0]) > 0:
-                version = "%s;%s" % (platform.platform(),
-                                     platform.mac_ver()[0])
+                version = "%s;%s" % (platform.platform(), platform.mac_ver()[0])
             else:
                 version = platform.platform()
         except:
@@ -136,7 +141,7 @@ class UpgradeCheck(object):
                 socket.setdefaulttimeout(self.timeout)
                 full_url = "%s?%s" % (self.url, params)
                 request = urllib.request.Request(full_url)
-                request.add_header('User-Agent', self.agent)
+                request.add_header("User-Agent", self.agent)
                 self.log.debug("Attempting to connect to %s" % full_url)
                 response = urllib.request.urlopen(request)
                 result = response.read()
@@ -152,5 +157,5 @@ class UpgradeCheck(object):
             self.log.info("no update needed")
             self._set(None, None)
         else:
-            self.log.warn("UPGRADE AVAILABLE:" + result.decode('utf-8'))
-            self._set(result.decode('utf-8'), None)
+            self.log.warn("UPGRADE AVAILABLE:" + result.decode("utf-8"))
+            self._set(result.decode("utf-8"), None)

--- a/src/omero_ext/argparse.py
+++ b/src/omero_ext/argparse.py
@@ -82,17 +82,18 @@ from builtins import str
 from builtins import range
 from past.builtins import basestring
 from builtins import object
-__version__ = '1.1'
+
+__version__ = "1.1"
 __all__ = [
-    'ArgumentParser',
-    'ArgumentError',
-    'Namespace',
-    'Action',
-    'FileType',
-    'HelpFormatter',
-    'RawDescriptionHelpFormatter',
-    'RawTextHelpFormatter',
-    'ArgumentDefaultsHelpFormatter',
+    "ArgumentParser",
+    "ArgumentError",
+    "Namespace",
+    "Action",
+    "FileType",
+    "HelpFormatter",
+    "RawDescriptionHelpFormatter",
+    "RawTextHelpFormatter",
+    "ArgumentDefaultsHelpFormatter",
 ]
 
 
@@ -127,29 +128,33 @@ except NameError:
 
 
 def _callable(obj):
-    return hasattr(obj, '__call__') or hasattr(obj, '__bases__')
+    return hasattr(obj, "__call__") or hasattr(obj, "__bases__")
+
 
 # silence Python 2.6 buggy warnings about Exception.message
 if _sys.version_info[:2] == (2, 6):
     import warnings
+
     warnings.filterwarnings(
-        action='ignore',
-        message='BaseException.message has been deprecated as of Python 2.6',
+        action="ignore",
+        message="BaseException.message has been deprecated as of Python 2.6",
         category=DeprecationWarning,
-        module='omero_ext.argparse')
+        module="omero_ext.argparse",
+    )
 
 
-SUPPRESS = '==SUPPRESS=='
+SUPPRESS = "==SUPPRESS=="
 
-OPTIONAL = '?'
-ZERO_OR_MORE = '*'
-ONE_OR_MORE = '+'
-PARSER = 'A...'
-REMAINDER = '...'
+OPTIONAL = "?"
+ZERO_OR_MORE = "*"
+ONE_OR_MORE = "+"
+PARSER = "A..."
+REMAINDER = "..."
 
 # =============================
 # Utility functions and classes
 # =============================
+
 
 class _AttributeHolder(object):
     """Abstract base class that provides __repr__.
@@ -166,8 +171,8 @@ class _AttributeHolder(object):
         for arg in self._get_args():
             arg_strings.append(repr(arg))
         for name, value in self._get_kwargs():
-            arg_strings.append('%s=%r' % (name, value))
-        return '%s(%s)' % (type_name, ', '.join(arg_strings))
+            arg_strings.append("%s=%r" % (name, value))
+        return "%s(%s)" % (type_name, ", ".join(arg_strings))
 
     def _get_kwargs(self):
         return _sorted(list(self.__dict__.items()))
@@ -186,6 +191,7 @@ def _ensure_value(namespace, name, value):
 # Formatting Help
 # ===============
 
+
 class HelpFormatter(object):
     """Formatter for generating usage messages and argument help strings.
 
@@ -193,16 +199,14 @@ class HelpFormatter(object):
     provided by the class are considered an implementation detail.
     """
 
-    def __init__(self,
-                 prog,
-                 indent_increment=2,
-                 max_help_position=24,
-                 width=None):
+    def __init__(
+        self, prog, indent_increment=2, max_help_position=24, width=None
+    ):
 
         # default setting for width
         if width is None:
             try:
-                width = int(_os.environ['COLUMNS'])
+                width = int(_os.environ["COLUMNS"])
             except (KeyError, ValueError):
                 width = 80
             width -= 2
@@ -219,8 +223,8 @@ class HelpFormatter(object):
         self._root_section = self._Section(self, None)
         self._current_section = self._root_section
 
-        self._whitespace_matcher = _re.compile(r'\s+')
-        self._long_break_matcher = _re.compile(r'\n\n\n+')
+        self._whitespace_matcher = _re.compile(r"\s+")
+        self._long_break_matcher = _re.compile(r"\n\n\n+")
 
     # ===============================
     # Section and indentation methods
@@ -231,11 +235,10 @@ class HelpFormatter(object):
 
     def _dedent(self):
         self._current_indent -= self._indent_increment
-        assert self._current_indent >= 0, 'Indent decreased below 0.'
+        assert self._current_indent >= 0, "Indent decreased below 0."
         self._level -= 1
 
     class _Section(object):
-
         def __init__(self, formatter, parent, heading=None):
             self.formatter = formatter
             self.parent = parent
@@ -255,17 +258,17 @@ class HelpFormatter(object):
 
             # return nothing if the section was empty
             if not item_help:
-                return ''
+                return ""
 
             # add the heading if the section was non-empty
             if self.heading is not SUPPRESS and self.heading is not None:
                 current_indent = self.formatter._current_indent
-                heading = '%*s%s:\n' % (current_indent, '', self.heading)
+                heading = "%*s%s:\n" % (current_indent, "", self.heading)
             else:
-                heading = ''
+                heading = ""
 
             # join the section-initial newline, the heading and the help
-            return join(['\n', heading, item_help, '\n'])
+            return join(["\n", heading, item_help, "\n"])
 
     def _add_item(self, func, args):
         self._current_section.items.append((func, args))
@@ -304,8 +307,9 @@ class HelpFormatter(object):
             # update the maximum item length
             invocation_length = max([len(s) for s in invocations])
             action_length = invocation_length + self._current_indent
-            self._action_max_length = max(self._action_max_length,
-                                          action_length)
+            self._action_max_length = max(
+                self._action_max_length, action_length
+            )
 
             # add the item to the list
             self._add_item(self._format_action, [action])
@@ -320,18 +324,18 @@ class HelpFormatter(object):
     def format_help(self):
         help = self._root_section.format_help()
         if help:
-            help = self._long_break_matcher.sub('\n\n', help)
-            help = help.strip('\n') + '\n'
+            help = self._long_break_matcher.sub("\n\n", help)
+            help = help.strip("\n") + "\n"
         return help
 
     def _join_parts(self, part_strings):
-        return ''.join([part
-                        for part in part_strings
-                        if part and part is not SUPPRESS])
+        return "".join(
+            [part for part in part_strings if part and part is not SUPPRESS]
+        )
 
     def _format_usage(self, usage, actions, groups, prefix):
         if prefix is None:
-            prefix = _('usage: ')
+            prefix = _("usage: ")
 
         # if usage is specified, use that
         if usage is not None:
@@ -339,11 +343,11 @@ class HelpFormatter(object):
 
         # if no optionals or positionals are available, usage is just prog
         elif usage is None and not actions:
-            usage = '%(prog)s' % dict(prog=self._prog)
+            usage = "%(prog)s" % dict(prog=self._prog)
 
         # if optionals and positionals are available, calculate usage
         elif usage is None:
-            prog = '%(prog)s' % dict(prog=self._prog)
+            prog = "%(prog)s" % dict(prog=self._prog)
 
             # split optionals from positionals
             optionals = []
@@ -357,20 +361,20 @@ class HelpFormatter(object):
             # build full usage string
             format = self._format_actions_usage
             action_usage = format(optionals + positionals, groups)
-            usage = ' '.join([s for s in [prog, action_usage] if s])
+            usage = " ".join([s for s in [prog, action_usage] if s])
 
             # wrap the usage parts if it's too long
             text_width = self._width - self._current_indent
             if len(prefix) + len(usage) > text_width:
 
                 # break usage into wrappable parts
-                part_regexp = r'\(.*?\)+|\[.*?\]+|\S+'
+                part_regexp = r"\(.*?\)+|\[.*?\]+|\S+"
                 opt_usage = format(optionals, groups)
                 pos_usage = format(positionals, groups)
                 opt_parts = _re.findall(part_regexp, opt_usage)
                 pos_parts = _re.findall(part_regexp, pos_usage)
-                assert ' '.join(opt_parts) == opt_usage
-                assert ' '.join(pos_parts) == pos_usage
+                assert " ".join(opt_parts) == opt_usage
+                assert " ".join(pos_parts) == pos_usage
 
                 # helper for wrapping lines
                 def get_lines(parts, indent, prefix=None):
@@ -382,20 +386,20 @@ class HelpFormatter(object):
                         line_len = len(indent) - 1
                     for part in parts:
                         if line_len + 1 + len(part) > text_width:
-                            lines.append(indent + ' '.join(line))
+                            lines.append(indent + " ".join(line))
                             line = []
                             line_len = len(indent) - 1
                         line.append(part)
                         line_len += len(part) + 1
                     if line:
-                        lines.append(indent + ' '.join(line))
+                        lines.append(indent + " ".join(line))
                     if prefix is not None:
-                        lines[0] = lines[0][len(indent):]
+                        lines[0] = lines[0][len(indent) :]
                     return lines
 
                 # if prog is short, follow it with optionals or positionals
                 if len(prefix) + len(prog) <= 0.75 * text_width:
-                    indent = ' ' * (len(prefix) + len(prog) + 1)
+                    indent = " " * (len(prefix) + len(prog) + 1)
                     if opt_parts:
                         lines = get_lines([prog] + opt_parts, indent, prefix)
                         lines.extend(get_lines(pos_parts, indent))
@@ -406,7 +410,7 @@ class HelpFormatter(object):
 
                 # if prog is long, put it on its own line
                 else:
-                    indent = ' ' * len(prefix)
+                    indent = " " * len(prefix)
                     parts = opt_parts + pos_parts
                     lines = get_lines(parts, indent)
                     if len(lines) > 1:
@@ -416,10 +420,10 @@ class HelpFormatter(object):
                     lines = [prog] + lines
 
                 # join lines into usage
-                usage = '\n'.join(lines)
+                usage = "\n".join(lines)
 
         # prefix with 'usage:'
-        return '%s%s\n\n' % (prefix, usage)
+        return "%s%s\n\n" % (prefix, usage)
 
     def _format_actions_usage(self, actions, groups):
         # find group indices and identify actions in groups
@@ -436,13 +440,13 @@ class HelpFormatter(object):
                     for action in group._group_actions:
                         group_actions.add(action)
                     if not group.required:
-                        inserts[start] = '['
-                        inserts[end] = ']'
+                        inserts[start] = "["
+                        inserts[end] = "]"
                     else:
-                        inserts[start] = '('
-                        inserts[end] = ')'
+                        inserts[start] = "("
+                        inserts[end] = ")"
                     for i in range(start + 1, end):
-                        inserts[i] = '|'
+                        inserts[i] = "|"
 
         # collect all actions format strings
         parts = []
@@ -452,9 +456,9 @@ class HelpFormatter(object):
             # remove | separators for suppressed arguments
             if action.help is SUPPRESS:
                 parts.append(None)
-                if inserts.get(i) == '|':
+                if inserts.get(i) == "|":
                     inserts.pop(i)
-                elif inserts.get(i + 1) == '|':
+                elif inserts.get(i + 1) == "|":
                     inserts.pop(i + 1)
 
             # produce all arg strings
@@ -463,7 +467,7 @@ class HelpFormatter(object):
 
                 # if it's in a group, strip the outer []
                 if action in group_actions:
-                    if part[0] == '[' and part[-1] == ']':
+                    if part[0] == "[" and part[-1] == "]":
                         part = part[1:-1]
 
                 # add the action string to the list
@@ -476,18 +480,18 @@ class HelpFormatter(object):
                 # if the Optional doesn't take a value, format is:
                 #    -s or --long
                 if action.nargs == 0:
-                    part = '%s' % option_string
+                    part = "%s" % option_string
 
                 # if the Optional takes a value, format is:
                 #    -s ARGS or --long ARGS
                 else:
                     default = action.dest.upper()
                     args_string = self._format_args(action, default)
-                    part = '%s %s' % (option_string, args_string)
+                    part = "%s %s" % (option_string, args_string)
 
                 # make it look optional if it's not required or in a group
                 if not action.required and action not in group_actions:
-                    part = '[%s]' % part
+                    part = "[%s]" % part
 
                 # add the action string to the list
                 parts.append(part)
@@ -497,50 +501,51 @@ class HelpFormatter(object):
             parts[i:i] = [inserts[i]]
 
         # join all the action items with spaces
-        text = ' '.join([item for item in parts if item is not None])
+        text = " ".join([item for item in parts if item is not None])
 
         # clean up separators for mutually exclusive groups
-        open = r'[\[(]'
-        close = r'[\])]'
-        text = _re.sub(r'(%s) ' % open, r'\1', text)
-        text = _re.sub(r' (%s)' % close, r'\1', text)
-        text = _re.sub(r'%s *%s' % (open, close), r'', text)
-        text = _re.sub(r'\(([^|]*)\)', r'\1', text)
+        open = r"[\[(]"
+        close = r"[\])]"
+        text = _re.sub(r"(%s) " % open, r"\1", text)
+        text = _re.sub(r" (%s)" % close, r"\1", text)
+        text = _re.sub(r"%s *%s" % (open, close), r"", text)
+        text = _re.sub(r"\(([^|]*)\)", r"\1", text)
         text = text.strip()
 
         # return the text
         return text
 
     def _format_text(self, text):
-        if '%(prog)' in text:
+        if "%(prog)" in text:
             text = text % dict(prog=self._prog)
         text_width = self._width - self._current_indent
-        indent = ' ' * self._current_indent
-        return self._fill_text(text, text_width, indent) + '\n\n'
+        indent = " " * self._current_indent
+        return self._fill_text(text, text_width, indent) + "\n\n"
 
     def _format_action(self, action):
         # determine the required width and the entry label
-        help_position = min(self._action_max_length + 2,
-                            self._max_help_position)
+        help_position = min(
+            self._action_max_length + 2, self._max_help_position
+        )
         help_width = self._width - help_position
         action_width = help_position - self._current_indent - 2
         action_header = self._format_action_invocation(action)
 
         # ho nelp; start on same line and add a final newline
         if not action.help:
-            tup = self._current_indent, '', action_header
-            action_header = '%*s%s\n' % tup
+            tup = self._current_indent, "", action_header
+            action_header = "%*s%s\n" % tup
 
         # short action name; start on the same line and pad two spaces
         elif len(action_header) <= action_width:
-            tup = self._current_indent, '', action_width, action_header
-            action_header = '%*s%-*s  ' % tup
+            tup = self._current_indent, "", action_width, action_header
+            action_header = "%*s%-*s  " % tup
             indent_first = 0
 
         # long action name; start on the next line
         else:
-            tup = self._current_indent, '', action_header
-            action_header = '%*s%s\n' % tup
+            tup = self._current_indent, "", action_header
+            action_header = "%*s%s\n" % tup
             indent_first = help_position
 
         # collect the pieces of the action help
@@ -550,13 +555,13 @@ class HelpFormatter(object):
         if action.help:
             help_text = self._expand_help(action)
             help_lines = self._split_lines(help_text, help_width)
-            parts.append('%*s%s\n' % (indent_first, '', help_lines[0]))
+            parts.append("%*s%s\n" % (indent_first, "", help_lines[0]))
             for line in help_lines[1:]:
-                parts.append('%*s%s\n' % (help_position, '', line))
+                parts.append("%*s%s\n" % (help_position, "", line))
 
         # or add a newline if the description doesn't end with one
-        elif not action_header.endswith('\n'):
-            parts.append('\n')
+        elif not action_header.endswith("\n"):
+            parts.append("\n")
 
         # if there are any sub-actions, add their help as well
         for subaction in self._iter_indented_subactions(action):
@@ -567,7 +572,7 @@ class HelpFormatter(object):
 
     def _format_action_invocation(self, action):
         if not action.option_strings:
-            metavar, = self._metavar_formatter(action, action.dest)(1)
+            (metavar,) = self._metavar_formatter(action, action.dest)(1)
             return metavar
 
         else:
@@ -584,16 +589,16 @@ class HelpFormatter(object):
                 default = action.dest.upper()
                 args_string = self._format_args(action, default)
                 for option_string in action.option_strings:
-                    parts.append('%s %s' % (option_string, args_string))
+                    parts.append("%s %s" % (option_string, args_string))
 
-            return ', '.join(parts)
+            return ", ".join(parts)
 
     def _metavar_formatter(self, action, default_metavar):
         if action.metavar is not None:
             result = action.metavar
         elif action.choices is not None:
             choice_strs = [str(choice) for choice in action.choices]
-            result = '{%s}' % ','.join(choice_strs)
+            result = "{%s}" % ",".join(choice_strs)
         else:
             result = default_metavar
 
@@ -601,26 +606,27 @@ class HelpFormatter(object):
             if isinstance(result, tuple):
                 return result
             else:
-                return (result, ) * tuple_size
+                return (result,) * tuple_size
+
         return format
 
     def _format_args(self, action, default_metavar):
         get_metavar = self._metavar_formatter(action, default_metavar)
         if action.nargs is None:
-            result = '%s' % get_metavar(1)
+            result = "%s" % get_metavar(1)
         elif action.nargs == OPTIONAL:
-            result = '[%s]' % get_metavar(1)
+            result = "[%s]" % get_metavar(1)
         elif action.nargs == ZERO_OR_MORE:
-            result = '[%s [%s ...]]' % get_metavar(2)
+            result = "[%s [%s ...]]" % get_metavar(2)
         elif action.nargs == ONE_OR_MORE:
-            result = '%s [%s ...]' % get_metavar(2)
+            result = "%s [%s ...]" % get_metavar(2)
         elif action.nargs == REMAINDER:
-            result = '...'
+            result = "..."
         elif action.nargs == PARSER:
-            result = '%s ...' % get_metavar(1)
+            result = "%s ..." % get_metavar(1)
         else:
-            formats = ['%s' for _ in range(action.nargs)]
-            result = ' '.join(formats) % get_metavar(action.nargs)
+            formats = ["%s" for _ in range(action.nargs)]
+            result = " ".join(formats) % get_metavar(action.nargs)
         return result
 
     def _expand_help(self, action):
@@ -629,11 +635,11 @@ class HelpFormatter(object):
             if params[name] is SUPPRESS:
                 del params[name]
         for name in list(params):
-            if hasattr(params[name], '__name__'):
+            if hasattr(params[name], "__name__"):
                 params[name] = params[name].__name__
-        if params.get('choices') is not None:
-            choices_str = ', '.join([str(c) for c in params['choices']])
-            params['choices'] = choices_str
+        if params.get("choices") is not None:
+            choices_str = ", ".join([str(c) for c in params["choices"]])
+            params["choices"] = choices_str
         return self._get_help_string(action) % params
 
     def _iter_indented_subactions(self, action):
@@ -648,13 +654,14 @@ class HelpFormatter(object):
             self._dedent()
 
     def _split_lines(self, text, width):
-        text = self._whitespace_matcher.sub(' ', text).strip()
+        text = self._whitespace_matcher.sub(" ", text).strip()
         return _textwrap.wrap(text, width)
 
     def _fill_text(self, text, width, indent):
-        text = self._whitespace_matcher.sub(' ', text).strip()
-        return _textwrap.fill(text, width, initial_indent=indent,
-                                           subsequent_indent=indent)
+        text = self._whitespace_matcher.sub(" ", text).strip()
+        return _textwrap.fill(
+            text, width, initial_indent=indent, subsequent_indent=indent
+        )
 
     def _get_help_string(self, action):
         return action.help
@@ -668,7 +675,7 @@ class RawDescriptionHelpFormatter(HelpFormatter):
     """
 
     def _fill_text(self, text, width, indent):
-        return ''.join([indent + line for line in text.splitlines(True)])
+        return "".join([indent + line for line in text.splitlines(True)])
 
 
 class RawTextHelpFormatter(RawDescriptionHelpFormatter):
@@ -691,11 +698,11 @@ class ArgumentDefaultsHelpFormatter(HelpFormatter):
 
     def _get_help_string(self, action):
         help = action.help
-        if '%(default)' not in action.help:
+        if "%(default)" not in action.help:
             if action.default is not SUPPRESS:
                 defaulting_nargs = [OPTIONAL, ZERO_OR_MORE]
                 if action.option_strings or action.nargs in defaulting_nargs:
-                    help += ' (default: %(default)s)'
+                    help += " (default: %(default)s)"
         return help
 
 
@@ -703,11 +710,12 @@ class ArgumentDefaultsHelpFormatter(HelpFormatter):
 # Options and Arguments
 # =====================
 
+
 def _get_action_name(argument):
     if argument is None:
         return None
     elif argument.option_strings:
-        return  '/'.join(argument.option_strings)
+        return "/".join(argument.option_strings)
     elif argument.metavar not in (None, SUPPRESS):
         return argument.metavar
     elif argument.dest not in (None, SUPPRESS):
@@ -729,21 +737,24 @@ class ArgumentError(Exception):
 
     def __str__(self):
         if self.argument_name is None:
-            format = '%(message)s'
+            format = "%(message)s"
         else:
-            format = 'argument %(argument_name)s: %(message)s'
-        return format % dict(message=self.message,
-                             argument_name=self.argument_name)
+            format = "argument %(argument_name)s: %(message)s"
+        return format % dict(
+            message=self.message, argument_name=self.argument_name
+        )
 
 
 class ArgumentTypeError(Exception):
     """An error from trying to convert a command line string to a type."""
+
     pass
 
 
 # ==============
 # Action classes
 # ==============
+
 
 class Action(_AttributeHolder):
     """Information about how to convert command line strings to Python objects.
@@ -796,17 +807,19 @@ class Action(_AttributeHolder):
             help string. If None, the 'dest' value will be used as the name.
     """
 
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 nargs=None,
-                 const=None,
-                 default=None,
-                 type=None,
-                 choices=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
         self.option_strings = option_strings
         self.dest = dest
         self.nargs = nargs
@@ -820,41 +833,44 @@ class Action(_AttributeHolder):
 
     def _get_kwargs(self):
         names = [
-            'option_strings',
-            'dest',
-            'nargs',
-            'const',
-            'default',
-            'type',
-            'choices',
-            'help',
-            'metavar',
+            "option_strings",
+            "dest",
+            "nargs",
+            "const",
+            "default",
+            "type",
+            "choices",
+            "help",
+            "metavar",
         ]
         return [(name, getattr(self, name)) for name in names]
 
     def __call__(self, parser, namespace, values, option_string=None):
-        raise NotImplementedError(_('.__call__() not defined'))
+        raise NotImplementedError(_(".__call__() not defined"))
 
 
 class _StoreAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 nargs=None,
-                 const=None,
-                 default=None,
-                 type=None,
-                 choices=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
         if nargs == 0:
-            raise ValueError('nargs for store actions must be > 0; if you '
-                             'have nothing to store, actions such as store '
-                             'true or store const may be more appropriate')
+            raise ValueError(
+                "nargs for store actions must be > 0; if you "
+                "have nothing to store, actions such as store "
+                "true or store const may be more appropriate"
+            )
         if const is not None and nargs != OPTIONAL:
-            raise ValueError('nargs must be %r to supply const' % OPTIONAL)
+            raise ValueError("nargs must be %r to supply const" % OPTIONAL)
         super(_StoreAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
@@ -865,22 +881,24 @@ class _StoreAction(Action):
             choices=choices,
             required=required,
             help=help,
-            metavar=metavar)
+            metavar=metavar,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
 
 
 class _StoreConstAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 const,
-                 default=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        const,
+        default=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
         super(_StoreConstAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
@@ -888,65 +906,63 @@ class _StoreConstAction(Action):
             const=const,
             default=default,
             required=required,
-            help=help)
+            help=help,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, self.const)
 
 
 class _StoreTrueAction(_StoreConstAction):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 default=False,
-                 required=False,
-                 help=None):
+    def __init__(
+        self, option_strings, dest, default=False, required=False, help=None
+    ):
         super(_StoreTrueAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             const=True,
             default=default,
             required=required,
-            help=help)
+            help=help,
+        )
 
 
 class _StoreFalseAction(_StoreConstAction):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 default=True,
-                 required=False,
-                 help=None):
+    def __init__(
+        self, option_strings, dest, default=True, required=False, help=None
+    ):
         super(_StoreFalseAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             const=False,
             default=default,
             required=required,
-            help=help)
+            help=help,
+        )
 
 
 class _AppendAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 nargs=None,
-                 const=None,
-                 default=None,
-                 type=None,
-                 choices=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
         if nargs == 0:
-            raise ValueError('nargs for append actions must be > 0; if arg '
-                             'strings are not supplying the value to append, '
-                             'the append const action may be more appropriate')
+            raise ValueError(
+                "nargs for append actions must be > 0; if arg "
+                "strings are not supplying the value to append, "
+                "the append const action may be more appropriate"
+            )
         if const is not None and nargs != OPTIONAL:
-            raise ValueError('nargs must be %r to supply const' % OPTIONAL)
+            raise ValueError("nargs must be %r to supply const" % OPTIONAL)
         super(_AppendAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
@@ -957,7 +973,8 @@ class _AppendAction(Action):
             choices=choices,
             required=required,
             help=help,
-            metavar=metavar)
+            metavar=metavar,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = _copy.copy(_ensure_value(namespace, self.dest, []))
@@ -966,15 +983,16 @@ class _AppendAction(Action):
 
 
 class _AppendConstAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 const,
-                 default=None,
-                 required=False,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        const,
+        default=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
         super(_AppendConstAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
@@ -983,7 +1001,8 @@ class _AppendConstAction(Action):
             default=default,
             required=required,
             help=help,
-            metavar=metavar)
+            metavar=metavar,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = _copy.copy(_ensure_value(namespace, self.dest, []))
@@ -992,20 +1011,17 @@ class _AppendConstAction(Action):
 
 
 class _CountAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest,
-                 default=None,
-                 required=False,
-                 help=None):
+    def __init__(
+        self, option_strings, dest, default=None, required=False, help=None
+    ):
         super(_CountAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             nargs=0,
             default=default,
             required=required,
-            help=help)
+            help=help,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         new_count = _ensure_value(namespace, self.dest, 0) + 1
@@ -1013,18 +1029,16 @@ class _CountAction(Action):
 
 
 class _HelpAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 dest=SUPPRESS,
-                 default=SUPPRESS,
-                 help=None):
+    def __init__(
+        self, option_strings, dest=SUPPRESS, default=SUPPRESS, help=None
+    ):
         super(_HelpAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
             nargs=0,
-            help=help)
+            help=help,
+        )
 
     def __call__(self, parser, namespace, values, option_string=None):
         parser.print_help()
@@ -1032,19 +1046,21 @@ class _HelpAction(Action):
 
 
 class _VersionAction(Action):
-
-    def __init__(self,
-                 option_strings,
-                 version=None,
-                 dest=SUPPRESS,
-                 default=SUPPRESS,
-                 help=None):
+    def __init__(
+        self,
+        option_strings,
+        version=None,
+        dest=SUPPRESS,
+        default=SUPPRESS,
+        help=None,
+    ):
         super(_VersionAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
             nargs=0,
-            help=help)
+            help=help,
+        )
         self.version = version
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -1057,20 +1073,20 @@ class _VersionAction(Action):
 
 
 class _SubParsersAction(Action):
-
     class _ChoicesPseudoAction(Action):
-
         def __init__(self, name, help):
             sup = super(_SubParsersAction._ChoicesPseudoAction, self)
             sup.__init__(option_strings=[], dest=name, help=help)
 
-    def __init__(self,
-                 option_strings,
-                 prog,
-                 parser_class,
-                 dest=SUPPRESS,
-                 help=None,
-                 metavar=None):
+    def __init__(
+        self,
+        option_strings,
+        prog,
+        parser_class,
+        dest=SUPPRESS,
+        help=None,
+        metavar=None,
+    ):
 
         self._prog_prefix = prog
         self._parser_class = parser_class
@@ -1083,16 +1099,17 @@ class _SubParsersAction(Action):
             nargs=PARSER,
             choices=self._name_parser_map,
             help=help,
-            metavar=metavar)
+            metavar=metavar,
+        )
 
     def add_parser(self, name, **kwargs):
         # set prog from the existing prefix
-        if kwargs.get('prog') is None:
-            kwargs['prog'] = '%s %s' % (self._prog_prefix, name)
+        if kwargs.get("prog") is None:
+            kwargs["prog"] = "%s %s" % (self._prog_prefix, name)
 
         # create a pseudo-action to hold the choice help
-        if 'help' in kwargs:
-            help = kwargs.pop('help')
+        if "help" in kwargs:
+            help = kwargs.pop("help")
             choice_action = self._ChoicesPseudoAction(name, help)
             self._choices_actions.append(choice_action)
 
@@ -1116,8 +1133,8 @@ class _SubParsersAction(Action):
         try:
             parser = self._name_parser_map[parser_name]
         except KeyError:
-            tup = parser_name, ', '.join(self._name_parser_map)
-            msg = _('unknown parser %r (choices: %s)' % tup)
+            tup = parser_name, ", ".join(self._name_parser_map)
+            msg = _("unknown parser %r (choices: %s)" % tup)
             raise ArgumentError(self, msg)
 
         # parse all the remaining options into the namespace
@@ -1127,6 +1144,7 @@ class _SubParsersAction(Action):
 # ==============
 # Type classes
 # ==============
+
 
 class FileType(object):
     """Factory for creating file object types
@@ -1141,16 +1159,16 @@ class FileType(object):
             the builtin open() function.
     """
 
-    def __init__(self, mode='r', bufsize=None):
+    def __init__(self, mode="r", bufsize=None):
         self._mode = mode
         self._bufsize = bufsize
 
     def __call__(self, string):
         # the special argument "-" means sys.std{in,out}
-        if string == '-':
-            if 'r' in self._mode:
+        if string == "-":
+            if "r" in self._mode:
                 return _sys.stdin
-            elif 'w' in self._mode:
+            elif "w" in self._mode:
                 return _sys.stdout
             else:
                 msg = _('argument "-" with mode %r' % self._mode)
@@ -1164,12 +1182,14 @@ class FileType(object):
 
     def __repr__(self):
         args = [self._mode, self._bufsize]
-        args_str = ', '.join([repr(arg) for arg in args if arg is not None])
-        return '%s(%s)' % (type(self).__name__, args_str)
+        args_str = ", ".join([repr(arg) for arg in args if arg is not None])
+        return "%s(%s)" % (type(self).__name__, args_str)
+
 
 # ===========================
 # Optional and Positional Parsing
 # ===========================
+
 
 class Namespace(_AttributeHolder):
     """Simple object for storing attributes.
@@ -1193,12 +1213,9 @@ class Namespace(_AttributeHolder):
 
 
 class _ActionsContainer(object):
-
-    def __init__(self,
-                 description,
-                 prefix_chars,
-                 argument_default,
-                 conflict_handler):
+    def __init__(
+        self, description, prefix_chars, argument_default, conflict_handler
+    ):
         super(_ActionsContainer, self).__init__()
 
         self.description = description
@@ -1210,17 +1227,17 @@ class _ActionsContainer(object):
         self._registries = {}
 
         # register actions
-        self.register('action', None, _StoreAction)
-        self.register('action', 'store', _StoreAction)
-        self.register('action', 'store_const', _StoreConstAction)
-        self.register('action', 'store_true', _StoreTrueAction)
-        self.register('action', 'store_false', _StoreFalseAction)
-        self.register('action', 'append', _AppendAction)
-        self.register('action', 'append_const', _AppendConstAction)
-        self.register('action', 'count', _CountAction)
-        self.register('action', 'help', _HelpAction)
-        self.register('action', 'version', _VersionAction)
-        self.register('action', 'parsers', _SubParsersAction)
+        self.register("action", None, _StoreAction)
+        self.register("action", "store", _StoreAction)
+        self.register("action", "store_const", _StoreConstAction)
+        self.register("action", "store_true", _StoreTrueAction)
+        self.register("action", "store_false", _StoreFalseAction)
+        self.register("action", "append", _AppendAction)
+        self.register("action", "append_const", _AppendConstAction)
+        self.register("action", "count", _CountAction)
+        self.register("action", "help", _HelpAction)
+        self.register("action", "version", _VersionAction)
+        self.register("action", "parsers", _SubParsersAction)
 
         # raise an exception if the conflict handler is invalid
         self._get_handler()
@@ -1237,7 +1254,7 @@ class _ActionsContainer(object):
         self._defaults = {}
 
         # determines whether an "option" looks like a negative number
-        self._negative_number_matcher = _re.compile(r'^-\d+$|^-\d*\.\d+$')
+        self._negative_number_matcher = _re.compile(r"^-\d+$|^-\d*\.\d+$")
 
         # whether or not there are any optionals that look like negative
         # numbers -- uses a list so it can be shared and edited
@@ -1271,7 +1288,6 @@ class _ActionsContainer(object):
                 return action.default
         return self._defaults.get(dest, None)
 
-
     # =======================
     # Adding argument actions
     # =======================
@@ -1286,8 +1302,8 @@ class _ActionsContainer(object):
         # argument
         chars = self.prefix_chars
         if not args or len(args) == 1 and args[0][0] not in chars:
-            if args and 'dest' in kwargs:
-                raise ValueError('dest supplied twice for positional argument')
+            if args and "dest" in kwargs:
+                raise ValueError("dest supplied twice for positional argument")
             kwargs = self._get_positional_kwargs(*args, **kwargs)
 
         # otherwise, we're adding an optional argument
@@ -1295,12 +1311,12 @@ class _ActionsContainer(object):
             kwargs = self._get_optional_kwargs(*args, **kwargs)
 
         # if no default was supplied, use the parser-level default
-        if 'default' not in kwargs:
-            dest = kwargs['dest']
+        if "default" not in kwargs:
+            dest = kwargs["dest"]
             if dest in self._defaults:
-                kwargs['default'] = self._defaults[dest]
+                kwargs["default"] = self._defaults[dest]
             elif self.argument_default is not None:
-                kwargs['default'] = self.argument_default
+                kwargs["default"] = self.argument_default
 
         # create the action object, and add it to the parser
         action_class = self._pop_action_class(kwargs)
@@ -1309,9 +1325,9 @@ class _ActionsContainer(object):
         action = action_class(**kwargs)
 
         # raise an error if the action type is not callable
-        type_func = self._registry_get('type', action.type, action.type)
+        type_func = self._registry_get("type", action.type, action.type)
         if not _callable(type_func):
-            raise ValueError('%r is not callable' % type_func)
+            raise ValueError("%r is not callable" % type_func)
 
         return self._add_action(action)
 
@@ -1354,7 +1370,7 @@ class _ActionsContainer(object):
         title_group_map = {}
         for group in self._action_groups:
             if group.title in title_group_map:
-                msg = _('cannot merge actions - two groups are named %r')
+                msg = _("cannot merge actions - two groups are named %r")
                 raise ValueError(msg % (group.title))
             title_group_map[group.title] = group
 
@@ -1368,7 +1384,8 @@ class _ActionsContainer(object):
                 title_group_map[group.title] = self.add_argument_group(
                     title=group.title,
                     description=group.description,
-                    conflict_handler=group.conflict_handler)
+                    conflict_handler=group.conflict_handler,
+                )
 
             # map the actions to their new group
             for action in group._group_actions:
@@ -1379,7 +1396,8 @@ class _ActionsContainer(object):
         # description= then this code will need to be expanded as above
         for group in container._mutually_exclusive_groups:
             mutex_group = self.add_mutually_exclusive_group(
-                required=group.required)
+                required=group.required
+            )
 
             # map the actions to their new mutex group
             for action in group._group_actions:
@@ -1391,16 +1409,16 @@ class _ActionsContainer(object):
 
     def _get_positional_kwargs(self, dest, **kwargs):
         # make sure required is not specified
-        if 'required' in kwargs:
+        if "required" in kwargs:
             msg = _("'required' is an invalid argument for positionals")
             raise TypeError(msg)
 
         # mark positional arguments as required if at least one is
         # always required
-        if kwargs.get('nargs') not in [OPTIONAL, ZERO_OR_MORE]:
-            kwargs['required'] = True
-        if kwargs.get('nargs') == ZERO_OR_MORE and 'default' not in kwargs:
-            kwargs['required'] = True
+        if kwargs.get("nargs") not in [OPTIONAL, ZERO_OR_MORE]:
+            kwargs["required"] = True
+        if kwargs.get("nargs") == ZERO_OR_MORE and "default" not in kwargs:
+            kwargs["required"] = True
 
         # return the keyword arguments with no option strings
         return dict(kwargs, dest=dest, option_strings=[])
@@ -1412,8 +1430,10 @@ class _ActionsContainer(object):
         for option_string in args:
             # error on strings that don't start with an appropriate prefix
             if not option_string[0] in self.prefix_chars:
-                msg = _('invalid option string %r: '
-                        'must start with a character %r')
+                msg = _(
+                    "invalid option string %r: "
+                    "must start with a character %r"
+                )
                 tup = option_string, self.prefix_chars
                 raise ValueError(msg % tup)
 
@@ -1425,7 +1445,7 @@ class _ActionsContainer(object):
                         long_option_strings.append(option_string)
 
         # infer destination, '--foo-bar' -> 'foo_bar' and '-x' -> 'x'
-        dest = kwargs.pop('dest', None)
+        dest = kwargs.pop("dest", None)
         if dest is None:
             if long_option_strings:
                 dest_option_string = long_option_strings[0]
@@ -1433,24 +1453,24 @@ class _ActionsContainer(object):
                 dest_option_string = option_strings[0]
             dest = dest_option_string.lstrip(self.prefix_chars)
             if not dest:
-                msg = _('dest= is required for options like %r')
+                msg = _("dest= is required for options like %r")
                 raise ValueError(msg % option_string)
-            dest = dest.replace('-', '_')
+            dest = dest.replace("-", "_")
 
         # return the updated keyword arguments
         return dict(kwargs, dest=dest, option_strings=option_strings)
 
     def _pop_action_class(self, kwargs, default=None):
-        action = kwargs.pop('action', default)
-        return self._registry_get('action', action, action)
+        action = kwargs.pop("action", default)
+        return self._registry_get("action", action, action)
 
     def _get_handler(self):
         # determine function from conflict handler string
-        handler_func_name = '_handle_conflict_%s' % self.conflict_handler
+        handler_func_name = "_handle_conflict_%s" % self.conflict_handler
         try:
             return getattr(self, handler_func_name)
         except AttributeError:
-            msg = _('invalid conflict_resolution value: %r')
+            msg = _("invalid conflict_resolution value: %r")
             raise ValueError(msg % self.conflict_handler)
 
     def _check_conflict(self, action):
@@ -1468,10 +1488,10 @@ class _ActionsContainer(object):
             conflict_handler(action, confl_optionals)
 
     def _handle_conflict_error(self, action, conflicting_actions):
-        message = _('conflicting option string(s): %s')
-        conflict_string = ', '.join([option_string
-                                     for option_string, action
-                                     in conflicting_actions])
+        message = _("conflicting option string(s): %s")
+        conflict_string = ", ".join(
+            [option_string for option_string, action in conflicting_actions]
+        )
         raise ArgumentError(action, message % conflict_string)
 
     def _handle_conflict_resolve(self, action, conflicting_actions):
@@ -1490,13 +1510,12 @@ class _ActionsContainer(object):
 
 
 class _ArgumentGroup(_ActionsContainer):
-
     def __init__(self, container, title=None, description=None, **kwargs):
         # add any missing keyword arguments by checking the container
         update = kwargs.setdefault
-        update('conflict_handler', container.conflict_handler)
-        update('prefix_chars', container.prefix_chars)
-        update('argument_default', container.argument_default)
+        update("conflict_handler", container.conflict_handler)
+        update("prefix_chars", container.prefix_chars)
+        update("argument_default", container.argument_default)
         super_init = super(_ArgumentGroup, self).__init__
         super_init(description=description, **kwargs)
 
@@ -1509,8 +1528,9 @@ class _ArgumentGroup(_ActionsContainer):
         self._actions = container._actions
         self._option_string_actions = container._option_string_actions
         self._defaults = container._defaults
-        self._has_negative_number_optionals = \
+        self._has_negative_number_optionals = (
             container._has_negative_number_optionals
+        )
 
     def _add_action(self, action):
         action = super(_ArgumentGroup, self)._add_action(action)
@@ -1523,7 +1543,6 @@ class _ArgumentGroup(_ActionsContainer):
 
 
 class _MutuallyExclusiveGroup(_ArgumentGroup):
-
     def __init__(self, container, required=False):
         super(_MutuallyExclusiveGroup, self).__init__(container)
         self.required = required
@@ -1531,7 +1550,7 @@ class _MutuallyExclusiveGroup(_ArgumentGroup):
 
     def _add_action(self, action):
         if action.required:
-            msg = _('mutually exclusive arguments must be optional')
+            msg = _("mutually exclusive arguments must be optional")
             raise ValueError(msg)
         action = self._container._add_action(action)
         self._group_actions.append(action)
@@ -1560,36 +1579,44 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         - add_help -- Add a -h/-help option
     """
 
-    def __init__(self,
-                 prog=None,
-                 usage=None,
-                 description=None,
-                 epilog=None,
-                 version=None,
-                 parents=None,
-                 formatter_class=HelpFormatter,
-                 prefix_chars='-',
-                 fromfile_prefix_chars=None,
-                 argument_default=None,
-                 conflict_handler='error',
-                 add_help=True):
+    def __init__(
+        self,
+        prog=None,
+        usage=None,
+        description=None,
+        epilog=None,
+        version=None,
+        parents=None,
+        formatter_class=HelpFormatter,
+        prefix_chars="-",
+        fromfile_prefix_chars=None,
+        argument_default=None,
+        conflict_handler="error",
+        add_help=True,
+    ):
 
         # See #4749
-        if parents is None: parents = []
+        if parents is None:
+            parents = []
 
         if version is not None:
             import warnings
+
             warnings.warn(
                 """The "version" argument to ArgumentParser is deprecated. """
                 """Please use """
                 """"add_argument(..., action='version', version="N", ...)" """
-                """instead""", DeprecationWarning)
+                """instead""",
+                DeprecationWarning,
+            )
 
         superinit = super(ArgumentParser, self).__init__
-        superinit(description=description,
-                  prefix_chars=prefix_chars,
-                  argument_default=argument_default,
-                  conflict_handler=conflict_handler)
+        superinit(
+            description=description,
+            prefix_chars=prefix_chars,
+            argument_default=argument_default,
+            conflict_handler=conflict_handler,
+        )
 
         # default setting for prog
         if prog is None:
@@ -1604,26 +1631,35 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         self.add_help = add_help
 
         add_group = self.add_argument_group
-        self._positionals = add_group(_('positional arguments'))
-        self._optionals = add_group(_('optional arguments'))
+        self._positionals = add_group(_("positional arguments"))
+        self._optionals = add_group(_("optional arguments"))
         self._subparsers = None
 
         # register types
         def identity(string):
             return string
-        self.register('type', None, identity)
+
+        self.register("type", None, identity)
 
         # add help and version arguments if necessary
         # (using explicit default to override global argument_default)
         if self.add_help:
             self.add_argument(
-                '-h', '--help', action='help', default=SUPPRESS,
-                help=_('show this help message and exit'))
+                "-h",
+                "--help",
+                action="help",
+                default=SUPPRESS,
+                help=_("show this help message and exit"),
+            )
         if self.version:
             self.add_argument(
-                '-v', '--version', action='version', default=SUPPRESS,
+                "-v",
+                "--version",
+                action="version",
+                default=SUPPRESS,
                 version=self.version,
-                help=_("show program's version number and exit"))
+                help=_("show program's version number and exit"),
+            )
 
         # add parent arguments and defaults
         for parent in parents:
@@ -1640,13 +1676,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # =======================
     def _get_kwargs(self):
         names = [
-            'prog',
-            'usage',
-            'description',
-            'version',
-            'formatter_class',
-            'conflict_handler',
-            'add_help',
+            "prog",
+            "usage",
+            "description",
+            "version",
+            "formatter_class",
+            "conflict_handler",
+            "add_help",
         ]
         return [(name, getattr(self, name)) for name in names]
 
@@ -1655,29 +1691,29 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # ==================================
     def add_subparsers(self, **kwargs):
         if self._subparsers is not None:
-            self.error(_('cannot have multiple subparser arguments'))
+            self.error(_("cannot have multiple subparser arguments"))
 
         # add the parser class to the arguments if it's not present
-        kwargs.setdefault('parser_class', type(self))
+        kwargs.setdefault("parser_class", type(self))
 
-        if 'title' in kwargs or 'description' in kwargs:
-            title = _(kwargs.pop('title', 'subcommands'))
-            description = _(kwargs.pop('description', None))
+        if "title" in kwargs or "description" in kwargs:
+            title = _(kwargs.pop("title", "subcommands"))
+            description = _(kwargs.pop("description", None))
             self._subparsers = self.add_argument_group(title, description)
         else:
             self._subparsers = self._positionals
 
         # prog defaults to the usage message of this parser, skipping
         # optional arguments and with no "usage:" prefix
-        if kwargs.get('prog') is None:
+        if kwargs.get("prog") is None:
             formatter = self._get_formatter()
             positionals = self._get_positional_actions()
             groups = self._mutually_exclusive_groups
-            formatter.add_usage(self.usage, positionals, groups, '')
-            kwargs['prog'] = formatter.format_help().strip()
+            formatter.add_usage(self.usage, positionals, groups, "")
+            kwargs["prog"] = formatter.format_help().strip()
 
         # create the parsers action and add it to the positionals list
-        parsers_class = self._pop_action_class(kwargs, 'parsers')
+        parsers_class = self._pop_action_class(kwargs, "parsers")
         action = parsers_class(option_strings=[], **kwargs)
         self._subparsers._add_action(action)
 
@@ -1692,14 +1728,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         return action
 
     def _get_optional_actions(self):
-        return [action
-                for action in self._actions
-                if action.option_strings]
+        return [action for action in self._actions if action.option_strings]
 
     def _get_positional_actions(self):
-        return [action
-                for action in self._actions
-                if not action.option_strings]
+        return [action for action in self._actions if not action.option_strings]
 
     # =====================================
     # Command line argument parsing methods
@@ -1707,8 +1739,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     def parse_args(self, args=None, namespace=None):
         args, argv = self.parse_known_args(args, namespace)
         if argv:
-            msg = _('unrecognized arguments: %s')
-            self.error(msg % ' '.join(argv))
+            msg = _("unrecognized arguments: %s")
+            self.error(msg % " ".join(argv))
         return args
 
     def parse_known_args(self, args=None, namespace=None):
@@ -1755,7 +1787,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             for i, mutex_action in enumerate(mutex_group._group_actions):
                 conflicts = action_conflicts.setdefault(mutex_action, [])
                 conflicts.extend(group_actions[:i])
-                conflicts.extend(group_actions[i + 1:])
+                conflicts.extend(group_actions[i + 1 :])
 
         # find all option indices, and determine the arg_string_pattern
         # which has an 'O' if there is an option at an index,
@@ -1766,24 +1798,24 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         for i, arg_string in enumerate(arg_strings_iter):
 
             # all args after -- are non-options
-            if arg_string == '--':
-                arg_string_pattern_parts.append('-')
+            if arg_string == "--":
+                arg_string_pattern_parts.append("-")
                 for arg_string in arg_strings_iter:
-                    arg_string_pattern_parts.append('A')
+                    arg_string_pattern_parts.append("A")
 
             # otherwise, add the arg to the arg strings
             # and note the index if it was an option
             else:
                 option_tuple = self._parse_optional(arg_string)
                 if option_tuple is None:
-                    pattern = 'A'
+                    pattern = "A"
                 else:
                     option_string_indices[i] = option_tuple
-                    pattern = 'O'
+                    pattern = "O"
                 arg_string_pattern_parts.append(pattern)
 
         # join the pieces together to form the pattern
-        arg_strings_pattern = ''.join(arg_string_pattern_parts)
+        arg_strings_pattern = "".join(arg_string_pattern_parts)
 
         # converts arg strings to the appropriate and then takes the action
         seen_actions = _set()
@@ -1800,7 +1832,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 seen_non_default_actions.add(action)
                 for conflict_action in action_conflicts.get(action, []):
                     if conflict_action in seen_non_default_actions:
-                        msg = _('not allowed with argument %s')
+                        msg = _("not allowed with argument %s")
                         action_name = _get_action_name(conflict_action)
                         raise ArgumentError(action, msg % action_name)
 
@@ -1830,7 +1862,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 # if there is an explicit argument, try to match the
                 # optional's string arguments to only this
                 if explicit_arg is not None:
-                    arg_count = match_argument(action, 'A')
+                    arg_count = match_argument(action, "A")
 
                     # if the action is a single-dash option and takes no
                     # arguments, try to parse more single-dash options out
@@ -1846,7 +1878,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                                 action = optionals_map[option_string]
                                 break
                         else:
-                            msg = _('ignored explicit argument %r')
+                            msg = _("ignored explicit argument %r")
                             raise ArgumentError(action, msg % explicit_arg)
 
                     # if the action expect exactly one argument, we've
@@ -1860,7 +1892,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                     # error if a double-dash option did not use the
                     # explicit argument
                     else:
-                        msg = _('ignored explicit argument %r')
+                        msg = _("ignored explicit argument %r")
                         raise ArgumentError(action, msg % explicit_arg)
 
                 # if there is no explicit argument, try to match the
@@ -1896,13 +1928,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             # slice off the appropriate arg strings for each Positional
             # and add the Positional and its args to the list
             for action, arg_count in zip(positionals, arg_counts):
-                args = arg_strings[start_index: start_index + arg_count]
+                args = arg_strings[start_index : start_index + arg_count]
                 start_index += arg_count
                 take_action(action, args)
 
             # slice off the Positionals that we just parsed and return the
             # index at which the Positionals' string args stopped
-            positionals[:] = positionals[len(arg_counts):]
+            positionals[:] = positionals[len(arg_counts) :]
             return start_index
 
         # consume Positionals and Optionals alternately, until we have
@@ -1916,10 +1948,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         while start_index <= max_option_string_index:
 
             # consume any Positionals preceding the next option
-            next_option_string_index = min([
-                index
-                for index in option_string_indices
-                if index >= start_index])
+            next_option_string_index = min(
+                [
+                    index
+                    for index in option_string_indices
+                    if index >= start_index
+                ]
+            )
             if start_index != next_option_string_index:
                 positionals_end_index = consume_positionals(start_index)
 
@@ -1950,14 +1985,14 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # if we didn't use all the Positional objects, there were too few
         # arg strings supplied.
         if positionals:
-            self.error(_('too few arguments'))
+            self.error(_("too few arguments"))
 
         # make sure all required actions were present
         for action in self._actions:
             if action.required:
                 if action not in seen_actions:
                     name = _get_action_name(action)
-                    self.error(_('argument %s is required') % name)
+                    self.error(_("argument %s is required") % name)
 
         # make sure all required groups had one option present
         for group in self._mutually_exclusive_groups:
@@ -1968,11 +2003,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
                 # if no actions were used, report the error
                 else:
-                    names = [_get_action_name(action)
-                             for action in group._group_actions
-                             if action.help is not SUPPRESS]
-                    msg = _('one of the arguments %s is required')
-                    self.error(msg % ' '.join(names))
+                    names = [
+                        _get_action_name(action)
+                        for action in group._group_actions
+                        if action.help is not SUPPRESS
+                    ]
+                    msg = _("one of the arguments %s is required")
+                    self.error(msg % " ".join(names))
 
         # return the updated namespace and the extra arguments
         return namespace, extras
@@ -2017,11 +2054,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # raise an exception if we weren't able to find a match
         if match is None:
             nargs_errors = {
-                None: _('expected one argument'),
-                OPTIONAL: _('expected at most one argument'),
-                ONE_OR_MORE: _('expected at least one argument'),
+                None: _("expected one argument"),
+                OPTIONAL: _("expected at most one argument"),
+                ONE_OR_MORE: _("expected at least one argument"),
             }
-            default = _('expected %s argument(s)') % action.nargs
+            default = _("expected %s argument(s)") % action.nargs
             msg = nargs_errors.get(action.nargs, default)
             raise ArgumentError(action, msg)
 
@@ -2034,8 +2071,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         result = []
         for i in range(len(actions), 0, -1):
             actions_slice = actions[:i]
-            pattern = ''.join([self._get_nargs_pattern(action)
-                               for action in actions_slice])
+            pattern = "".join(
+                [self._get_nargs_pattern(action) for action in actions_slice]
+            )
             match = _re.match(pattern, arg_strings_pattern)
             if match is not None:
                 result.extend([len(string) for string in match.groups()])
@@ -2063,8 +2101,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             return None
 
         # if the option string before the "=" is present, return the action
-        if '=' in arg_string:
-            option_string, explicit_arg = arg_string.split('=', 1)
+        if "=" in arg_string:
+            option_string, explicit_arg = arg_string.split("=", 1)
             if option_string in self._option_string_actions:
                 action = self._option_string_actions[option_string]
                 return action, option_string, explicit_arg
@@ -2075,15 +2113,19 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # if multiple actions match, the option string was ambiguous
         if len(option_tuples) > 1:
-            options = ', '.join([option_string
-                for action, option_string, explicit_arg in option_tuples])
+            options = ", ".join(
+                [
+                    option_string
+                    for action, option_string, explicit_arg in option_tuples
+                ]
+            )
             tup = arg_string, options
-            self.error(_('ambiguous option: %s could match %s') % tup)
+            self.error(_("ambiguous option: %s could match %s") % tup)
 
         # if exactly one action matched, this segmentation is good,
         # so return the parsed action
         elif len(option_tuples) == 1:
-            option_tuple, = option_tuples
+            (option_tuple,) = option_tuples
             return option_tuple
 
         # if it was not found as an option, but it looks like a negative
@@ -2094,7 +2136,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 return None
 
         # if it contains a space, it was meant to be a positional
-        if ' ' in arg_string:
+        if " " in arg_string:
             return None
 
         # it was meant to be an optional but there is no such option
@@ -2108,8 +2150,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # split at the '='
         chars = self.prefix_chars
         if option_string[0] in chars and option_string[1] in chars:
-            if '=' in option_string:
-                option_prefix, explicit_arg = option_string.split('=', 1)
+            if "=" in option_string:
+                option_prefix, explicit_arg = option_string.split("=", 1)
             else:
                 option_prefix = option_string
                 explicit_arg = None
@@ -2140,7 +2182,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # shouldn't ever get here
         else:
-            self.error(_('unexpected option string: %s') % option_string)
+            self.error(_("unexpected option string: %s") % option_string)
 
         # return the collected option tuples
         return result
@@ -2152,36 +2194,36 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # the default (None) is assumed to be a single argument
         if nargs is None:
-            nargs_pattern = '(-*A-*)'
+            nargs_pattern = "(-*A-*)"
 
         # allow zero or one arguments
         elif nargs == OPTIONAL:
-            nargs_pattern = '(-*A?-*)'
+            nargs_pattern = "(-*A?-*)"
 
         # allow zero or more arguments
         elif nargs == ZERO_OR_MORE:
-            nargs_pattern = '(-*[A-]*)'
+            nargs_pattern = "(-*[A-]*)"
 
         # allow one or more arguments
         elif nargs == ONE_OR_MORE:
-            nargs_pattern = '(-*A[A-]*)'
+            nargs_pattern = "(-*A[A-]*)"
 
         # allow any number of options or arguments
         elif nargs == REMAINDER:
-            nargs_pattern = '([-AO]*)'
+            nargs_pattern = "([-AO]*)"
 
         # allow one argument followed by any number of options or arguments
         elif nargs == PARSER:
-            nargs_pattern = '(-*A[-AO]*)'
+            nargs_pattern = "(-*A[-AO]*)"
 
         # all others should be integers
         else:
-            nargs_pattern = '(-*%s-*)' % '-*'.join('A' * nargs)
+            nargs_pattern = "(-*%s-*)" % "-*".join("A" * nargs)
 
         # if this is an optional action, -- is not allowed
         if action.option_strings:
-            nargs_pattern = nargs_pattern.replace('-*', '')
-            nargs_pattern = nargs_pattern.replace('-', '')
+            nargs_pattern = nargs_pattern.replace("-*", "")
+            nargs_pattern = nargs_pattern.replace("-", "")
 
         # return the pattern
         return nargs_pattern
@@ -2192,7 +2234,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     def _get_values(self, action, arg_strings):
         # for everything but PARSER args, strip out '--'
         if action.nargs not in [PARSER, REMAINDER]:
-            arg_strings = [s for s in arg_strings if s != '--']
+            arg_strings = [s for s in arg_strings if s != "--"]
 
         # optional argument produces a default when not present
         if not arg_strings and action.nargs == OPTIONAL:
@@ -2206,8 +2248,11 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # when nargs='*' on a positional, if there were no command-line
         # args, use the default if it is anything other than None
-        elif (not arg_strings and action.nargs == ZERO_OR_MORE and
-              not action.option_strings):
+        elif (
+            not arg_strings
+            and action.nargs == ZERO_OR_MORE
+            and not action.option_strings
+        ):
             if action.default is not None:
                 value = action.default
             else:
@@ -2216,7 +2261,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # single argument or optional argument produces a single value
         elif len(arg_strings) == 1 and action.nargs in [None, OPTIONAL]:
-            arg_string, = arg_strings
+            (arg_string,) = arg_strings
             value = self._get_value(action, arg_string)
             self._check_value(action, value)
 
@@ -2239,9 +2284,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         return value
 
     def _get_value(self, action, arg_string):
-        type_func = self._registry_get('type', action.type, action.type)
+        type_func = self._registry_get("type", action.type, action.type)
         if not _callable(type_func):
-            msg = _('%r is not callable')
+            msg = _("%r is not callable")
             raise ArgumentError(action, msg % type_func)
 
         # convert the value to the appropriate type
@@ -2250,14 +2295,14 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # ArgumentTypeErrors indicate errors
         except ArgumentTypeError:
-            name = getattr(action.type, '__name__', repr(action.type))
+            name = getattr(action.type, "__name__", repr(action.type))
             msg = str(_sys.exc_info()[1])
             raise ArgumentError(action, msg)
 
         # TypeErrors or ValueErrors also indicate errors
         except (TypeError, ValueError):
-            name = getattr(action.type, '__name__', repr(action.type))
-            msg = _('invalid %s value: %r')
+            name = getattr(action.type, "__name__", repr(action.type))
+            msg = _("invalid %s value: %r")
             raise ArgumentError(action, msg % (name, arg_string))
 
         # return the converted value
@@ -2266,8 +2311,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     def _check_value(self, action, value):
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
-            tup = value, ', '.join(map(repr, action.choices))
-            msg = _('invalid choice: %r (choose from %s)') % tup
+            tup = value, ", ".join(map(repr, action.choices))
+            msg = _("invalid choice: %r (choose from %s)") % tup
             raise ArgumentError(action, msg)
 
     # =======================
@@ -2275,16 +2320,18 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # =======================
     def format_usage(self):
         formatter = self._get_formatter()
-        formatter.add_usage(self.usage, self._actions,
-                            self._mutually_exclusive_groups)
+        formatter.add_usage(
+            self.usage, self._actions, self._mutually_exclusive_groups
+        )
         return formatter.format_help()
 
     def format_help(self):
         formatter = self._get_formatter()
 
         # usage
-        formatter.add_usage(self.usage, self._actions,
-                            self._mutually_exclusive_groups)
+        formatter.add_usage(
+            self.usage, self._actions, self._mutually_exclusive_groups
+        )
 
         # description
         formatter.add_text(self.description)
@@ -2304,10 +2351,12 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
     def format_version(self):
         import warnings
+
         warnings.warn(
             'The format_version method is deprecated -- the "version" '
-            'argument to ArgumentParser is no longer supported.',
-            DeprecationWarning)
+            "argument to ArgumentParser is no longer supported.",
+            DeprecationWarning,
+        )
         formatter = self._get_formatter()
         formatter.add_text(self.version)
         return formatter.format_help()
@@ -2330,10 +2379,12 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
     def print_version(self, file=None):
         import warnings
+
         warnings.warn(
             'The print_version method is deprecated -- the "version" '
-            'argument to ArgumentParser is no longer supported.',
-            DeprecationWarning)
+            "argument to ArgumentParser is no longer supported.",
+            DeprecationWarning,
+        )
         self._print_message(self.format_version(), file)
 
     def _print_message(self, message, file=None):
@@ -2360,4 +2411,4 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         should either exit or raise an exception.
         """
         self.print_usage(_sys.stderr)
-        self.exit(2, _('%s: error: %s\n') % (self.prog, message))
+        self.exit(2, _("%s: error: %s\n") % (self.prog, message))

--- a/src/omero_ext/cloghandler.py
+++ b/src/omero_ext/cloghandler.py
@@ -48,8 +48,9 @@ from __future__ import absolute_import
 
 
 from builtins import range
-__version__  = '0.9.1'
-__revision__  = 'lowell87@gmail.com-20130711022321-doutxl7zyzuwss5a 2013-07-10 22:23:21 -0400 [0]'
+
+__version__ = "0.9.1"
+__revision__ = "lowell87@gmail.com-20130711022321-doutxl7zyzuwss5a 2013-07-10 22:23:21 -0400 [0]"
 __author__ = "Lowell Alleman"
 __all__ = [
     "ConcurrentRotatingFileHandler",
@@ -68,7 +69,6 @@ except ImportError:
     codecs = None
 
 
-
 # Question/TODO: Should we have a fallback mode if we can't load portalocker /
 # we should still be better off than with the standard RotattingFileHandler
 # class, right? We do some rename checking... that should prevent some file
@@ -82,8 +82,10 @@ from .portalocker import lock, unlock, LOCK_EX, LOCK_NB, LockException
 class NullLogRecord(LogRecord):
     def __init__(self):
         pass
+
     def __getattr__(self, attr):
         return None
+
 
 class ConcurrentRotatingFileHandler(BaseRotatingHandler):
     """
@@ -92,8 +94,17 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
     write to the log file concurrently, but this may mean that the file will
     exceed the given size.
     """
-    def __init__(self, filename, mode='a', maxBytes=0, backupCount=0,
-                 encoding=None, debug=True, delay=0):
+
+    def __init__(
+        self,
+        filename,
+        mode="a",
+        maxBytes=0,
+        backupCount=0,
+        encoding=None,
+        debug=True,
+        delay=0,
+    ):
         """
         Open the specified file and use it as the stream for logging.
 
@@ -134,7 +145,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         expected. The same is true if this class is used by one application, but
         the RotatingFileHandler is used by another.
         """
-        # Absolute file name handling done by FileHandler since Python 2.5  
+        # Absolute file name handling done by FileHandler since Python 2.5
         BaseRotatingHandler.__init__(self, filename, mode, encoding, delay)
         self.delay = delay
         self._rotateFailed = False
@@ -144,7 +155,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         # For debug mode, swap out the "_degrade()" method with a more a verbose one.
         if debug:
             self._degrade = self._degrade_debug
-    
+
     def _open_lockfile(self):
         # Use 'file.lock' and not 'file.log.lock' (Only handles the normal "*.log" case.)
         if self.baseFilename.endswith(".log"):
@@ -152,8 +163,8 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         else:
             lock_file = self.baseFilename
         lock_file += ".lock"
-        self.stream_lock = open(lock_file,"w")
-    
+        self.stream_lock = open(lock_file, "w")
+
     def _open(self, mode=None):
         """
         Open the current base file with the (original) mode and encoding.
@@ -168,7 +179,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         else:
             stream = codecs.open(self.baseFilename, mode, self.encoding)
         return stream
-    
+
     def _close(self):
         """ Close file stream.  Unlike close(), we don't tear anything down, we
         expect the log to be re-opened after rotation."""
@@ -180,7 +191,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
                     self.stream.close()
             finally:
                 self.stream = None
-    
+
     def acquire(self):
         """ Acquire thread and file locks.  Re-opening log for 'degraded' mode.
         """
@@ -223,7 +234,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             finally:
                 # release thread lock
                 Handler.release(self)
-    
+
     def close(self):
         """
         Close log stream and stream_lock. """
@@ -234,27 +245,31 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         finally:
             self.stream_lock = None
             Handler.close(self)
-    
+
     def _degrade(self, degrade, msg, *args):
         """ Set degrade mode or not.  Ignore msg. """
         self._rotateFailed = degrade
-        del msg, args   # avoid pychecker warnings
-    
+        del msg, args  # avoid pychecker warnings
+
     def _degrade_debug(self, degrade, msg, *args):
         """ A more colorful version of _degade(). (This is enabled by passing
         "debug=True" at initialization).
         """
         if degrade:
             if not self._rotateFailed:
-                sys.stderr.write("Degrade mode - ENTERING - (pid=%d)  %s\n" %
-                                 (os.getpid(), msg % args))
+                sys.stderr.write(
+                    "Degrade mode - ENTERING - (pid=%d)  %s\n"
+                    % (os.getpid(), msg % args)
+                )
                 self._rotateFailed = True
         else:
             if self._rotateFailed:
-                sys.stderr.write("Degrade mode - EXITING  - (pid=%d)   %s\n" %
-                                 (os.getpid(), msg % args))
+                sys.stderr.write(
+                    "Degrade mode - EXITING  - (pid=%d)   %s\n"
+                    % (os.getpid(), msg % args)
+                )
                 self._rotateFailed = False
-    
+
     def doRollover(self):
         """
         Do a rollover, as described in __init__().
@@ -268,24 +283,30 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         try:
             # Determine if we can rename the log file or not. Windows refuses to
             # rename an open file, Unix is inode base so it doesn't care.
-            
+
             # Attempt to rename logfile to tempname:  There is a slight race-condition here, but it seems unavoidable
             tmpname = None
             while not tmpname or os.path.exists(tmpname):
-                tmpname = "%s.rotate.%08d" % (self.baseFilename, randint(0,99999999))
+                tmpname = "%s.rotate.%08d" % (
+                    self.baseFilename,
+                    randint(0, 99999999),
+                )
             try:
                 # Do a rename test to determine if we can successfully rename the log file
                 os.rename(self.baseFilename, tmpname)
             except (IOError, OSError):
                 exc_value = sys.exc_info()[1]
-                self._degrade(True, "rename failed.  File in use?  "
-                              "exception=%s", exc_value)
+                self._degrade(
+                    True,
+                    "rename failed.  File in use?  " "exception=%s",
+                    exc_value,
+                )
                 return
-            
+
             # Q: Is there some way to protect this code from a KeboardInterupt?
-            # This isn't necessarily a data loss issue, but it certainly does 
+            # This isn't necessarily a data loss issue, but it certainly does
             # break the rotation process during stress testing.
-            
+
             # There is currently no mechanism in place to handle the situation
             # where one of these log files cannot be renamed. (Example, user
             # opens "logfile.3" in notepad); we could test rename each file, but
@@ -295,7 +316,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
                 sfn = "%s.%d" % (self.baseFilename, i)
                 dfn = "%s.%d" % (self.baseFilename, i + 1)
                 if os.path.exists(sfn):
-                    #print "%s -> %s" % (sfn, dfn)
+                    # print "%s -> %s" % (sfn, dfn)
                     if os.path.exists(dfn):
                         os.remove(dfn)
                     os.rename(sfn, dfn)
@@ -303,7 +324,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             if os.path.exists(dfn):
                 os.remove(dfn)
             os.rename(tmpname, dfn)
-            #print "%s -> %s" % (self.baseFilename, dfn)
+            # print "%s -> %s" % (self.baseFilename, dfn)
             self._degrade(False, "Rotation completed")
         finally:
             # Re-open the output stream, but if "delay" is enabled then wait
@@ -311,7 +332,7 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             # some usage patterns.
             if not self.delay:
                 self.stream = self._open()
-    
+
     def shouldRollover(self, record):
         """
         Determine if rollover should occur.
@@ -334,10 +355,10 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
             self.stream = self._open()
             return self._shouldRollover()
         return False
-    
+
     def _shouldRollover(self):
-        if self.maxBytes > 0:                   # are we rolling over?
-            self.stream.seek(0, 2)  #due to non-posix-compliant Windows feature
+        if self.maxBytes > 0:  # are we rolling over?
+            self.stream.seek(0, 2)  # due to non-posix-compliant Windows feature
             if self.stream.tell() >= self.maxBytes:
                 return True
             else:
@@ -345,7 +366,8 @@ class ConcurrentRotatingFileHandler(BaseRotatingHandler):
         return False
 
 
-# Publish this class to the "logging.handlers" module so that it can be use 
+# Publish this class to the "logging.handlers" module so that it can be use
 # from a logging config file via logging.config.fileConfig().
 import logging.handlers
+
 logging.handlers.ConcurrentRotatingFileHandler = ConcurrentRotatingFileHandler

--- a/src/omero_ext/functional.py
+++ b/src/omero_ext/functional.py
@@ -27,5 +27,8 @@ import warnings
 
 assert wraps  # silence pyflakes
 
-warnings.warn("the omero_ext.functional module will be removed in OMERO 5.6",
-              DeprecationWarning, stacklevel=2)
+warnings.warn(
+    "the omero_ext.functional module will be removed in OMERO 5.6",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/src/omero_ext/path.py
+++ b/src/omero_ext/path.py
@@ -96,11 +96,16 @@ except AttributeError:
 
 PY3 = sys.version_info[0] >= 3
 if PY3:
+
     def u(x):
         return x
+
+
 else:
+
     def u(x):
         return codecs.unicode_escape_decode(x)[0]
+
 
 o777 = 511
 o766 = 502
@@ -124,18 +129,19 @@ def surrogate_escape(error):
     """
     Simulate the Python 3 surrogateescape handler, but for Python 2 only.
     """
-    chars = error.object[error.start:error.end]
+    chars = error.object[error.start : error.end]
     assert len(chars) == 1
     val = ord(chars)
-    val += 0xdc00
+    val += 0xDC00
     return chr(val), error.end
 
+
 if not PY3:
-    codecs.register_error('surrogateescape', surrogate_escape)
+    codecs.register_error("surrogateescape", surrogate_escape)
 ###############################################################
 
-__version__ = '5.2'
-__all__ = ['path', 'CaseInsensitivePattern']
+__version__ = "5.2"
+__all__ = ["path", "CaseInsensitivePattern"]
 
 
 class TreeWalkWarning(Warning):
@@ -154,6 +160,7 @@ def simple_cache(func):
             return saved_results[module]
         saved_results[module] = func(cls, module)
         return saved_results[module]
+
     return wrapper
 
 
@@ -167,12 +174,14 @@ class multimethod(object):
     Acts like a classmethod when invoked from the class and like an
     instancemethod when invoked from the instance.
     """
+
     def __init__(self, func):
         self.func = func
 
     def __get__(self, instance, owner):
         return (
-            functools.partial(self.func, owner) if instance is None
+            functools.partial(self.func, owner)
+            if instance is None
             else functools.partial(self.func, owner, instance)
         )
 
@@ -190,16 +199,16 @@ class path(str):
     .. seealso:: :mod:`os.path`
     """
 
-    def __init__(self, other=''):
+    def __init__(self, other=""):
         if other is None:
             raise TypeError("Invalid initial value for path: None")
 
     @classmethod
     @simple_cache
     def using_module(cls, module):
-        subclass_name = cls.__name__ + '_' + module.__name__
+        subclass_name = cls.__name__ + "_" + module.__name__
         bases = (cls,)
-        ns = {'module': module}
+        ns = {"module": module}
         return type(subclass_name, bases, ns)
 
     @ClassProperty
@@ -218,12 +227,12 @@ class path(str):
         """
         if PY3 or isinstance(path, str):
             return path
-        return path.decode(sys.getfilesystemencoding(), 'surrogateescape')
+        return path.decode(sys.getfilesystemencoding(), "surrogateescape")
 
     # --- Special Python methods.
 
     def __repr__(self):
-        return '%s(%s)' % (type(self).__name__, super(path, self).__repr__())
+        return "%s(%s)" % (type(self).__name__, super(path, self).__repr__())
 
     # Adding a path and a string yields a path.
     def __add__(self, more):
@@ -339,7 +348,9 @@ class path(str):
         return self._next_class(drive)
 
     parent = property(
-        dirname, None, None,
+        dirname,
+        None,
+        None,
         """ This path's parent directory, as a new path object.
 
         For example,
@@ -347,17 +358,21 @@ class path(str):
         path('/usr/local/lib')``
 
         .. seealso:: :meth:`dirname`, :func:`os.path.dirname`
-        """)
+        """,
+    )
 
     name = property(
-        basename, None, None,
+        basename,
+        None,
+        None,
         """ The name of this file or directory without the full path.
 
         For example,
         ``path('/usr/local/lib/libpython.so').name == 'libpython.so'``
 
         .. seealso:: :meth:`basename`, :func:`os.path.basename`
-        """)
+        """,
+    )
 
     def splitpath(self):
         """ p.splitpath() -> Return ``(p.parent, p.name)``.
@@ -451,7 +466,7 @@ class path(str):
         parts.reverse()
         return parts
 
-    def relpath(self, start='.'):
+    def relpath(self, start="."):
         """ Return this path as a relative path,
         based from `start`, which defaults to the current working directory.
         """
@@ -541,7 +556,7 @@ class path(str):
             else:
                 raise
         if pattern is None:
-            pattern = '*'
+            pattern = "*"
         return [
             old_div(self, child)
             for child in map(self._always_unicode, names)
@@ -574,7 +589,7 @@ class path(str):
 
         return [p for p in self.listdir(pattern) if p.isfile()]
 
-    def walk(self, pattern=None, errors='ignore'):
+    def walk(self, pattern=None, errors="ignore"):
         """ D.walk() -> iterator over files and subdirs, recursively.
 
         The iterator yields path objects naming each child item of
@@ -589,19 +604,20 @@ class path(str):
         exception.  The other allowed values are 'warn', which
         reports the error via ``warnings.warn()``, and 'ignore'.
         """
-        if errors not in ('strict', 'warn', 'ignore'):
+        if errors not in ("strict", "warn", "ignore"):
             raise ValueError("invalid errors parameter")
 
         try:
             childList = self.listdir()
         except Exception:
-            if errors == 'ignore':
+            if errors == "ignore":
                 return
-            elif errors == 'warn':
+            elif errors == "warn":
                 warnings.warn(
                     "Unable to list directory '%s': %s"
                     % (self, sys.exc_info()[1]),
-                    TreeWalkWarning)
+                    TreeWalkWarning,
+                )
                 return
             else:
                 raise
@@ -612,13 +628,14 @@ class path(str):
             try:
                 isdir = child.isdir()
             except Exception:
-                if errors == 'ignore':
+                if errors == "ignore":
                     isdir = False
-                elif errors == 'warn':
+                elif errors == "warn":
                     warnings.warn(
                         "Unable to access '%s': %s"
                         % (child, sys.exc_info()[1]),
-                        TreeWalkWarning)
+                        TreeWalkWarning,
+                    )
                     isdir = False
                 else:
                     raise
@@ -627,7 +644,7 @@ class path(str):
                 for item in child.walk(pattern, errors):
                     yield item
 
-    def walkdirs(self, pattern=None, errors='strict'):
+    def walkdirs(self, pattern=None, errors="strict"):
         """ D.walkdirs() -> iterator over subdirs, recursively.
 
         With the optional `pattern` argument, this yields only
@@ -640,19 +657,20 @@ class path(str):
         exception.  The other allowed values are 'warn', which
         reports the error via ``warnings.warn()``, and 'ignore'.
         """
-        if errors not in ('strict', 'warn', 'ignore'):
+        if errors not in ("strict", "warn", "ignore"):
             raise ValueError("invalid errors parameter")
 
         try:
             dirs = self.dirs()
         except Exception:
-            if errors == 'ignore':
+            if errors == "ignore":
                 return
-            elif errors == 'warn':
+            elif errors == "warn":
                 warnings.warn(
                     "Unable to list directory '%s': %s"
                     % (self, sys.exc_info()[1]),
-                    TreeWalkWarning)
+                    TreeWalkWarning,
+                )
                 return
             else:
                 raise
@@ -663,7 +681,7 @@ class path(str):
             for subsubdir in child.walkdirs(pattern, errors):
                 yield subsubdir
 
-    def walkfiles(self, pattern=None, errors='strict'):
+    def walkfiles(self, pattern=None, errors="strict"):
         """ D.walkfiles() -> iterator over files in D, recursively.
 
         The optional argument, `pattern`, limits the results to files
@@ -671,19 +689,20 @@ class path(str):
         ``mydir.walkfiles('*.tmp')`` yields only files with the .tmp
         extension.
         """
-        if errors not in ('strict', 'warn', 'ignore'):
+        if errors not in ("strict", "warn", "ignore"):
             raise ValueError("invalid errors parameter")
 
         try:
             childList = self.listdir()
         except Exception:
-            if errors == 'ignore':
+            if errors == "ignore":
                 return
-            elif errors == 'warn':
+            elif errors == "warn":
                 warnings.warn(
                     "Unable to list directory '%s': %s"
                     % (self, sys.exc_info()[1]),
-                    TreeWalkWarning)
+                    TreeWalkWarning,
+                )
                 return
             else:
                 raise
@@ -693,13 +712,13 @@ class path(str):
                 isfile = child.isfile()
                 isdir = not isfile and child.isdir()
             except:
-                if errors == 'ignore':
+                if errors == "ignore":
                     continue
-                elif errors == 'warn':
+                elif errors == "warn":
                     warnings.warn(
-                        "Unable to access '%s': %s"
-                        % (self, sys.exc_info()[1]),
-                        TreeWalkWarning)
+                        "Unable to access '%s': %s" % (self, sys.exc_info()[1]),
+                        TreeWalkWarning,
+                    )
                     continue
                 else:
                     raise
@@ -724,7 +743,7 @@ class path(str):
 
         .. seealso:: :func:`fnmatch.fnmatch`
         """
-        default_normcase = getattr(pattern, 'normcase', self.module.normcase)
+        default_normcase = getattr(pattern, "normcase", self.module.normcase)
         normcase = normcase or default_normcase
         name = normcase(self.name)
         pattern = normcase(pattern)
@@ -755,7 +774,7 @@ class path(str):
 
     def bytes(self):
         """ Open this file, read all bytes, return them as a string. """
-        with self.open('rb') as f:
+        with self.open("rb") as f:
             return f.read()
 
     def chunks(self, size, *args, **kwargs):
@@ -786,13 +805,13 @@ class path(str):
         Call ``p.write_bytes(bytes, append=True)`` to append instead.
         """
         if append:
-            mode = 'ab'
+            mode = "ab"
         else:
-            mode = 'wb'
+            mode = "wb"
         with self.open(mode) as f:
             f.write(bytes)
 
-    def text(self, encoding=None, errors='strict'):
+    def text(self, encoding=None, errors="strict"):
         r""" Open this file, read it in, return the content as a string.
 
         This method uses ``'U'`` mode, so ``'\r\n'`` and ``'\r'`` are
@@ -810,22 +829,30 @@ class path(str):
         """
         if encoding is None:
             # 8-bit
-            with self.open('U') as f:
+            with self.open("U") as f:
                 return f.read()
         else:
             # Unicode
-            with codecs.open(self, 'r', encoding, errors) as f:
+            with codecs.open(self, "r", encoding, errors) as f:
                 # (Note - Can't use 'U' mode here, since codecs.open
                 # doesn't support 'U' mode.)
                 t = f.read()
-            return (t.replace(u('\r\n'), u('\n'))
-                     .replace(u('\r\x85'), u('\n'))
-                     .replace(u('\r'), u('\n'))
-                     .replace(u('\x85'), u('\n'))
-                     .replace(u('\u2028'), u('\n')))
+            return (
+                t.replace(u("\r\n"), u("\n"))
+                .replace(u("\r\x85"), u("\n"))
+                .replace(u("\r"), u("\n"))
+                .replace(u("\x85"), u("\n"))
+                .replace(u("\u2028"), u("\n"))
+            )
 
-    def write_text(self, text, encoding=None, errors='strict',
-                   linesep=os.linesep, append=False):
+    def write_text(
+        self,
+        text,
+        encoding=None,
+        errors="strict",
+        linesep=os.linesep,
+        append=False,
+    ):
         r""" Write the given text to this file.
 
         The default behavior is to overwrite any existing file;
@@ -893,12 +920,14 @@ class path(str):
             if linesep is not None:
                 # Convert all standard end-of-line sequences to
                 # ordinary newline characters.
-                text = (text.replace(u('\r\n'), u('\n'))
-                            .replace(u('\r\x85'), u('\n'))
-                            .replace(u('\r'), u('\n'))
-                            .replace(u('\x85'), u('\n'))
-                            .replace(u('\u2028'), u('\n')))
-                text = text.replace(u('\n'), linesep)
+                text = (
+                    text.replace(u("\r\n"), u("\n"))
+                    .replace(u("\r\x85"), u("\n"))
+                    .replace(u("\r"), u("\n"))
+                    .replace(u("\x85"), u("\n"))
+                    .replace(u("\u2028"), u("\n"))
+                )
+                text = text.replace(u("\n"), linesep)
             if encoding is None:
                 encoding = sys.getdefaultencoding()
             _bytes = text.encode(encoding, errors)
@@ -908,13 +937,12 @@ class path(str):
             assert encoding is None
 
             if linesep is not None:
-                text = (text.replace(b'\r\n', b'\n')
-                            .replace(b'\r', b'\n'))
-                _bytes = text.replace(b'\n', bytes(linesep, 'utf-8'))
+                text = text.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+                _bytes = text.replace(b"\n", bytes(linesep, "utf-8"))
 
         self.write_bytes(_bytes, append)
 
-    def lines(self, encoding=None, errors='strict', retain=True):
+    def lines(self, encoding=None, errors="strict", retain=True):
         r""" Open this file, read all lines, return them in a list.
 
         Optional arguments:
@@ -934,13 +962,19 @@ class path(str):
         .. seealso:: :meth:`text`
         """
         if encoding is None and retain:
-            with self.open('U') as f:
+            with self.open("U") as f:
                 return f.readlines()
         else:
             return self.text(encoding, errors).splitlines(retain)
 
-    def write_lines(self, lines, encoding=None, errors='strict',
-                    linesep=os.linesep, append=False):
+    def write_lines(
+        self,
+        lines,
+        encoding=None,
+        errors="strict",
+        linesep=os.linesep,
+        append=False,
+    ):
         r""" Write the given lines of text to this file.
 
         By default this overwrites any existing file at this path.
@@ -975,9 +1009,9 @@ class path(str):
         to read the file later.
         """
         if append:
-            mode = 'ab'
+            mode = "ab"
         else:
-            mode = 'wb'
+            mode = "wb"
         with self.open(mode) as f:
             for line in lines:
                 isUnicode = isinstance(line, str)
@@ -985,15 +1019,19 @@ class path(str):
                     # Strip off any existing line-end and add the
                     # specified linesep string.
                     if isUnicode:
-                        if line[-2:] in (u('\r\n'), u('\x0d\x85')):
+                        if line[-2:] in (u("\r\n"), u("\x0d\x85")):
                             line = line[:-2]
-                        elif line[-1:] in (u('\r'), u('\n'),
-                                           u('\x85'), u('\u2028')):
+                        elif line[-1:] in (
+                            u("\r"),
+                            u("\n"),
+                            u("\x85"),
+                            u("\u2028"),
+                        ):
                             line = line[:-1]
                     else:
-                        if line[-2:] == '\r\n':
+                        if line[-2:] == "\r\n":
                             line = line[:-2]
-                        elif line[-1:] in ('\r', '\n'):
+                        elif line[-1:] in ("\r", "\n"):
                             line = line[:-1]
                     line += linesep
                 if isUnicode:
@@ -1009,7 +1047,7 @@ class path(str):
 
         .. seealso:: :meth:`read_hash`
         """
-        return self.read_hash('md5')
+        return self.read_hash("md5")
 
     def _hash(self, hash_name):
         """ Returns a hash object for the file at the current path.
@@ -1080,46 +1118,59 @@ class path(str):
         return self.module.getatime(self)
 
     atime = property(
-        getatime, None, None,
+        getatime,
+        None,
+        None,
         """ Last access time of the file.
 
         .. seealso:: :meth:`getatime`, :func:`os.path.getatime`
-        """)
+        """,
+    )
 
     def getmtime(self):
         """ .. seealso:: :attr:`mtime`, :func:`os.path.getmtime` """
         return self.module.getmtime(self)
 
     mtime = property(
-        getmtime, None, None,
+        getmtime,
+        None,
+        None,
         """ Last-modified time of the file.
 
         .. seealso:: :meth:`getmtime`, :func:`os.path.getmtime`
-        """)
+        """,
+    )
 
     def getctime(self):
         """ .. seealso:: :attr:`ctime`, :func:`os.path.getctime` """
         return self.module.getctime(self)
 
     ctime = property(
-        getctime, None, None,
+        getctime,
+        None,
+        None,
         """ Creation time of the file.
 
         .. seealso:: :meth:`getctime`, :func:`os.path.getctime`
-        """)
+        """,
+    )
 
     def getsize(self):
         """ .. seealso:: :attr:`size`, :func:`os.path.getsize` """
         return self.module.getsize(self)
 
     size = property(
-        getsize, None, None,
+        getsize,
+        None,
+        None,
         """ Size of the file, in bytes.
 
         .. seealso:: :meth:`getsize`, :func:`os.path.getsize`
-        """)
+        """,
+    )
 
-    if hasattr(os, 'access'):
+    if hasattr(os, "access"):
+
         def access(self, mode):
             """ Return true if current user has access to this path.
 
@@ -1154,10 +1205,11 @@ class path(str):
         .. seealso:: :attr:`owner`
         """
         desc = win32security.GetFileSecurity(
-            self, win32security.OWNER_SECURITY_INFORMATION)
+            self, win32security.OWNER_SECURITY_INFORMATION
+        )
         sid = desc.GetSecurityDescriptorOwner()
         account, domain, typecode = win32security.LookupAccountSid(None, sid)
-        return domain + u('\\') + account
+        return domain + u("\\") + account
 
     def __get_owner_unix(self):
         """
@@ -1172,20 +1224,24 @@ class path(str):
     def __get_owner_not_implemented(self):
         raise NotImplementedError("Ownership not available on this platform.")
 
-    if 'win32security' in globals():
+    if "win32security" in globals():
         get_owner = __get_owner_windows
-    elif 'pwd' in globals():
+    elif "pwd" in globals():
         get_owner = __get_owner_unix
     else:
         get_owner = __get_owner_not_implemented
 
     owner = property(
-        get_owner, None, None,
+        get_owner,
+        None,
+        None,
         """ Name of the owner of this file or directory.
 
-        .. seealso:: :meth:`get_owner`""")
+        .. seealso:: :meth:`get_owner`""",
+    )
 
-    if hasattr(os, 'statvfs'):
+    if hasattr(os, "statvfs"):
+
         def statvfs(self):
             """ Perform a ``statvfs()`` system call on this path.
 
@@ -1193,7 +1249,8 @@ class path(str):
             """
             return os.statvfs(self)
 
-    if hasattr(os, 'pathconf'):
+    if hasattr(os, "pathconf"):
+
         def pathconf(self, name):
             """ .. seealso:: :func:`os.pathconf` """
             return os.pathconf(self, name)
@@ -1214,7 +1271,8 @@ class path(str):
         os.chmod(self, mode)
         return self
 
-    if hasattr(os, 'chown'):
+    if hasattr(os, "chown"):
+
         def chown(self, uid=-1, gid=-1):
             """ .. seealso:: :func:`os.chown` """
             os.chown(self, uid, gid)
@@ -1337,7 +1395,8 @@ class path(str):
 
     # --- Links
 
-    if hasattr(os, 'link'):
+    if hasattr(os, "link"):
+
         def link(self, newpath):
             """ Create a hard link at `newpath`, pointing to this file.
 
@@ -1346,7 +1405,8 @@ class path(str):
             os.link(self, newpath)
             return self._next_class(newpath)
 
-    if hasattr(os, 'symlink'):
+    if hasattr(os, "symlink"):
+
         def symlink(self, newlink):
             """ Create a symbolic link at `newlink`, pointing here.
 
@@ -1355,7 +1415,8 @@ class path(str):
             os.symlink(self, newlink)
             return self._next_class(newlink)
 
-    if hasattr(os, 'readlink'):
+    if hasattr(os, "readlink"):
+
         def readlink(self):
             """ Return the path to which this symbolic link points.
 
@@ -1387,7 +1448,7 @@ class path(str):
     copy = shutil.copy
     copy2 = shutil.copy2
     copytree = shutil.copytree
-    if hasattr(shutil, 'move'):
+    if hasattr(shutil, "move"):
         move = shutil.move
     rmtree = shutil.rmtree
 
@@ -1411,12 +1472,14 @@ class path(str):
     #
     # --- Special stuff from os
 
-    if hasattr(os, 'chroot'):
+    if hasattr(os, "chroot"):
+
         def chroot(self):
             """ .. seealso:: :func:`os.chroot` """
             os.chroot(self)
 
-    if hasattr(os, 'startfile'):
+    if hasattr(os, "startfile"):
+
         def startfile(self):
             """ .. seealso:: :func:`os.startfile` """
             os.startfile(self)
@@ -1425,8 +1488,15 @@ class path(str):
     # in-place re-writing, courtesy of Martijn Pieters
     # http://www.zopatista.com/python/2013/11/26/inplace-file-rewriting/
     @contextlib.contextmanager
-    def in_place(self, mode='r', buffering=-1, encoding=None, errors=None,
-                 newline=None, backup_extension=None):
+    def in_place(
+        self,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+        backup_extension=None,
+    ):
         """
         A context in which a file may be re-written in-place with new content.
 
@@ -1452,38 +1522,51 @@ class path(str):
         """
         import io
 
-        if set(mode).intersection('wa+'):
-            raise ValueError('Only read-only file modes can be used')
+        if set(mode).intersection("wa+"):
+            raise ValueError("Only read-only file modes can be used")
 
         # move existing file to backup, create new file with same permissions
         # borrowed extensively from the fileinput module
-        backup_fn = self + (backup_extension or os.extsep + 'bak')
+        backup_fn = self + (backup_extension or os.extsep + "bak")
         try:
             os.unlink(backup_fn)
         except os.error:
             pass
         os.rename(self, backup_fn)
         readable = io.open(
-            backup_fn, mode, buffering=buffering,
-            encoding=encoding, errors=errors, newline=newline)
+            backup_fn,
+            mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
         try:
             perm = os.fstat(readable.fileno()).st_mode
         except OSError:
             writable = open(
-                self, 'w' + mode.replace('r', ''),
-                buffering=buffering, encoding=encoding, errors=errors,
-                newline=newline)
+                self,
+                "w" + mode.replace("r", ""),
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+            )
         else:
             os_mode = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
-            if hasattr(os, 'O_BINARY'):
+            if hasattr(os, "O_BINARY"):
                 os_mode |= os.O_BINARY
             fd = os.open(self, os_mode, perm)
             writable = io.open(
-                fd, "w" + mode.replace('r', ''),
-                buffering=buffering, encoding=encoding, errors=errors,
-                newline=newline)
+                fd,
+                "w" + mode.replace("r", ""),
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+            )
             try:
-                if hasattr(os, 'chmod'):
+                if hasattr(os, "chmod"):
                     os.chmod(self, perm)
             except OSError:
                 pass
@@ -1556,23 +1639,25 @@ def _permission_mask(mode):
     >>> _permission_mask('go-x')(o777) == o766
     True
     """
-    parsed = re.match(r'(?P<who>[ugo]+)(?P<op>[-+])(?P<what>[rwx]+)$', mode)
+    parsed = re.match(r"(?P<who>[ugo]+)(?P<op>[-+])(?P<what>[rwx]+)$", mode)
     if not parsed:
         raise ValueError("Unrecognized symbolic mode", mode)
     spec_map = dict(r=4, w=2, x=1)
-    spec = reduce(operator.or_, [spec_map[perm]
-                  for perm in parsed.group('what')])
+    spec = reduce(
+        operator.or_, [spec_map[perm] for perm in parsed.group("what")]
+    )
     # now apply spec to each in who
     shift_map = dict(u=6, g=3, o=0)
-    mask = reduce(operator.or_, [spec << shift_map[subj]
-                  for subj in parsed.group('who')])
+    mask = reduce(
+        operator.or_, [spec << shift_map[subj] for subj in parsed.group("who")]
+    )
 
-    op = parsed.group('op')
+    op = parsed.group("op")
     # if op is -, invert the mask
-    if op == '-':
+    if op == "-":
         mask ^= o777
 
-    op_map = {'+': operator.or_, '-': operator.and_}
+    op_map = {"+": operator.or_, "-": operator.and_}
     return functools.partial(op_map[op], mask)
 
 
@@ -1591,4 +1676,4 @@ class CaseInsensitivePattern(str):
 
     @property
     def normcase(self):
-        return __import__('ntpath').normcase
+        return __import__("ntpath").normcase

--- a/src/omero_ext/portalocker.py
+++ b/src/omero_ext/portalocker.py
@@ -65,28 +65,32 @@ __all__ = [
 
 import os
 
+
 class LockException(Exception):
     # Error codes:
     LOCK_FAILED = 1
 
-if os.name == 'nt':
+
+if os.name == "nt":
     import win32con
     import win32file
     import pywintypes
+
     LOCK_EX = win32con.LOCKFILE_EXCLUSIVE_LOCK
-    LOCK_SH = 0 # the default
+    LOCK_SH = 0  # the default
     LOCK_NB = win32con.LOCKFILE_FAIL_IMMEDIATELY
     # is there any reason not to reuse the following structure?
     __overlapped = pywintypes.OVERLAPPED()
-elif os.name == 'posix':
+elif os.name == "posix":
     import fcntl
+
     LOCK_EX = fcntl.LOCK_EX
     LOCK_SH = fcntl.LOCK_SH
     LOCK_NB = fcntl.LOCK_NB
 else:
     raise RuntimeError("PortaLocker only defined for nt and posix platforms")
 
-if os.name == 'nt':
+if os.name == "nt":
 
     def lockno(fileno, flags):
         hfile = win32file._get_osfhandle(fileno)
@@ -96,7 +100,8 @@ if os.name == 'nt':
             # error: (33, 'LockFileEx', 'The process cannot access the file because another process has locked a portion of the file.')
             if exc_value.args[0] == 33:
                 raise LockException(
-                    LockException.LOCK_FAILED, exc_value.args[2])
+                    LockException.LOCK_FAILED, exc_value.args[2]
+                )
             else:
                 # Q:  Are there exceptions/codes we should be dealing with here?
                 raise
@@ -114,7 +119,9 @@ if os.name == 'nt':
                 # Q:  Are there exceptions/codes we should be dealing with here?
                 raise
 
-elif os.name == 'posix':
+
+elif os.name == "posix":
+
     def lockno(fileno, flags):
         try:
             fcntl.flock(fileno, flags)
@@ -124,7 +131,8 @@ elif os.name == 'posix':
             #  IOError: [Errno 35] Resource temporarily unavailable
             if exc_value.args[0] == 11 or exc_value.args[0] == 35:
                 raise LockException(
-                    LockException.LOCK_FAILED, exc_value.args[1])
+                    LockException.LOCK_FAILED, exc_value.args[1]
+                )
             else:
                 raise
 
@@ -140,19 +148,18 @@ def unlock(file):
     unlockno(file.fileno())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from time import time, strftime, localtime
     import sys
     from . import portalocker
 
-    log = open('log.txt', "a+")
+    log = open("log.txt", "a+")
     portalocker.lock(log, portalocker.LOCK_EX)
 
     timestamp = strftime("%m/%d/%Y %H:%M:%S\n", localtime(time()))
-    log.write( timestamp )
+    log.write(timestamp)
 
     print("Wrote lines. Hit enter to release lock.")
     dummy = sys.stdin.readline()
 
     log.close()
-

--- a/src/omero_ext/stubout.py
+++ b/src/omero_ext/stubout.py
@@ -20,7 +20,7 @@ import inspect
 
 
 class StubOutForTesting(object):
-  """Sample Usage:
+    """Sample Usage:
      You want os.path.exists() to always return true during testing.
 
      stubs = StubOutForTesting()
@@ -33,16 +33,17 @@ class StubOutForTesting(object):
      of os.path.exists and restores it.
 
   """
-  def __init__(self):
-    self.cache = []
-    self.stubs = []
 
-  def __del__(self):
-    self.SmartUnsetAll()
-    self.UnsetAll()
+    def __init__(self):
+        self.cache = []
+        self.stubs = []
 
-  def SmartSet(self, obj, attr_name, new_attr):
-    """Replace obj.attr_name with new_attr. This method is smart and works
+    def __del__(self):
+        self.SmartUnsetAll()
+        self.UnsetAll()
+
+    def SmartSet(self, obj, attr_name, new_attr):
+        """Replace obj.attr_name with new_attr. This method is smart and works
        at the module, class, and instance level while preserving proper
        inheritance. It will not stub out C types however unless that has been
        explicitly allowed by the type.
@@ -61,55 +62,58 @@ class StubOutForTesting(object):
 
        Raises AttributeError if the attribute cannot be found.
     """
-    if (inspect.ismodule(obj) or
-        (not inspect.isclass(obj) and attr_name in obj.__dict__)):
-      orig_obj = obj
-      orig_attr = getattr(obj, attr_name)
+        if inspect.ismodule(obj) or (
+            not inspect.isclass(obj) and attr_name in obj.__dict__
+        ):
+            orig_obj = obj
+            orig_attr = getattr(obj, attr_name)
 
-    else:
-      if not inspect.isclass(obj):
-        mro = list(inspect.getmro(obj.__class__))
-      else:
-        mro = list(inspect.getmro(obj))
+        else:
+            if not inspect.isclass(obj):
+                mro = list(inspect.getmro(obj.__class__))
+            else:
+                mro = list(inspect.getmro(obj))
 
-      mro.reverse()
+            mro.reverse()
 
-      orig_attr = None
+            orig_attr = None
 
-      for cls in mro:
-        try:
-          orig_obj = cls
-          orig_attr = getattr(obj, attr_name)
-        except AttributeError:
-          continue
+            for cls in mro:
+                try:
+                    orig_obj = cls
+                    orig_attr = getattr(obj, attr_name)
+                except AttributeError:
+                    continue
 
-    if orig_attr is None:
-      raise AttributeError("Attribute not found.")
+        if orig_attr is None:
+            raise AttributeError("Attribute not found.")
 
-    # Calling getattr() on a staticmethod transforms it to a 'normal' function.
-    # We need to ensure that we put it back as a staticmethod.
-    old_attribute = obj.__dict__.get(attr_name)
-    if old_attribute is not None and isinstance(old_attribute, staticmethod):
-      orig_attr = staticmethod(orig_attr)
+        # Calling getattr() on a staticmethod transforms it to a 'normal' function.
+        # We need to ensure that we put it back as a staticmethod.
+        old_attribute = obj.__dict__.get(attr_name)
+        if old_attribute is not None and isinstance(
+            old_attribute, staticmethod
+        ):
+            orig_attr = staticmethod(orig_attr)
 
-    self.stubs.append((orig_obj, attr_name, orig_attr))
-    setattr(orig_obj, attr_name, new_attr)
+        self.stubs.append((orig_obj, attr_name, orig_attr))
+        setattr(orig_obj, attr_name, new_attr)
 
-  def SmartUnsetAll(self):
-    """Reverses all the SmartSet() calls, restoring things to their original
+    def SmartUnsetAll(self):
+        """Reverses all the SmartSet() calls, restoring things to their original
     definition.  Its okay to call SmartUnsetAll() repeatedly, as later calls
     have no effect if no SmartSet() calls have been made.
 
     """
-    self.stubs.reverse()
+        self.stubs.reverse()
 
-    for args in self.stubs:
-      setattr(*args)
+        for args in self.stubs:
+            setattr(*args)
 
-    self.stubs = []
+        self.stubs = []
 
-  def Set(self, parent, child_name, new_child):
-    """Replace child_name's old definition with new_child, in the context
+    def Set(self, parent, child_name, new_child):
+        """Replace child_name's old definition with new_child, in the context
     of the given parent.  The parent could be a module when the child is a
     function at module scope.  Or the parent could be a class when a class'
     method is being replaced.  The named child is set to new_child, while
@@ -118,25 +122,27 @@ class StubOutForTesting(object):
     This method supports the case where child_name is a staticmethod or a
     classmethod of parent.
     """
-    old_child = getattr(parent, child_name)
+        old_child = getattr(parent, child_name)
 
-    old_attribute = parent.__dict__.get(child_name)
-    if old_attribute is not None and isinstance(old_attribute, staticmethod):
-      old_child = staticmethod(old_child)
+        old_attribute = parent.__dict__.get(child_name)
+        if old_attribute is not None and isinstance(
+            old_attribute, staticmethod
+        ):
+            old_child = staticmethod(old_child)
 
-    self.cache.append((parent, old_child, child_name))
-    setattr(parent, child_name, new_child)
+        self.cache.append((parent, old_child, child_name))
+        setattr(parent, child_name, new_child)
 
-  def UnsetAll(self):
-    """Reverses all the Set() calls, restoring things to their original
+    def UnsetAll(self):
+        """Reverses all the Set() calls, restoring things to their original
     definition.  Its okay to call UnsetAll() repeatedly, as later calls have
     no effect if no Set() calls have been made.
 
     """
-    # Undo calls to Set() in reverse order, in case Set() was called on the
-    # same arguments repeatedly (want the original call to be last one undone)
-    self.cache.reverse()
+        # Undo calls to Set() in reverse order, in case Set() was called on the
+        # same arguments repeatedly (want the original call to be last one undone)
+        self.cache.reverse()
 
-    for (parent, old_child, child_name) in self.cache:
-      setattr(parent, child_name, old_child)
-    self.cache = []
+        for (parent, old_child, child_name) in self.cache:
+            setattr(parent, child_name, old_child)
+        self.cache = []

--- a/src/omero_ext/which.py
+++ b/src/omero_ext/which.py
@@ -36,9 +36,11 @@ of where the match was found. For example:
 from __future__ import print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import map
 from builtins import range
+
 _cmdlnUsage = """
     Show the full path of commands.
 
@@ -73,7 +75,7 @@ _cmdlnUsage = """
 
 __revision__ = "$Id: which.py 430 2005-08-20 03:11:58Z trentm $"
 __version_info__ = (1, 1, 0)
-__version__ = '.'.join(map(str, __version_info__))
+__version__ = ".".join(map(str, __version_info__))
 
 import os
 import sys
@@ -81,39 +83,46 @@ import getopt
 import stat
 
 
-#---- exceptions
+# ---- exceptions
+
 
 class WhichError(Exception):
     pass
 
 
+# ---- internal support stuff
 
-#---- internal support stuff
 
 def _getRegisteredExecutable(exeName):
     """Windows allow application paths to be registered in the registry."""
     registered = None
-    if sys.platform.startswith('win'):
-        if os.path.splitext(exeName)[1].lower() != '.exe':
-            exeName += '.exe'
+    if sys.platform.startswith("win"):
+        if os.path.splitext(exeName)[1].lower() != ".exe":
+            exeName += ".exe"
         import winreg
+
         try:
-            key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +\
-                  exeName
+            key = (
+                "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\"
+                + exeName
+            )
             value = winreg.QueryValue(winreg.HKEY_LOCAL_MACHINE, key)
-            registered = (value, "from HKLM\\"+key)
+            registered = (value, "from HKLM\\" + key)
         except winreg.error:
             pass
         if registered and not os.path.exists(registered[0]):
             registered = None
     return registered
 
+
 def _samefile(fname1, fname2):
-    if sys.platform.startswith('win'):
-        return ( os.path.normpath(os.path.normcase(fname1)) ==\
-            os.path.normpath(os.path.normcase(fname2)) )
+    if sys.platform.startswith("win"):
+        return os.path.normpath(os.path.normcase(fname1)) == os.path.normpath(
+            os.path.normcase(fname2)
+        )
     else:
         return os.path.samefile(fname1, fname2)
+
 
 def _cull(potential, matches, verbose=0):
     """Cull inappropriate matches. Possible reasons:
@@ -134,14 +143,14 @@ def _cull(potential, matches, verbose=0):
                 sys.stderr.write("not a regular file: %s (%s)\n" % potential)
         elif not os.access(potential[0], os.X_OK):
             if verbose:
-                sys.stderr.write("no executable access: %s (%s)\n"\
-                                 % potential)
+                sys.stderr.write("no executable access: %s (%s)\n" % potential)
         else:
             matches.append(potential)
             return potential
 
-        
-#---- module API
+
+# ---- module API
+
 
 def whichgen(command, path=None, verbose=0, exts=None):
     """Return a generator of full paths to the given command.
@@ -182,13 +191,15 @@ def whichgen(command, path=None, verbose=0, exts=None):
                 if ext.lower() == ".exe":
                     break
             else:
-                exts = ['.COM', '.EXE', '.BAT']
+                exts = [".COM", ".EXE", ".BAT"]
         elif not isinstance(exts, list):
             raise TypeError("'exts' argument must be a list or None")
     else:
         if exts is not None:
-            raise WhichError("'exts' argument is not supported on "\
-                             "platform '%s'" % sys.platform)
+            raise WhichError(
+                "'exts' argument is not supported on "
+                "platform '%s'" % sys.platform
+            )
         exts = []
 
     # File name cannot have path separators because PATH lookup does not
@@ -199,12 +210,17 @@ def whichgen(command, path=None, verbose=0, exts=None):
         for i in range(len(path)):
             dirName = path[i]
             # On windows the dirName *could* be quoted, drop the quotes
-            if sys.platform.startswith("win") and len(dirName) >= 2\
-               and dirName[0] == '"' and dirName[-1] == '"':
+            if (
+                sys.platform.startswith("win")
+                and len(dirName) >= 2
+                and dirName[0] == '"'
+                and dirName[-1] == '"'
+            ):
                 dirName = dirName[1:-1]
-            for ext in ['']+exts:
+            for ext in [""] + exts:
                 absName = os.path.abspath(
-                    os.path.normpath(os.path.join(dirName, command+ext)))
+                    os.path.normpath(os.path.join(dirName, command + ext))
+                )
                 if os.path.isfile(absName):
                     if usingGivenPath:
                         fromWhere = "from given path element %d" % i
@@ -213,7 +229,7 @@ def whichgen(command, path=None, verbose=0, exts=None):
                     elif i == 0:
                         fromWhere = "from current directory"
                     else:
-                        fromWhere = "from PATH element %d" % (i-1)
+                        fromWhere = "from PATH element %d" % (i - 1)
                     match = _cull((absName, fromWhere), matches, verbose)
                     if match:
                         if verbose:
@@ -272,11 +288,11 @@ def whichall(command, path=None, verbose=0, exts=None):
         not a VisualBasic script but ".vbs" is on PATHEXT. This option
         is only supported on Windows.
     """
-    return list( whichgen(command, path, verbose, exts) )
+    return list(whichgen(command, path, verbose, exts))
 
 
+# ---- mainline
 
-#---- mainline
 
 def main(argv):
     all = 0
@@ -284,32 +300,36 @@ def main(argv):
     altpath = None
     exts = None
     try:
-        optlist, args = getopt.getopt(argv[1:], 'haVvqp:e:',
-            ['help', 'all', 'version', 'verbose', 'quiet', 'path=', 'exts='])
+        optlist, args = getopt.getopt(
+            argv[1:],
+            "haVvqp:e:",
+            ["help", "all", "version", "verbose", "quiet", "path=", "exts="],
+        )
     except getopt.GetoptError as msg:
-        sys.stderr.write("which: error: %s. Your invocation was: %s\n"\
-                         % (msg, argv))
+        sys.stderr.write(
+            "which: error: %s. Your invocation was: %s\n" % (msg, argv)
+        )
         sys.stderr.write("Try 'which --help'.\n")
         return 1
     for opt, optarg in optlist:
-        if opt in ('-h', '--help'):
+        if opt in ("-h", "--help"):
             print(_cmdlnUsage)
             return 0
-        elif opt in ('-V', '--version'):
+        elif opt in ("-V", "--version"):
             print("which %s" % __version__)
             return 0
-        elif opt in ('-a', '--all'):
+        elif opt in ("-a", "--all"):
             all = 1
-        elif opt in ('-v', '--verbose'):
+        elif opt in ("-v", "--verbose"):
             verbose = 1
-        elif opt in ('-q', '--quiet'):
+        elif opt in ("-q", "--quiet"):
             verbose = 0
-        elif opt in ('-p', '--path'):
+        elif opt in ("-p", "--path"):
             if optarg:
                 altpath = optarg.split(os.pathsep)
             else:
                 altpath = []
-        elif opt in ('-e', '--exts'):
+        elif opt in ("-e", "--exts"):
             if optarg:
                 exts = optarg.split(os.pathsep)
             else:
@@ -320,7 +340,7 @@ def main(argv):
 
     failures = 0
     for arg in args:
-        #print "debug: search for %r" % arg
+        # print "debug: search for %r" % arg
         nmatches = 0
         for match in whichgen(arg, path=altpath, verbose=verbose, exts=exts):
             if verbose:
@@ -336,6 +356,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit( main(sys.argv) )
-
-
+    sys.exit(main(sys.argv))

--- a/src/omero_ext/winprocess.py
+++ b/src/omero_ext/winprocess.py
@@ -17,10 +17,10 @@
 # the rights to use, copy, modify, merge, publish, distribute, sublicense,
 # and/or sell copies of the Software, and to permit persons to whom the
 # Software is furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,12 +30,30 @@
 # DEALINGS IN THE SOFTWARE.
 
 from builtins import object
-from ctypes import c_void_p, POINTER, sizeof, Structure, windll, WinError, WINFUNCTYPE
-from ctypes.wintypes import BOOL, BYTE, DWORD, HANDLE, LPCWSTR, LPWSTR, UINT, WORD
+from ctypes import (
+    c_void_p,
+    POINTER,
+    sizeof,
+    Structure,
+    windll,
+    WinError,
+    WINFUNCTYPE,
+)
+from ctypes.wintypes import (
+    BOOL,
+    BYTE,
+    DWORD,
+    HANDLE,
+    LPCWSTR,
+    LPWSTR,
+    UINT,
+    WORD,
+)
 
 LPVOID = c_void_p
 LPBYTE = POINTER(BYTE)
 LPDWORD = POINTER(DWORD)
+
 
 def ErrCheckBool(result, func, args):
     """errcheck function for Windows functions that return a BOOL True
@@ -43,6 +61,7 @@ def ErrCheckBool(result, func, args):
     if not result:
         raise WinError()
     return args
+
 
 # CloseHandle()
 
@@ -52,18 +71,21 @@ CloseHandle.errcheck = ErrCheckBool
 
 # AutoHANDLE
 
+
 class AutoHANDLE(HANDLE):
     """Subclass of HANDLE which will call CloseHandle() on deletion."""
+
     def Close(self):
         if self.value:
             CloseHandle(self)
             self.value = 0
-    
+
     def __del__(self):
         self.Close()
 
     def __int__(self):
         return self.value
+
 
 def ErrCheckHandle(result, func, args):
     """errcheck function for Windows functions that return a HANDLE."""
@@ -71,56 +93,66 @@ def ErrCheckHandle(result, func, args):
         raise WinError()
     return AutoHANDLE(result)
 
+
 # PROCESS_INFORMATION structure
 
+
 class PROCESS_INFORMATION(Structure):
-    _fields_ = [("hProcess", HANDLE),
-                ("hThread", HANDLE),
-                ("dwProcessID", DWORD),
-                ("dwThreadID", DWORD)]
+    _fields_ = [
+        ("hProcess", HANDLE),
+        ("hThread", HANDLE),
+        ("dwProcessID", DWORD),
+        ("dwThreadID", DWORD),
+    ]
 
     def __init__(self):
         Structure.__init__(self)
-        
+
         self.cb = sizeof(self)
+
 
 LPPROCESS_INFORMATION = POINTER(PROCESS_INFORMATION)
 
 # STARTUPINFO structure
 
+
 class STARTUPINFO(Structure):
-    _fields_ = [("cb", DWORD),
-                ("lpReserved", LPWSTR),
-                ("lpDesktop", LPWSTR),
-                ("lpTitle", LPWSTR),
-                ("dwX", DWORD),
-                ("dwY", DWORD),
-                ("dwXSize", DWORD),
-                ("dwYSize", DWORD),
-                ("dwXCountChars", DWORD),
-                ("dwYCountChars", DWORD),
-                ("dwFillAttribute", DWORD),
-                ("dwFlags", DWORD),
-                ("wShowWindow", WORD),
-                ("cbReserved2", WORD),
-                ("lpReserved2", LPBYTE),
-                ("hStdInput", HANDLE),
-                ("hStdOutput", HANDLE),
-                ("hStdError", HANDLE)
-                ]
+    _fields_ = [
+        ("cb", DWORD),
+        ("lpReserved", LPWSTR),
+        ("lpDesktop", LPWSTR),
+        ("lpTitle", LPWSTR),
+        ("dwX", DWORD),
+        ("dwY", DWORD),
+        ("dwXSize", DWORD),
+        ("dwYSize", DWORD),
+        ("dwXCountChars", DWORD),
+        ("dwYCountChars", DWORD),
+        ("dwFillAttribute", DWORD),
+        ("dwFlags", DWORD),
+        ("wShowWindow", WORD),
+        ("cbReserved2", WORD),
+        ("lpReserved2", LPBYTE),
+        ("hStdInput", HANDLE),
+        ("hStdOutput", HANDLE),
+        ("hStdError", HANDLE),
+    ]
+
+
 LPSTARTUPINFO = POINTER(STARTUPINFO)
 
-STARTF_USESHOWWINDOW    = 0x01
-STARTF_USESIZE          = 0x02
-STARTF_USEPOSITION      = 0x04
-STARTF_USECOUNTCHARS    = 0x08
+STARTF_USESHOWWINDOW = 0x01
+STARTF_USESIZE = 0x02
+STARTF_USEPOSITION = 0x04
+STARTF_USECOUNTCHARS = 0x08
 STARTF_USEFILLATTRIBUTE = 0x10
-STARTF_RUNFULLSCREEN    = 0x20
-STARTF_FORCEONFEEDBACK  = 0x40
+STARTF_RUNFULLSCREEN = 0x20
+STARTF_FORCEONFEEDBACK = 0x40
 STARTF_FORCEOFFFEEDBACK = 0x80
-STARTF_USESTDHANDLES    = 0x100
+STARTF_USESTDHANDLES = 0x100
 
 # EnvironmentBlock
+
 
 class EnvironmentBlock(object):
     """An object which can be passed as the lpEnv parameter of CreateProcess.
@@ -130,45 +162,56 @@ class EnvironmentBlock(object):
         if not dict:
             self._as_parameter_ = None
         else:
-            values = ["%s=%s" % (key, value)
-                      for (key, value) in dict.items()]
+            values = ["%s=%s" % (key, value) for (key, value) in dict.items()]
             values.append("")
             self._as_parameter_ = LPCWSTR("\0".join(values))
-        
+
+
 # CreateProcess()
 
-CreateProcessProto = WINFUNCTYPE(BOOL,                  # Return type
-                                 LPCWSTR,               # lpApplicationName
-                                 LPWSTR,                # lpCommandLine
-                                 LPVOID,                # lpProcessAttributes
-                                 LPVOID,                # lpThreadAttributes
-                                 BOOL,                  # bInheritHandles
-                                 DWORD,                 # dwCreationFlags
-                                 LPVOID,                # lpEnvironment
-                                 LPCWSTR,               # lpCurrentDirectory
-                                 LPSTARTUPINFO,         # lpStartupInfo
-                                 LPPROCESS_INFORMATION  # lpProcessInformation
-                                 )
+CreateProcessProto = WINFUNCTYPE(
+    BOOL,  # Return type
+    LPCWSTR,  # lpApplicationName
+    LPWSTR,  # lpCommandLine
+    LPVOID,  # lpProcessAttributes
+    LPVOID,  # lpThreadAttributes
+    BOOL,  # bInheritHandles
+    DWORD,  # dwCreationFlags
+    LPVOID,  # lpEnvironment
+    LPCWSTR,  # lpCurrentDirectory
+    LPSTARTUPINFO,  # lpStartupInfo
+    LPPROCESS_INFORMATION,  # lpProcessInformation
+)
 
-CreateProcessFlags = ((1, "lpApplicationName", None),
-                      (1, "lpCommandLine"),
-                      (1, "lpProcessAttributes", None),
-                      (1, "lpThreadAttributes", None),
-                      (1, "bInheritHandles", True),
-                      (1, "dwCreationFlags", 0),
-                      (1, "lpEnvironment", None),
-                      (1, "lpCurrentDirectory", None),
-                      (1, "lpStartupInfo"),
-                      (2, "lpProcessInformation"))
+CreateProcessFlags = (
+    (1, "lpApplicationName", None),
+    (1, "lpCommandLine"),
+    (1, "lpProcessAttributes", None),
+    (1, "lpThreadAttributes", None),
+    (1, "bInheritHandles", True),
+    (1, "dwCreationFlags", 0),
+    (1, "lpEnvironment", None),
+    (1, "lpCurrentDirectory", None),
+    (1, "lpStartupInfo"),
+    (2, "lpProcessInformation"),
+)
+
 
 def ErrCheckCreateProcess(result, func, args):
     ErrCheckBool(result, func, args)
     # return a tuple (hProcess, hThread, dwProcessID, dwThreadID)
     pi = args[9]
-    return AutoHANDLE(pi.hProcess), AutoHANDLE(pi.hThread), pi.dwProcessID, pi.dwThreadID
+    return (
+        AutoHANDLE(pi.hProcess),
+        AutoHANDLE(pi.hThread),
+        pi.dwProcessID,
+        pi.dwThreadID,
+    )
 
-CreateProcess = CreateProcessProto(("CreateProcessW", windll.kernel32),
-                                   CreateProcessFlags)
+
+CreateProcess = CreateProcessProto(
+    ("CreateProcessW", windll.kernel32), CreateProcessFlags
+)
 CreateProcess.errcheck = ErrCheckCreateProcess
 
 CREATE_BREAKAWAY_FROM_JOB = 0x01000000
@@ -184,32 +227,30 @@ DETACHED_PROCESS = 0x00000008
 
 # CreateJobObject()
 
-CreateJobObjectProto = WINFUNCTYPE(HANDLE,             # Return type
-                                   LPVOID,             # lpJobAttributes
-                                   LPCWSTR             # lpName
-                                   )
+CreateJobObjectProto = WINFUNCTYPE(
+    HANDLE, LPVOID, LPCWSTR  # Return type  # lpJobAttributes  # lpName
+)
 
-CreateJobObjectFlags = ((1, "lpJobAttributes", None),
-                        (1, "lpName", None))
+CreateJobObjectFlags = ((1, "lpJobAttributes", None), (1, "lpName", None))
 
-CreateJobObject = CreateJobObjectProto(("CreateJobObjectW", windll.kernel32),
-                                       CreateJobObjectFlags)
+CreateJobObject = CreateJobObjectProto(
+    ("CreateJobObjectW", windll.kernel32), CreateJobObjectFlags
+)
 CreateJobObject.errcheck = ErrCheckHandle
 
 # AssignProcessToJobObject()
 
-AssignProcessToJobObjectProto = WINFUNCTYPE(BOOL,      # Return type
-                                            HANDLE,    # hJob
-                                            HANDLE     # hProcess
-                                            )
-AssignProcessToJobObjectFlags = ((1, "hJob"),
-                                 (1, "hProcess"))
+AssignProcessToJobObjectProto = WINFUNCTYPE(
+    BOOL, HANDLE, HANDLE  # Return type  # hJob  # hProcess
+)
+AssignProcessToJobObjectFlags = ((1, "hJob"), (1, "hProcess"))
 AssignProcessToJobObject = AssignProcessToJobObjectProto(
-    ("AssignProcessToJobObject", windll.kernel32),
-    AssignProcessToJobObjectFlags)
+    ("AssignProcessToJobObject", windll.kernel32), AssignProcessToJobObjectFlags
+)
 AssignProcessToJobObject.errcheck = ErrCheckBool
 
 # ResumeThread()
+
 
 def ErrCheckResumeThread(result, func, args):
     if result == -1:
@@ -217,38 +258,34 @@ def ErrCheckResumeThread(result, func, args):
 
     return args
 
-ResumeThreadProto = WINFUNCTYPE(DWORD,      # Return type
-                                HANDLE      # hThread
-                                )
+
+ResumeThreadProto = WINFUNCTYPE(DWORD, HANDLE)  # Return type  # hThread
 ResumeThreadFlags = ((1, "hThread"),)
-ResumeThread = ResumeThreadProto(("ResumeThread", windll.kernel32),
-                                 ResumeThreadFlags)
+ResumeThread = ResumeThreadProto(
+    ("ResumeThread", windll.kernel32), ResumeThreadFlags
+)
 ResumeThread.errcheck = ErrCheckResumeThread
 
 # TerminateJobObject()
 
-TerminateJobObjectProto = WINFUNCTYPE(BOOL,   # Return type
-                                      HANDLE, # hJob
-                                      UINT    # uExitCode
-                                      )
-TerminateJobObjectFlags = ((1, "hJob"),
-                           (1, "uExitCode", 127))
+TerminateJobObjectProto = WINFUNCTYPE(
+    BOOL, HANDLE, UINT  # Return type  # hJob  # uExitCode
+)
+TerminateJobObjectFlags = ((1, "hJob"), (1, "uExitCode", 127))
 TerminateJobObject = TerminateJobObjectProto(
-    ("TerminateJobObject", windll.kernel32),
-    TerminateJobObjectFlags)
+    ("TerminateJobObject", windll.kernel32), TerminateJobObjectFlags
+)
 TerminateJobObject.errcheck = ErrCheckBool
 
 # WaitForSingleObject()
 
-WaitForSingleObjectProto = WINFUNCTYPE(DWORD,  # Return type
-                                       HANDLE, # hHandle
-                                       DWORD,  # dwMilliseconds
-                                       )
-WaitForSingleObjectFlags = ((1, "hHandle"),
-                            (1, "dwMilliseconds", -1))
+WaitForSingleObjectProto = WINFUNCTYPE(
+    DWORD, HANDLE, DWORD,  # Return type  # hHandle  # dwMilliseconds
+)
+WaitForSingleObjectFlags = ((1, "hHandle"), (1, "dwMilliseconds", -1))
 WaitForSingleObject = WaitForSingleObjectProto(
-    ("WaitForSingleObject", windll.kernel32),
-    WaitForSingleObjectFlags)
+    ("WaitForSingleObject", windll.kernel32), WaitForSingleObjectFlags
+)
 
 INFINITE = -1
 WAIT_TIMEOUT = 0x0102
@@ -257,14 +294,11 @@ WAIT_ABANDONED = 0x0080
 
 # GetExitCodeProcess()
 
-GetExitCodeProcessProto = WINFUNCTYPE(BOOL,    # Return type
-                                      HANDLE,  # hProcess
-                                      LPDWORD, # lpExitCode
-                                      )
-GetExitCodeProcessFlags = ((1, "hProcess"),
-                           (2, "lpExitCode"))
+GetExitCodeProcessProto = WINFUNCTYPE(
+    BOOL, HANDLE, LPDWORD,  # Return type  # hProcess  # lpExitCode
+)
+GetExitCodeProcessFlags = ((1, "hProcess"), (2, "lpExitCode"))
 GetExitCodeProcess = GetExitCodeProcessProto(
-    ("GetExitCodeProcess", windll.kernel32),
-    GetExitCodeProcessFlags)
+    ("GetExitCodeProcess", windll.kernel32), GetExitCodeProcessFlags
+)
 GetExitCodeProcess.errcheck = ErrCheckBool
-

--- a/src/omero_model_DetailsI.py
+++ b/src/omero_model_DetailsI.py
@@ -11,6 +11,7 @@
 """
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Details_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -18,7 +19,6 @@ __name__ = "omero.model"
 
 
 class DetailsI(_omero_model.Details):
-
     def __init__(self, client=None):
         super(DetailsI, self).__init__()
         self.__client = client
@@ -132,5 +132,6 @@ class DetailsI(_omero_model.Details):
                     return self.setExternalInfo(value)
                 else:
                     raise
+
 
 _omero_model.DetailsI = DetailsI

--- a/src/omero_model_ElectricPotentialI.py
+++ b/src/omero_model_ElectricPotentialI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_ElectricPotential_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,846 +52,2106 @@ class ElectricPotentialI(_omero_model.ElectricPotential, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 6), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Int(1000), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 16), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 13), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 4), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Int(10), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 7), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 10), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 22), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 19), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centiv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 19), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Int(1000), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Int(100), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 16), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 7), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 4), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 10), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 13), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Int(10), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 25), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 22), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 17), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Int(10), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 14), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 5), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Int(100), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 8), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 11), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 23), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 20), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.DECIVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("deciv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 36), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 20), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 17), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 19), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 33), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Pow(10, 9), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 16), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 15), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Pow(10, 12), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 24), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 21), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 27), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Int(1000), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 30), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Pow(10, 6), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 18), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 42), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 39), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.EXAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Int(1000), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 9), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 6), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 27), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 11), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 8), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 10), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 24), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 7), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 6), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Int(1000), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 15), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 12), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 18), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 21), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 9), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 33), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 30), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 20), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 4), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Int(10), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Int(1000), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 17), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 8), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 5), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 11), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 14), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Int(100), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 26), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 23), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 21), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 5), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Int(100), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 4), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 18), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Int(10), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 9), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 6), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 12), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 15), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Int(1000), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 27), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 24), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.KILOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 24), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 8), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 5), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 7), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 21), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 4), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Int(1000), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 12), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 9), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 15), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 18), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 6), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 30), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 27), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 12), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 9), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Int(1000), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 6), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 18), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 15), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MICROVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("microv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 15), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 12), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Int(1000), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 6), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 9), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 21), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 18), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("milliv"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 9), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 6), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Int(1000), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 15), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 12), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.NANOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 33), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 17), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 14), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 16), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 30), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Pow(10, 6), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 13), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 12), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Pow(10, 9), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 21), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 18), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 24), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 27), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Int(1000), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 15), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 39), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 36), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PETAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 6), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Int(1000), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 12), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 9), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.PICOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 30), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 14), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 11), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 13), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 27), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Int(1000), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 10), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 9), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Pow(10, 6), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 18), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 15), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 21), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 24), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 12), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 36), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 33), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.TERAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("terav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 18), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Int(100), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Int(10), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 15), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 6), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Int(1000), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 9), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 12), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 24), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 21), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.VOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("v"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 42), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 26), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 23), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 25), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Pow(10, 6), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 39), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Pow(10, 15), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 22), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 21), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Pow(10, 18), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 30), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 27), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 33), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Pow(10, 9), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 36), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Pow(10, 12), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 24), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 48), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 45), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Int(1000), Sym("yottav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Int(1000), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][UnitsElectricPotential.ZETTAVOLT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptov"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.ATTOVOLT] = \
-        Mul(Pow(10, 39), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.CENTIVOLT] = \
-        Mul(Pow(10, 23), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.DECAVOLT] = \
-        Mul(Pow(10, 20), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.DECIVOLT] = \
-        Mul(Pow(10, 22), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.EXAVOLT] = \
-        Mul(Int(1000), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.FEMTOVOLT] = \
-        Mul(Pow(10, 36), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.GIGAVOLT] = \
-        Mul(Pow(10, 12), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.HECTOVOLT] = \
-        Mul(Pow(10, 19), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.KILOVOLT] = \
-        Mul(Pow(10, 18), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.MEGAVOLT] = \
-        Mul(Pow(10, 15), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.MICROVOLT] = \
-        Mul(Pow(10, 27), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.MILLIVOLT] = \
-        Mul(Pow(10, 24), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.NANOVOLT] = \
-        Mul(Pow(10, 30), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.PETAVOLT] = \
-        Mul(Pow(10, 6), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.PICOVOLT] = \
-        Mul(Pow(10, 33), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.TERAVOLT] = \
-        Mul(Pow(10, 9), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.VOLT] = \
-        Mul(Pow(10, 21), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.YOCTOVOLT] = \
-        Mul(Pow(10, 45), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.YOTTAVOLT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettav"))  # nopep8
-    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][UnitsElectricPotential.ZEPTOVOLT] = \
-        Mul(Pow(10, 42), Sym("zettav"))  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Int(1000), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ATTOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 16), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 13), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 4), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Int(10), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 7), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 10), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Int(100)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 22), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 19), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.CENTIVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centiv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 19), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Int(1000), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Int(100), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 16), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(100)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 7), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 4), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 10), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 13), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Int(10), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 25), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 22), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 17), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Int(10), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(100)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 14), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 5), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Int(100), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 8), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 11), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 23), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 20), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.DECIVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("deciv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 36), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 20), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 17), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 19), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 16), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Int(1000), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 18), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 42), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 39), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.EXAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Int(1000), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.FEMTOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 11), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 8), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 10), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 7), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Int(1000), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 9), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.GIGAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 20), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 4), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Int(10), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Int(1000), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 17), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 8), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 5), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 11), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 14), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Int(100), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 26), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 23), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.HECTOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 5), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Int(100), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 4), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Int(10), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Int(1000), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.KILOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 8), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 5), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 7), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 4), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Int(1000), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 6), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MEGAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Int(1000), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MICROVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("microv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Int(100)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Int(1000), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.MILLIVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("milliv")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Int(1000), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.NANOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 17), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 14), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 16), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 13), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Int(1000), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 15), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 39), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 36), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PETAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Int(1000), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.PICOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 14), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 11), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 13), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Int(1000), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 10), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 12), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 36), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.TERAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("terav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Int(100), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(10)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Int(10), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(100)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Int(1000), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.VOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("v")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOCTOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 42), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 26), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 23), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 25), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 39), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 22), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 21), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 36), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 24), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 48), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 45), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.YOTTAVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Int(1000), Sym("yottav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Int(1000), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZEPTOVOLT][
+        UnitsElectricPotential.ZETTAVOLT
+    ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptov")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.ATTOVOLT
+    ] = Mul(
+        Pow(10, 39), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.CENTIVOLT
+    ] = Mul(
+        Pow(10, 23), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.DECAVOLT
+    ] = Mul(
+        Pow(10, 20), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.DECIVOLT
+    ] = Mul(
+        Pow(10, 22), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.EXAVOLT
+    ] = Mul(
+        Int(1000), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.FEMTOVOLT
+    ] = Mul(
+        Pow(10, 36), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.GIGAVOLT
+    ] = Mul(
+        Pow(10, 12), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.HECTOVOLT
+    ] = Mul(
+        Pow(10, 19), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.KILOVOLT
+    ] = Mul(
+        Pow(10, 18), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.MEGAVOLT
+    ] = Mul(
+        Pow(10, 15), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.MICROVOLT
+    ] = Mul(
+        Pow(10, 27), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.MILLIVOLT
+    ] = Mul(
+        Pow(10, 24), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.NANOVOLT
+    ] = Mul(
+        Pow(10, 30), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.PETAVOLT
+    ] = Mul(
+        Pow(10, 6), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.PICOVOLT
+    ] = Mul(
+        Pow(10, 33), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.TERAVOLT
+    ] = Mul(
+        Pow(10, 9), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.VOLT
+    ] = Mul(
+        Pow(10, 21), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.YOCTOVOLT
+    ] = Mul(
+        Pow(10, 45), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.YOTTAVOLT
+    ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettav")
+    )  # nopep8
+    CONVERSIONS[UnitsElectricPotential.ZETTAVOLT][
+        UnitsElectricPotential.ZEPTOVOLT
+    ] = Mul(
+        Pow(10, 42), Sym("zettav")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -926,9 +2187,7 @@ class ElectricPotentialI(_omero_model.ElectricPotential, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsElectricPotential, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.ElectricPotentialI):
             # This is a copy-constructor call.
@@ -976,5 +2235,6 @@ class ElectricPotentialI(_omero_model.ElectricPotential, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.ElectricPotentialI = ElectricPotentialI

--- a/src/omero_model_FrequencyI.py
+++ b/src/omero_model_FrequencyI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Frequency_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,846 +52,1266 @@ class FrequencyI(_omero_model.Frequency, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 6), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Int(1000), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 16), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 13), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 4), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Int(10), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 7), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 10), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 22), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 19), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 19), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Int(1000), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Int(100), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 16), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Int(10), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 7), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 4), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 10), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 13), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 25), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 22), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 17), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Int(10), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 14), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 5), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Int(100), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 8), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 11), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 23), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 20), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("decihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 36), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 20), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 17), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 19), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 33), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Pow(10, 9), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 16), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 18), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 15), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Pow(10, 12), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 24), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 21), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 27), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Int(1000), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 30), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Pow(10, 6), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 42), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 39), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Int(1000), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 9), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 6), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 27), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 11), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 8), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 10), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 24), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 7), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 9), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 6), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Int(1000), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 15), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 12), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 18), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 21), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 33), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 30), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 20), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 4), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Int(10), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Int(1000), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 17), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Int(100), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 8), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 5), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 11), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 14), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 26), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 23), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 18), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Int(100), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Int(10), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 15), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Int(100)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 6), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Int(1000), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 9), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 12), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 24), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 21), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("hz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 21), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 5), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Int(100), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 4), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 18), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Int(10), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Int(1000), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 9), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 6), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 12), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 15), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 27), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 24), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 24), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 8), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 5), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 7), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 21), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 4), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 6), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Int(1000), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 12), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 9), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 15), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 18), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 30), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 27), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 12), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 9), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Int(1000), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 6), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 18), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 15), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("microhz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 15), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Int(10)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Int(100)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 12), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Int(1000), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 6), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 9), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 21), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 18), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("millihz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 9), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 6), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Int(1000), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 15), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 12), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 33), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 17), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 14), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 16), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 30), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Pow(10, 6), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 13), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 15), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 12), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Pow(10, 9), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 21), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 18), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 24), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 27), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Int(1000), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 39), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 36), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 6), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Int(1000), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 12), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 9), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 30), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 14), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 11), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 13), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 27), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Int(1000), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 10), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 12), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 9), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Pow(10, 6), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 18), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 15), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 21), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 24), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 36), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 33), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("terahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 42), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 26), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 23), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 25), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Pow(10, 6), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 39), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Pow(10, 15), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 22), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 24), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 21), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Pow(10, 18), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 30), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 27), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 33), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Pow(10, 9), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 36), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Pow(10, 12), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 48), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 45), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Int(1000), Sym("yottahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Int(1000), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.ZETTAHERTZ] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptohz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.ATTOHERTZ] = \
-        Mul(Pow(10, 39), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.CENTIHERTZ] = \
-        Mul(Pow(10, 23), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.DECAHERTZ] = \
-        Mul(Pow(10, 20), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.DECIHERTZ] = \
-        Mul(Pow(10, 22), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.EXAHERTZ] = \
-        Mul(Int(1000), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.FEMTOHERTZ] = \
-        Mul(Pow(10, 36), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.GIGAHERTZ] = \
-        Mul(Pow(10, 12), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.HECTOHERTZ] = \
-        Mul(Pow(10, 19), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.HERTZ] = \
-        Mul(Pow(10, 21), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.KILOHERTZ] = \
-        Mul(Pow(10, 18), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MEGAHERTZ] = \
-        Mul(Pow(10, 15), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MICROHERTZ] = \
-        Mul(Pow(10, 27), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MILLIHERTZ] = \
-        Mul(Pow(10, 24), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.NANOHERTZ] = \
-        Mul(Pow(10, 30), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.PETAHERTZ] = \
-        Mul(Pow(10, 6), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.PICOHERTZ] = \
-        Mul(Pow(10, 33), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.TERAHERTZ] = \
-        Mul(Pow(10, 9), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.YOCTOHERTZ] = \
-        Mul(Pow(10, 45), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.YOTTAHERTZ] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettahz"))  # nopep8
-    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.ZEPTOHERTZ] = \
-        Mul(Pow(10, 42), Sym("zettahz"))  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 6), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Int(1000), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ATTOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 16), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 13), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Int(100)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 4), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Int(10), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 7), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 10), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 22), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 19), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.CENTIHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 19), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Int(1000), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Int(100), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 16), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Int(10), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Int(100)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 7), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 4), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 10), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 13), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 25), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 22), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 17), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Int(10), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Int(100)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 14), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 5), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Int(100), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 8), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 11), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 23), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 20), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.DECIHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("decihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 36), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 20), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 17), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 19), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 33), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Pow(10, 9), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 16), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 18), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 15), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Pow(10, 12), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 24), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 21), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 27), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Int(1000), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 30), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Pow(10, 6), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 42), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 39), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.EXAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Int(1000), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 9), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 6), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.FEMTOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 27), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 11), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 8), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 10), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 24), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 7), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 9), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 6), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Int(1000), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 15), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 12), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 18), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 21), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 33), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 30), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.GIGAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 20), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 4), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Int(10), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Int(1000), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 17), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Int(100), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 8), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 5), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 11), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 14), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 26), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 23), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HECTOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 18), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Int(100), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Int(10), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 15), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Int(100)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 6), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Int(1000), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 9), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 12), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 24), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 21), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.HERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("hz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 21), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 5), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Int(100), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 4), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 18), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Int(10), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Int(1000), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 9), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 6), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 12), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 15), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 27), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 24), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.KILOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 24), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 8), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 5), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 7), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 21), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 4), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 6), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Int(1000), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 12), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 9), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 15), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 18), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 30), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 27), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MEGAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 12), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 9), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Int(1000), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 6), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 18), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 15), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MICROHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("microhz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 15), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Int(10)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Int(100)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 12), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Int(1000), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 6), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 9), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 21), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 18), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.MILLIHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("millihz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 9), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 6), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Int(1000), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 15), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 12), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.NANOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 33), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 17), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 14), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 16), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 30), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Pow(10, 6), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 13), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 15), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 12), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Pow(10, 9), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 21), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 18), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 24), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 27), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Int(1000), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 39), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 36), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PETAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 6), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Int(1000), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 12), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 9), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.PICOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 30), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 14), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 11), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 13), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 27), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Int(1000), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 10), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 12), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 9), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Pow(10, 6), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 18), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 15), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 21), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 24), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 36), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 33), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.TERAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("terahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOCTOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 42), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 26), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 23), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 25), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Pow(10, 6), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 39), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Pow(10, 15), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 22), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 24), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 21), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Pow(10, 18), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 30), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 27), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 33), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Pow(10, 9), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 36), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Pow(10, 12), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 48), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 45), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.YOTTAHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Int(1000), Sym("yottahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Int(1000), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZEPTOHERTZ][UnitsFrequency.ZETTAHERTZ] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptohz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.ATTOHERTZ] = Mul(
+        Pow(10, 39), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.CENTIHERTZ] = Mul(
+        Pow(10, 23), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.DECAHERTZ] = Mul(
+        Pow(10, 20), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.DECIHERTZ] = Mul(
+        Pow(10, 22), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.EXAHERTZ] = Mul(
+        Int(1000), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.FEMTOHERTZ] = Mul(
+        Pow(10, 36), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.GIGAHERTZ] = Mul(
+        Pow(10, 12), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.HECTOHERTZ] = Mul(
+        Pow(10, 19), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.HERTZ] = Mul(
+        Pow(10, 21), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.KILOHERTZ] = Mul(
+        Pow(10, 18), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MEGAHERTZ] = Mul(
+        Pow(10, 15), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MICROHERTZ] = Mul(
+        Pow(10, 27), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.MILLIHERTZ] = Mul(
+        Pow(10, 24), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.NANOHERTZ] = Mul(
+        Pow(10, 30), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.PETAHERTZ] = Mul(
+        Pow(10, 6), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.PICOHERTZ] = Mul(
+        Pow(10, 33), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.TERAHERTZ] = Mul(
+        Pow(10, 9), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.YOCTOHERTZ] = Mul(
+        Pow(10, 45), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.YOTTAHERTZ] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettahz")
+    )  # nopep8
+    CONVERSIONS[UnitsFrequency.ZETTAHERTZ][UnitsFrequency.ZEPTOHERTZ] = Mul(
+        Pow(10, 42), Sym("zettahz")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -926,9 +1347,7 @@ class FrequencyI(_omero_model.Frequency, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsFrequency, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.FrequencyI):
             # This is a copy-constructor call.
@@ -976,5 +1395,6 @@ class FrequencyI(_omero_model.Frequency, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.FrequencyI = FrequencyI

--- a/src/omero_model_LengthI.py
+++ b/src/omero_model_LengthI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Length_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,1990 +52,2982 @@ class LengthI(_omero_model.Length, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 12))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 8), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 28)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 5), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 14))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 14)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 12))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 12))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 15))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 19))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PICOMETER] = \
-        Mul(Int(100), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 11))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 17)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 14))), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 14), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 34)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 11), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 31)), Sym("ang"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ANGSTROM] = \
-        Mul(Mul(Int(1495978707), Pow(10, 12)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ATTOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 20)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.CENTIMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 4)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.DECAMETER] = \
-        Mul(Int("14959787070"), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.DECIMETER] = \
-        Mul(Int("1495978707000"), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 16)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.FEMTOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 17)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.FOOT] = \
-        Mul(Rat(Int("196322770974869"), Int(400)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 7)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.HECTOMETER] = \
-        Mul(Int(1495978707), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.INCH] = \
-        Mul(Rat(Int("588968312924607"), Int(100)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1495978707), Int(10)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(6830953), Int("431996825232")), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.LINE] = \
-        Mul(Rat(Int("1766904938773821"), Int(25)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 4)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.METER] = \
-        Mul(Int("149597870700"), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MICROMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 8)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MILE] = \
-        Mul(Rat(Int("17847524634079"), Int(192000)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MILLIMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 5)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.NANOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 11)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(498659569), Mul(Int(10285592), Pow(10, 7))), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 13)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PICOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 14)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.POINT] = \
-        Mul(Rat(Int("10601429632642926"), Int(25)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 10)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.THOU] = \
-        Mul(Rat(Int("588968312924607"), Pow(10, 5)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YARD] = \
-        Mul(Rat(Int("196322770974869"), Int(1200)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YOCTOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 26)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 22)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ZEPTOMETER] = \
-        Mul(Mul(Int(1495978707), Pow(10, 23)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1495978707), Pow(10, 19)), Sym("ua"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 20))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 22))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 22)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 20))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 20))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 23))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 27))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PICOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 19))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 25)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 22))), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 6), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Int(1000), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attom"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 8), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 4))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 16), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 13), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 6))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 6)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 4))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 4))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 4), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 7))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MILLIMETER] = \
-        Mul(Int(10), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 7), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 11))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 10), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Int(125000)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 9)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 6))), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 22), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 19), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 11), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Int("14959787070")), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 19), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Int(1000), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.DECIMETER] = \
-        Mul(Int(100), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 16), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Int(12000)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Int(1000)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Int("946073047258080")), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Int(250)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.METER] = \
-        Mul(Int(10), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 7), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 4))), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 4), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 10), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 8))), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 13), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Int(125)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 6)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Int(36000)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 25), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 22), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decam"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 9), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Int("1495978707000")), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 17), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.CENTIMETER] = \
-        Mul(Int(10), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 14), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 5))), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 5)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Int("94607304725808000")), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Int(25000)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 5), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 6))), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MILLIMETER] = \
-        Mul(Int(100), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 8), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 10))), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 11), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Int(12500)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 8)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 5))), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 23), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 20), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("decim"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 28), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 16), Int(1495978707)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 36), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 20), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 17), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 19), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 33), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 12)), Int(3)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Pow(10, 9), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 16), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 14)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 15), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(625), Pow(10, 12)), Int("5912956545363")), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 14)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Pow(10, 12), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 18), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 24), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Mul(Int(559234375), Pow(10, 7)), Int(9)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 21), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 27), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 6)), Int(3857097)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PETAMETER] = \
-        Mul(Int(1000), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 30), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 14)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.TERAMETER] = \
-        Mul(Pow(10, 6), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.THOU] = \
-        Mul(Mul(Int(393701), Pow(10, 11)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 12)), Int(9)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 42), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 39), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exam"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 17))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Int(1000), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 19))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 19)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 17))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 17))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 20))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 24))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PICOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 16))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 22)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 19))), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 9), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 6), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtom"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 14)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(400), Int("196322770974869")), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 22)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 6)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(12000), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.DECIMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 5)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(3), Mul(Int(9842525), Pow(10, 12))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 19)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(3), Int("9842525000")), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1200), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.INCH] = \
-        Mul(Int(12), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(120), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(25), Int("775978968288652821")), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.LINE] = \
-        Mul(Int(144), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(3), Int(9842525)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.METER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 4)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MICROMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 10)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MILE] = \
-        Mul(Rat(Int(1), Int(5280)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 7)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.NANOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 13)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int("1012361963998"), Pow(10, 5))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(3), Mul(Int(9842525), Pow(10, 9))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PICOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 16)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.POINT] = \
-        Mul(Int(864), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(3), Mul(Int(9842525), Pow(10, 6))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.THOU] = \
-        Mul(Rat(Int(3), Int(250)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YARD] = \
-        Mul(Rat(Int(1), Int(3)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 28)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(3), Mul(Int(9842525), Pow(10, 18))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Mul(Int(12), Pow(10, 25)), Int(393701)), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(3), Mul(Int(9842525), Pow(10, 15))), Sym("ft"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 19), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 7), Int(1495978707)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 27), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 11), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 8), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 10), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 24), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int("9842525000"), Int(3)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 7), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 5)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 6), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(625000), Int("5912956545363")), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 5)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Int(1000), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 9), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 15), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(22369375), Int(36)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 12), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 18), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Int(30856776)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 21), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 5)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.THOU] = \
-        Mul(Int(39370100), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int("9842525000"), Int(9)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 33), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 30), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigam"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 12), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Int(1495978707)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 20), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 4), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.DECAMETER] = \
-        Mul(Int(10), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.DECIMETER] = \
-        Mul(Int(1000), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 17), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Int(1200)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Int(100)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Int("94607304725808")), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Int(25)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.METER] = \
-        Mul(Int(100), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 8), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Int(576000)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 5), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 11), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 7))), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 14), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(7086618), Int(25)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 5)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Int(3600)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 26), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 23), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectom"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Pow(10, 14), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(100), Int("588968312924607")), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Pow(10, 22), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Pow(10, 6), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1000), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.DECIMETER] = \
-        Mul(Rat(Pow(10, 5), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 14))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Pow(10, 19), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.FOOT] = \
-        Mul(Rat(Int(1), Int(12)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 5))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(100), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(10), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(25), Int("9311747619463833852")), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.LINE] = \
-        Mul(Int(12), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Int(39370100)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.METER] = \
-        Mul(Rat(Pow(10, 4), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.MICROMETER] = \
-        Mul(Rat(Pow(10, 10), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.MILE] = \
-        Mul(Rat(Int(1), Int(63360)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Pow(10, 7), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.NANOMETER] = \
-        Mul(Rat(Pow(10, 13), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int("12148343567976"), Pow(10, 5))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 11))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.PICOMETER] = \
-        Mul(Rat(Pow(10, 16), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.POINT] = \
-        Mul(Int(72), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 8))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.THOU] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.YARD] = \
-        Mul(Rat(Int(1), Int(36)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Pow(10, 28), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 20))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Pow(10, 25), Int(393701)), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.INCH][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 17))), Sym("in"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 13), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(10), Int(1495978707)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 21), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 5), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.DECAMETER] = \
-        Mul(Int(100), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 4), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 18), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Int(120)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Int(10), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Int(10)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(5), Int("47303652362904")), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(2362206), Int(5)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.METER] = \
-        Mul(Int(1000), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 9), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Int(57600)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 6), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 12), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 6))), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 15), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(14173236), Int(5)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 4)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Int(360)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 27), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 24), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilom"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ANGSTROM] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 12)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int("431996825232"), Int(6830953)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ATTOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 20)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.CENTIMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 4)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.DECAMETER] = \
-        Mul(Int("946073047258080"), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.DECIMETER] = \
-        Mul(Int("94607304725808000"), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 12))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.FEMTOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 17)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.FOOT] = \
-        Mul(Rat(Int("775978968288652821"), Int(25)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int("5912956545363"), Int(625000)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.HECTOMETER] = \
-        Mul(Int("94607304725808"), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.INCH] = \
-        Mul(Rat(Int("9311747619463833852"), Int(25)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int("47303652362904"), Int(5)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.LINE] = \
-        Mul(Rat(Int("111740971433566006224"), Int(25)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int("5912956545363"), Int(625)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.METER] = \
-        Mul(Int("9460730472580800"), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MICROMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 8)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MILE] = \
-        Mul(Rat(Int("23514514190565237"), Int(4000)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MILLIMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 5)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.NANOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 11)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PARSEC] = \
-        Mul(Rat(Int("1970985515121"), Mul(Int(6428495), Pow(10, 6))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 9))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PICOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 14)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.POINT] = \
-        Mul(Rat(Int("670445828601396037344"), Int(25)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 6))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.THOU] = \
-        Mul(Rat(Int("2327936904865958463"), Int(6250)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YARD] = \
-        Mul(Rat(Int("258659656096217607"), Int(25)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YOCTOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 26)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 18))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ZEPTOMETER] = \
-        Mul(Mul(Int("94607304725808"), Pow(10, 23)), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 15))), Sym("ly"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 12)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(25), Int("1766904938773821")), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 20)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 4)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(250), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(25000), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 14))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 17)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.FOOT] = \
-        Mul(Rat(Int(1), Int(144)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 5))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(25), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.INCH] = \
-        Mul(Rat(Int(1), Int(12)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(5), Int(2362206)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(25), Int("111740971433566006224")), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Int(472441200)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.METER] = \
-        Mul(Rat(Int(2500), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.MICROMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 8)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.MILE] = \
-        Mul(Rat(Int(1), Int(760320)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 5)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.NANOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 11)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int("145780122815712"), Pow(10, 5))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 11))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.PICOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 14)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.POINT] = \
-        Mul(Int(6), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 8))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.THOU] = \
-        Mul(Rat(Int(1), Int(12000)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.YARD] = \
-        Mul(Rat(Int(1), Int(432)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 26)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 20))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 23)), Int(1181103)), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.LINE][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(4724412), Pow(10, 17))), Sym("li"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 16), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 4), Int(1495978707)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 24), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 8), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 5), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 7), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 21), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(9842525), Int(3)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 4), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.INCH] = \
-        Mul(Int(39370100), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.KILOMETER] = \
-        Mul(Int(1000), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(625), Int("5912956545363")), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.LINE] = \
-        Mul(Int(472441200), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 6), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 12), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(178955), Int(288)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 9), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 15), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Int("30856776000")), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 18), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.POINT] = \
-        Mul(Int("2834647200"), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Int(10)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(9842525), Int(9)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 30), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 27), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megam"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 10), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Int("149597870700")), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 18), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.CENTIMETER] = \
-        Mul(Int(100), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.DECIMETER] = \
-        Mul(Int(10), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 15), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 4))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Int(100)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 4)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Int("9460730472580800")), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Int(2500)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 6), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 5))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.MILLIMETER] = \
-        Mul(Int(1000), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 9), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 9))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 12), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Int(1250)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 7)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 4))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 24), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 21), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.METER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 4), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 8))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 12), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 9), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 10))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 10)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 8))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 8))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 11))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.NANOMETER] = \
-        Mul(Int(1000), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 15))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 6), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 7))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 13)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 10))), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 18), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 15), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("microm"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 15)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(192000), Int("17847524634079")), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 23)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 7)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.DECAMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 4)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.DECIMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 6)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(559234375), Pow(10, 7))), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 20)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.FOOT] = \
-        Mul(Int(5280), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(36), Int(22369375)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(576000), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.INCH] = \
-        Mul(Int(63360), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(57600), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(4000), Int("23514514190565237")), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.LINE] = \
-        Mul(Int(760320), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(288), Int(178955)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.METER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 5)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.MICROMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 11)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 8)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.NANOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 14)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(3), Int("57520566136250")), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(559234375), Pow(10, 4))), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.PICOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 17)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.POINT] = \
-        Mul(Int(4561920), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(9), Int("5592343750")), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.THOU] = \
-        Mul(Rat(Int(1584), Int(25)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.YARD] = \
-        Mul(Int(1760), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 29)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(559234375), Pow(10, 13))), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Mul(Int(576), Pow(10, 26)), Int(35791)), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILE][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(559234375), Pow(10, 10))), Sym("mi"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 7), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 5))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 15), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Int(10)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Int(100)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 12), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 7))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 7)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 5))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 5))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MICROMETER] = \
-        Mul(Int(1000), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 8))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 6), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 12))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 9), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 4))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 10)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 7))), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 21), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 18), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("millim"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Int(10), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 11))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 9), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 6), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 13))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 13)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 11))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 11))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 14))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 18))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PICOMETER] = \
-        Mul(Int(1000), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 10))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 16)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 13))), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 15), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 12), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanom"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ANGSTROM] = \
-        Mul(Mul(Int(30856776), Pow(10, 19)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Mul(Int(10285592), Pow(10, 7)), Int(498659569)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ATTOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 27)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.CENTIMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 11)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.DECAMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 8)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.DECIMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 10)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(3857097), Mul(Int(125), Pow(10, 6))), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.FEMTOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 24)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.FOOT] = \
-        Mul(Mul(Int("1012361963998"), Pow(10, 5)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.GIGAMETER] = \
-        Mul(Int(30856776), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.HECTOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 7)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.INCH] = \
-        Mul(Mul(Int("12148343567976"), Pow(10, 5)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.KILOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 6)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(6428495), Pow(10, 6)), Int("1970985515121")), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.LINE] = \
-        Mul(Mul(Int("145780122815712"), Pow(10, 5)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MEGAMETER] = \
-        Mul(Int("30856776000"), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.METER] = \
-        Mul(Mul(Int(30856776), Pow(10, 9)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MICROMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 15)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MILE] = \
-        Mul(Rat(Int("57520566136250"), Int(3)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MILLIMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 12)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.NANOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 18)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(3857097), Int(125000)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.PICOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 21)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.POINT] = \
-        Mul(Mul(Int("874680736894272"), Pow(10, 5)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(3857097), Int(125)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.THOU] = \
-        Mul(Int("1214834356797600"), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int("1012361963998"), Pow(10, 5)), Int(3)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YOCTOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 33)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(3857097), Mul(Int(125), Pow(10, 12))), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ZEPTOMETER] = \
-        Mul(Mul(Int(30856776), Pow(10, 30)), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(3857097), Mul(Int(125), Pow(10, 9))), Sym("pc"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 25), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 13), Int(1495978707)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 33), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 17), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 14), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 16), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 30), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 9)), Int(3)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Pow(10, 6), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 13), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 11)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 12), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(625), Pow(10, 9)), Int("5912956545363")), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 11)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Pow(10, 9), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 15), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 21), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Mul(Int(559234375), Pow(10, 4)), Int(9)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 18), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 24), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(125000), Int(3857097)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 27), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 11)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.TERAMETER] = \
-        Mul(Int(1000), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.THOU] = \
-        Mul(Mul(Int(393701), Pow(10, 8)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 9)), Int(9)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 39), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 36), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petam"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Int(1), Int(100)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 14))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 6), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Int(1000), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 16))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 16)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 14))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 14))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 17))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 21))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 13))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 19)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 16))), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 12), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 9), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picom"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 11)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(25), Int("10601429632642926")), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 19)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(125000), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(125), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(12500), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 14))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 16)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.FOOT] = \
-        Mul(Rat(Int(1), Int(864)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 5))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(25), Int(7086618)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.INCH] = \
-        Mul(Rat(Int(1), Int(72)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(5), Int(14173236)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(25), Int("670445828601396037344")), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.LINE] = \
-        Mul(Rat(Int(1), Int(6)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Int("2834647200")), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.METER] = \
-        Mul(Rat(Int(1250), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.MICROMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 7)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.MILE] = \
-        Mul(Rat(Int(1), Int(4561920)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 4)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.NANOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 10)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int("874680736894272"), Pow(10, 5))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 11))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.PICOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 13)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 8))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.THOU] = \
-        Mul(Rat(Int(1), Int(72000)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.YARD] = \
-        Mul(Rat(Int(1), Int(2592)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 25)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 20))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 22)), Int(3543309)), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.POINT][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 17))), Sym("pt"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 22), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 10), Int(1495978707)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 30), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 14), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 11), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 13), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 27), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 6)), Int(3)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Int(1000), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 10), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 8)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 9), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(625), Pow(10, 6)), Int("5912956545363")), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 8)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Pow(10, 6), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 12), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 18), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int("5592343750"), Int(9)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 15), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 21), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(125), Int(3857097)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 24), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 8)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.THOU] = \
-        Mul(Mul(Int(393701), Pow(10, 5)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 6)), Int(9)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 36), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 33), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("teram"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Pow(10, 17), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 5), Int("588968312924607")), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Pow(10, 25), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Pow(10, 9), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.DECAMETER] = \
-        Mul(Rat(Pow(10, 6), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.DECIMETER] = \
-        Mul(Rat(Pow(10, 8), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 11))), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Pow(10, 22), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.FOOT] = \
-        Mul(Rat(Int(250), Int(3)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Int(39370100)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Pow(10, 5), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.INCH] = \
-        Mul(Int(1000), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.KILOMETER] = \
-        Mul(Rat(Pow(10, 4), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(6250), Int("2327936904865958463")), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.LINE] = \
-        Mul(Int(12000), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(10), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.METER] = \
-        Mul(Rat(Pow(10, 7), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.MICROMETER] = \
-        Mul(Rat(Pow(10, 13), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.MILE] = \
-        Mul(Rat(Int(25), Int(1584)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Pow(10, 10), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.NANOMETER] = \
-        Mul(Rat(Pow(10, 16), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Int("1214834356797600")), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 8))), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.PICOMETER] = \
-        Mul(Rat(Pow(10, 19), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.POINT] = \
-        Mul(Int(72000), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 5))), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.YARD] = \
-        Mul(Rat(Int(250), Int(9)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Pow(10, 31), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 17))), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Pow(10, 28), Int(393701)), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.THOU][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Mul(Int(393701), Pow(10, 14))), Sym("thou"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 14)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1200), Int("196322770974869")), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 22)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 6)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(36000), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.DECIMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 5)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(9842525), Pow(10, 12))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 19)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.FOOT] = \
-        Mul(Int(3), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(9), Int("9842525000")), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(3600), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.INCH] = \
-        Mul(Int(36), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(360), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(25), Int("258659656096217607")), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.LINE] = \
-        Mul(Int(432), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(9), Int(9842525)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.METER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 4)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.MICROMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 10)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.MILE] = \
-        Mul(Rat(Int(1), Int(1760)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 7)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.NANOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 13)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(3), Mul(Int("1012361963998"), Pow(10, 5))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(9842525), Pow(10, 9))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.PICOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 16)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.POINT] = \
-        Mul(Int(2592), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(9842525), Pow(10, 6))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.THOU] = \
-        Mul(Rat(Int(9), Int(250)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.YOCTOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 28)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(9842525), Pow(10, 18))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Mul(Int(36), Pow(10, 25)), Int(393701)), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YARD][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(9), Mul(Int(9842525), Pow(10, 15))), Sym("yd"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 26))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 28))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 28)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 26))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 26))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 29))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 33))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PICOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 25))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 31)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 28))), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctom"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 34), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 22), Int(1495978707)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 42), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 26), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 23), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 25), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.EXAMETER] = \
-        Mul(Pow(10, 6), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 39), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 18)), Int(3)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Pow(10, 15), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 22), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 20)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 21), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(625), Pow(10, 18)), Int("5912956545363")), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 20)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Pow(10, 18), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 24), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 30), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Mul(Int(559234375), Pow(10, 13)), Int(9)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 27), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 33), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 12)), Int(3857097)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PETAMETER] = \
-        Mul(Pow(10, 9), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 36), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 20)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.TERAMETER] = \
-        Mul(Pow(10, 12), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.THOU] = \
-        Mul(Mul(Int(393701), Pow(10, 17)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 18)), Int(9)), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 48), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 45), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Int(1000), Sym("yottam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ANGSTROM] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Int(1), Mul(Int(1495978707), Pow(10, 23))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ATTOMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.CENTIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.DECAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.DECIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.EXAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Int(393701), Mul(Int(12), Pow(10, 25))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.GIGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.HECTOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.INCH] = \
-        Mul(Rat(Int(393701), Pow(10, 25)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.KILOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 23))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.LINE] = \
-        Mul(Rat(Int(1181103), Mul(Int(25), Pow(10, 23))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MEGAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.METER] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MICROMETER] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MILE] = \
-        Mul(Rat(Int(35791), Mul(Int(576), Pow(10, 26))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MILLIMETER] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.NANOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Int(1), Mul(Int(30856776), Pow(10, 30))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PETAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PICOMETER] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.POINT] = \
-        Mul(Rat(Int(3543309), Mul(Int(125), Pow(10, 22))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.TERAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.THOU] = \
-        Mul(Rat(Int(393701), Pow(10, 28)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YARD] = \
-        Mul(Rat(Int(393701), Mul(Int(36), Pow(10, 25))), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Int(1000), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ZETTAMETER] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptom"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ANGSTROM] = \
-        Mul(Pow(10, 31), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ASTRONOMICALUNIT] = \
-        Mul(Rat(Pow(10, 19), Int(1495978707)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ATTOMETER] = \
-        Mul(Pow(10, 39), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.CENTIMETER] = \
-        Mul(Pow(10, 23), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.DECAMETER] = \
-        Mul(Pow(10, 20), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.DECIMETER] = \
-        Mul(Pow(10, 22), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.EXAMETER] = \
-        Mul(Int(1000), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.FEMTOMETER] = \
-        Mul(Pow(10, 36), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.FOOT] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 15)), Int(3)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.GIGAMETER] = \
-        Mul(Pow(10, 12), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.HECTOMETER] = \
-        Mul(Pow(10, 19), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.INCH] = \
-        Mul(Mul(Int(393701), Pow(10, 17)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.KILOMETER] = \
-        Mul(Pow(10, 18), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.LIGHTYEAR] = \
-        Mul(Rat(Mul(Int(625), Pow(10, 15)), Int("5912956545363")), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.LINE] = \
-        Mul(Mul(Int(4724412), Pow(10, 17)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MEGAMETER] = \
-        Mul(Pow(10, 15), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.METER] = \
-        Mul(Pow(10, 21), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MICROMETER] = \
-        Mul(Pow(10, 27), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MILE] = \
-        Mul(Rat(Mul(Int(559234375), Pow(10, 10)), Int(9)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MILLIMETER] = \
-        Mul(Pow(10, 24), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.NANOMETER] = \
-        Mul(Pow(10, 30), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PARSEC] = \
-        Mul(Rat(Mul(Int(125), Pow(10, 9)), Int(3857097)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PETAMETER] = \
-        Mul(Pow(10, 6), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PICOMETER] = \
-        Mul(Pow(10, 33), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.POINT] = \
-        Mul(Mul(Int(28346472), Pow(10, 17)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.TERAMETER] = \
-        Mul(Pow(10, 9), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.THOU] = \
-        Mul(Mul(Int(393701), Pow(10, 14)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YARD] = \
-        Mul(Rat(Mul(Int(9842525), Pow(10, 15)), Int(9)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YOCTOMETER] = \
-        Mul(Pow(10, 45), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YOTTAMETER] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettam"))  # nopep8
-    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ZEPTOMETER] = \
-        Mul(Pow(10, 42), Sym("zettam"))  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 12))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 8), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 28)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 5), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 14))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 14)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 12))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 12))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 15))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 19))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.PICOMETER] = Mul(
+        Int(100), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 11))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 17)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 14))), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 14), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 34)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 11), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ANGSTROM][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 31)), Sym("ang")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ANGSTROM] = Mul(
+        Mul(Int(1495978707), Pow(10, 12)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ATTOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 20)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.CENTIMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 4)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.DECAMETER] = Mul(
+        Int("14959787070"), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.DECIMETER] = Mul(
+        Int("1495978707000"), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 16)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.FEMTOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 17)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.FOOT] = Mul(
+        Rat(Int("196322770974869"), Int(400)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 7)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.HECTOMETER] = Mul(
+        Int(1495978707), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.INCH] = Mul(
+        Rat(Int("588968312924607"), Int(100)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1495978707), Int(10)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(6830953), Int("431996825232")), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.LINE] = Mul(
+        Rat(Int("1766904938773821"), Int(25)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 4)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.METER] = Mul(
+        Int("149597870700"), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MICROMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 8)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MILE] = Mul(
+        Rat(Int("17847524634079"), Int(192000)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.MILLIMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 5)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.NANOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 11)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PARSEC] = Mul(
+        Rat(Int(498659569), Mul(Int(10285592), Pow(10, 7))), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 13)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.PICOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 14)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.POINT] = Mul(
+        Rat(Int("10601429632642926"), Int(25)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 10)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.THOU] = Mul(
+        Rat(Int("588968312924607"), Pow(10, 5)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YARD] = Mul(
+        Rat(Int("196322770974869"), Int(1200)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YOCTOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 26)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 22)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ZEPTOMETER] = Mul(
+        Mul(Int(1495978707), Pow(10, 23)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ASTRONOMICALUNIT][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1495978707), Pow(10, 19)), Sym("ua")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ANGSTROM] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 20))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 22))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 22)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 20))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 20))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 23))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 27))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.PICOMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 19))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 25)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 22))), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 6), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Int(1000), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ATTOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 8), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 4))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 16), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 13), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 6))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 6)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 4))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 4))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Int(100)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 4), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 7))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.MILLIMETER] = Mul(
+        Int(10), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 7), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 11))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 10), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Int(125000)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 9)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 6))), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 22), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 19), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.CENTIMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 11), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Int("14959787070")), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 19), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.CENTIMETER] = Mul(
+        Int(1000), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.DECIMETER] = Mul(
+        Int(100), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 16), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Int(12000)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Int(1000)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Int(100)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Int("946073047258080")), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Int(250)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.METER] = Mul(
+        Int(10), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 7), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 4))), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 4), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 10), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 8))), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 13), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Int(125)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 6)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Int(36000)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 25), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 22), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 9), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Int("1495978707000")), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 17), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.CENTIMETER] = Mul(
+        Int(10), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Int(100)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 14), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 5))), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 5)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Int("94607304725808000")), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Int(25000)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Int(10)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 5), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 6))), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.MILLIMETER] = Mul(
+        Int(100), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 8), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 10))), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 11), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Int(12500)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 8)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 5))), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 23), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 20), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.DECIMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("decim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 28), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 16), Int(1495978707)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 36), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 20), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 17), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 19), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 33), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 12)), Int(3)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.GIGAMETER] = Mul(
+        Pow(10, 9), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 16), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 14)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 15), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(625), Pow(10, 12)), Int("5912956545363")), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 14)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MEGAMETER] = Mul(
+        Pow(10, 12), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 18), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 24), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MILE] = Mul(
+        Rat(Mul(Int(559234375), Pow(10, 7)), Int(9)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 21), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 27), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Mul(Int(125), Pow(10, 6)), Int(3857097)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PETAMETER] = Mul(
+        Int(1000), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 30), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 14)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.TERAMETER] = Mul(
+        Pow(10, 6), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.THOU] = Mul(
+        Mul(Int(393701), Pow(10, 11)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 12)), Int(9)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 42), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 39), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.EXAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ANGSTROM] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 17))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ATTOMETER] = Mul(
+        Int(1000), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 19))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 19)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 17))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 17))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 20))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 24))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.PICOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 16))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 22)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 19))), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 9), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 6), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FEMTOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ANGSTROM] = Mul(
+        Rat(Mul(Int(12), Pow(10, 14)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(400), Int("196322770974869")), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ATTOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 22)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.CENTIMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 6)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(12000), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.DECIMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 5)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(3), Mul(Int(9842525), Pow(10, 12))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 19)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(3), Int("9842525000")), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1200), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.INCH] = Mul(
+        Int(12), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(120), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(25), Int("775978968288652821")), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.LINE] = Mul(
+        Int(144), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(3), Int(9842525)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.METER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 4)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MICROMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 10)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MILE] = Mul(
+        Rat(Int(1), Int(5280)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.MILLIMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 7)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.NANOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 13)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int("1012361963998"), Pow(10, 5))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(3), Mul(Int(9842525), Pow(10, 9))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.PICOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 16)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.POINT] = Mul(
+        Int(864), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(3), Mul(Int(9842525), Pow(10, 6))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.THOU] = Mul(
+        Rat(Int(3), Int(250)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YARD] = Mul(
+        Rat(Int(1), Int(3)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 28)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(3), Mul(Int(9842525), Pow(10, 18))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Mul(Int(12), Pow(10, 25)), Int(393701)), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.FOOT][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(3), Mul(Int(9842525), Pow(10, 15))), Sym("ft")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 19), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 7), Int(1495978707)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 27), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 11), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 8), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 10), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 24), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int("9842525000"), Int(3)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 7), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 5)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 6), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(625000), Int("5912956545363")), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 5)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MEGAMETER] = Mul(
+        Int(1000), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 9), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 15), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(22369375), Int(36)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 12), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 18), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Int(30856776)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 21), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 5)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.THOU] = Mul(
+        Int(39370100), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YARD] = Mul(
+        Rat(Int("9842525000"), Int(9)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 33), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 30), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.GIGAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 12), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Int(1495978707)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 20), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 4), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.DECAMETER] = Mul(
+        Int(10), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.DECIMETER] = Mul(
+        Int(1000), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 17), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Int(1200)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Int(100)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Int("94607304725808")), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Int(25)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.METER] = Mul(
+        Int(100), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 8), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Int(576000)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 5), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 11), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 7))), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 14), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(7086618), Int(25)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 5)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Int(3600)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 26), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 23), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.HECTOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.ANGSTROM] = Mul(
+        Rat(Pow(10, 14), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(100), Int("588968312924607")), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.ATTOMETER] = Mul(
+        Rat(Pow(10, 22), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.CENTIMETER] = Mul(
+        Rat(Pow(10, 6), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1000), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.DECIMETER] = Mul(
+        Rat(Pow(10, 5), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 14))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Pow(10, 19), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.FOOT] = Mul(
+        Rat(Int(1), Int(12)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 5))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(100), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(10), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(25), Int("9311747619463833852")), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.LINE] = Mul(
+        Int(12), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Int(39370100)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.METER] = Mul(
+        Rat(Pow(10, 4), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.MICROMETER] = Mul(
+        Rat(Pow(10, 10), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.MILE] = Mul(
+        Rat(Int(1), Int(63360)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.MILLIMETER] = Mul(
+        Rat(Pow(10, 7), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.NANOMETER] = Mul(
+        Rat(Pow(10, 13), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int("12148343567976"), Pow(10, 5))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 11))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.PICOMETER] = Mul(
+        Rat(Pow(10, 16), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.POINT] = Mul(
+        Int(72), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 8))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.THOU] = Mul(
+        Rat(Int(1), Int(1000)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.YARD] = Mul(
+        Rat(Int(1), Int(36)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Pow(10, 28), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 20))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Pow(10, 25), Int(393701)), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.INCH][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 17))), Sym("in")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 13), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(10), Int(1495978707)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 21), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 5), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.DECAMETER] = Mul(
+        Int(100), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 4), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 18), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Int(120)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.HECTOMETER] = Mul(
+        Int(10), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Int(10)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(5), Int("47303652362904")), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(2362206), Int(5)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.METER] = Mul(
+        Int(1000), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 9), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Int(57600)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 6), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 12), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 6))), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 15), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(14173236), Int(5)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 4)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Int(360)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 27), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 24), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.KILOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ANGSTROM] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 12)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int("431996825232"), Int(6830953)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ATTOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 20)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.CENTIMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 4)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.DECAMETER] = Mul(
+        Int("946073047258080"), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.DECIMETER] = Mul(
+        Int("94607304725808000"), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.EXAMETER] = Mul(
+        Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 12))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.FEMTOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 17)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.FOOT] = Mul(
+        Rat(Int("775978968288652821"), Int(25)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int("5912956545363"), Int(625000)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.HECTOMETER] = Mul(
+        Int("94607304725808"), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.INCH] = Mul(
+        Rat(Int("9311747619463833852"), Int(25)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.KILOMETER] = Mul(
+        Rat(Int("47303652362904"), Int(5)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.LINE] = Mul(
+        Rat(Int("111740971433566006224"), Int(25)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int("5912956545363"), Int(625)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.METER] = Mul(
+        Int("9460730472580800"), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MICROMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 8)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MILE] = Mul(
+        Rat(Int("23514514190565237"), Int(4000)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.MILLIMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 5)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.NANOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 11)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PARSEC] = Mul(
+        Rat(Int("1970985515121"), Mul(Int(6428495), Pow(10, 6))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PETAMETER] = Mul(
+        Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 9))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.PICOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 14)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.POINT] = Mul(
+        Rat(Int("670445828601396037344"), Int(25)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.TERAMETER] = Mul(
+        Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 6))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.THOU] = Mul(
+        Rat(Int("2327936904865958463"), Int(6250)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YARD] = Mul(
+        Rat(Int("258659656096217607"), Int(25)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YOCTOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 26)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 18))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ZEPTOMETER] = Mul(
+        Mul(Int("94607304725808"), Pow(10, 23)), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LIGHTYEAR][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int("5912956545363"), Mul(Int(625), Pow(10, 15))), Sym("ly")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.ANGSTROM] = Mul(
+        Rat(Mul(Int(25), Pow(10, 12)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(25), Int("1766904938773821")), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.ATTOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 20)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.CENTIMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 4)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(250), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(25000), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 14))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 17)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.FOOT] = Mul(
+        Rat(Int(1), Int(144)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 5))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(25), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.INCH] = Mul(
+        Rat(Int(1), Int(12)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(5), Int(2362206)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(25), Int("111740971433566006224")), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Int(472441200)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.METER] = Mul(
+        Rat(Int(2500), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.MICROMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 8)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.MILE] = Mul(
+        Rat(Int(1), Int(760320)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.MILLIMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 5)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.NANOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 11)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int("145780122815712"), Pow(10, 5))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 11))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.PICOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 14)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.POINT] = Mul(
+        Int(6), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 8))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.THOU] = Mul(
+        Rat(Int(1), Int(12000)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.YARD] = Mul(
+        Rat(Int(1), Int(432)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 26)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 20))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Mul(Int(25), Pow(10, 23)), Int(1181103)), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.LINE][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(4724412), Pow(10, 17))), Sym("li")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 16), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 4), Int(1495978707)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 24), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 8), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 5), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 7), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 21), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(9842525), Int(3)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 4), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.INCH] = Mul(
+        Int(39370100), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.KILOMETER] = Mul(
+        Int(1000), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(625), Int("5912956545363")), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.LINE] = Mul(
+        Int(472441200), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 6), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 12), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(178955), Int(288)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 9), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 15), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Int("30856776000")), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 18), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.POINT] = Mul(
+        Int("2834647200"), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Int(10)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(9842525), Int(9)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 30), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 27), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MEGAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 10), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Int("149597870700")), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 18), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.CENTIMETER] = Mul(
+        Int(100), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.DECIMETER] = Mul(
+        Int(10), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 15), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 4))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Int(100)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 4)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Int("9460730472580800")), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Int(2500)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 6), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 5))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.MILLIMETER] = Mul(
+        Int(1000), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 9), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 9))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 12), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Int(1250)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 7)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 4))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 24), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 21), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.METER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 4), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 8))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 12), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 9), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 10))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 10)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 8))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 8))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 11))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.NANOMETER] = Mul(
+        Int(1000), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 15))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 6), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 7))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 13)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 10))), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 18), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 15), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MICROMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("microm")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.ANGSTROM] = Mul(
+        Rat(Mul(Int(576), Pow(10, 15)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(192000), Int("17847524634079")), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.ATTOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 23)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.CENTIMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 7)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.DECAMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 4)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.DECIMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 6)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(9), Mul(Int(559234375), Pow(10, 7))), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 20)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.FOOT] = Mul(
+        Int(5280), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(36), Int(22369375)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(576000), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.INCH] = Mul(
+        Int(63360), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(57600), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(4000), Int("23514514190565237")), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.LINE] = Mul(
+        Int(760320), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(288), Int(178955)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.METER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 5)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.MICROMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 11)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.MILLIMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 8)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.NANOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 14)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.PARSEC] = Mul(
+        Rat(Int(3), Int("57520566136250")), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(9), Mul(Int(559234375), Pow(10, 4))), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.PICOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 17)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.POINT] = Mul(
+        Int(4561920), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(9), Int("5592343750")), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.THOU] = Mul(
+        Rat(Int(1584), Int(25)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.YARD] = Mul(
+        Int(1760), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 29)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(9), Mul(Int(559234375), Pow(10, 13))), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Mul(Int(576), Pow(10, 26)), Int(35791)), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILE][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(9), Mul(Int(559234375), Pow(10, 10))), Sym("mi")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 7), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 5))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 15), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Int(10)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Int(100)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 12), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 7))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 7)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 5))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 5))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MICROMETER] = Mul(
+        Int(1000), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 8))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 6), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 12))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 9), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 4))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 10)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 7))), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 21), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 18), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.MILLIMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("millim")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ANGSTROM] = Mul(
+        Int(10), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 11))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 9), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 6), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 13))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 13)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 11))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 11))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 14))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 18))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.PICOMETER] = Mul(
+        Int(1000), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 10))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 16)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 13))), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 15), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 12), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.NANOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ANGSTROM] = Mul(
+        Mul(Int(30856776), Pow(10, 19)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Mul(Int(10285592), Pow(10, 7)), Int(498659569)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ATTOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 27)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.CENTIMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 11)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.DECAMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 8)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.DECIMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 10)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(3857097), Mul(Int(125), Pow(10, 6))), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.FEMTOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 24)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.FOOT] = Mul(
+        Mul(Int("1012361963998"), Pow(10, 5)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.GIGAMETER] = Mul(
+        Int(30856776), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.HECTOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 7)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.INCH] = Mul(
+        Mul(Int("12148343567976"), Pow(10, 5)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.KILOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 6)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(6428495), Pow(10, 6)), Int("1970985515121")), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.LINE] = Mul(
+        Mul(Int("145780122815712"), Pow(10, 5)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MEGAMETER] = Mul(
+        Int("30856776000"), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.METER] = Mul(
+        Mul(Int(30856776), Pow(10, 9)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MICROMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 15)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MILE] = Mul(
+        Rat(Int("57520566136250"), Int(3)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.MILLIMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 12)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.NANOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 18)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(3857097), Int(125000)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.PICOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 21)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.POINT] = Mul(
+        Mul(Int("874680736894272"), Pow(10, 5)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(3857097), Int(125)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.THOU] = Mul(
+        Int("1214834356797600"), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int("1012361963998"), Pow(10, 5)), Int(3)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YOCTOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 33)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(3857097), Mul(Int(125), Pow(10, 12))), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ZEPTOMETER] = Mul(
+        Mul(Int(30856776), Pow(10, 30)), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PARSEC][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(3857097), Mul(Int(125), Pow(10, 9))), Sym("pc")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 25), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 13), Int(1495978707)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 33), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 17), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 14), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 16), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 30), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 9)), Int(3)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.GIGAMETER] = Mul(
+        Pow(10, 6), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 13), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 11)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 12), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(625), Pow(10, 9)), Int("5912956545363")), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 11)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MEGAMETER] = Mul(
+        Pow(10, 9), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 15), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 21), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MILE] = Mul(
+        Rat(Mul(Int(559234375), Pow(10, 4)), Int(9)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 18), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 24), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(125000), Int(3857097)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 27), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 11)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.TERAMETER] = Mul(
+        Int(1000), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.THOU] = Mul(
+        Mul(Int(393701), Pow(10, 8)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 9)), Int(9)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 39), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 36), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PETAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ANGSTROM] = Mul(
+        Rat(Int(1), Int(100)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 14))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 6), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Int(1000), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 16))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 16)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 14))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 14))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 17))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 21))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 13))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 19)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 16))), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 12), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 9), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.PICOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.ANGSTROM] = Mul(
+        Rat(Mul(Int(125), Pow(10, 11)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(25), Int("10601429632642926")), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.ATTOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 19)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(125000), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(125), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(12500), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 14))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 16)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.FOOT] = Mul(
+        Rat(Int(1), Int(864)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 5))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(25), Int(7086618)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.INCH] = Mul(
+        Rat(Int(1), Int(72)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(5), Int(14173236)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(25), Int("670445828601396037344")), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.LINE] = Mul(
+        Rat(Int(1), Int(6)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Int("2834647200")), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.METER] = Mul(
+        Rat(Int(1250), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.MICROMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 7)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.MILE] = Mul(
+        Rat(Int(1), Int(4561920)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.MILLIMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 4)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.NANOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 10)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int("874680736894272"), Pow(10, 5))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 11))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.PICOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 13)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 8))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.THOU] = Mul(
+        Rat(Int(1), Int(72000)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.YARD] = Mul(
+        Rat(Int(1), Int(2592)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 25)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 20))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Mul(Int(125), Pow(10, 22)), Int(3543309)), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.POINT][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(28346472), Pow(10, 17))), Sym("pt")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 22), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 10), Int(1495978707)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 30), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 14), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 11), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 13), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 27), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 6)), Int(3)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.GIGAMETER] = Mul(
+        Int(1000), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 10), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 8)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 9), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(625), Pow(10, 6)), Int("5912956545363")), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 8)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MEGAMETER] = Mul(
+        Pow(10, 6), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 12), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 18), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MILE] = Mul(
+        Rat(Int("5592343750"), Int(9)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 15), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 21), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(125), Int(3857097)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 24), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 8)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.THOU] = Mul(
+        Mul(Int(393701), Pow(10, 5)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 6)), Int(9)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 36), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 33), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.TERAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("teram")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.ANGSTROM] = Mul(
+        Rat(Pow(10, 17), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 5), Int("588968312924607")), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.ATTOMETER] = Mul(
+        Rat(Pow(10, 25), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.CENTIMETER] = Mul(
+        Rat(Pow(10, 9), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.DECAMETER] = Mul(
+        Rat(Pow(10, 6), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.DECIMETER] = Mul(
+        Rat(Pow(10, 8), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 11))), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Pow(10, 22), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.FOOT] = Mul(
+        Rat(Int(250), Int(3)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Int(39370100)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.HECTOMETER] = Mul(
+        Rat(Pow(10, 5), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.INCH] = Mul(
+        Int(1000), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.KILOMETER] = Mul(
+        Rat(Pow(10, 4), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(6250), Int("2327936904865958463")), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.LINE] = Mul(
+        Int(12000), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(10), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.METER] = Mul(
+        Rat(Pow(10, 7), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.MICROMETER] = Mul(
+        Rat(Pow(10, 13), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.MILE] = Mul(
+        Rat(Int(25), Int(1584)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.MILLIMETER] = Mul(
+        Rat(Pow(10, 10), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.NANOMETER] = Mul(
+        Rat(Pow(10, 16), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Int("1214834356797600")), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 8))), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.PICOMETER] = Mul(
+        Rat(Pow(10, 19), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.POINT] = Mul(
+        Int(72000), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 5))), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.YARD] = Mul(
+        Rat(Int(250), Int(9)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Pow(10, 31), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 17))), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Pow(10, 28), Int(393701)), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.THOU][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Mul(Int(393701), Pow(10, 14))), Sym("thou")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.ANGSTROM] = Mul(
+        Rat(Mul(Int(36), Pow(10, 14)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1200), Int("196322770974869")), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.ATTOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 22)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.CENTIMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 6)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(36000), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.DECIMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 5)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(9), Mul(Int(9842525), Pow(10, 12))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 19)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.FOOT] = Mul(
+        Int(3), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(9), Int("9842525000")), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(3600), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.INCH] = Mul(
+        Int(36), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(360), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(25), Int("258659656096217607")), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.LINE] = Mul(
+        Int(432), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(9), Int(9842525)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.METER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 4)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.MICROMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 10)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.MILE] = Mul(
+        Rat(Int(1), Int(1760)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.MILLIMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 7)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.NANOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 13)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.PARSEC] = Mul(
+        Rat(Int(3), Mul(Int("1012361963998"), Pow(10, 5))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(9), Mul(Int(9842525), Pow(10, 9))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.PICOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 16)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.POINT] = Mul(
+        Int(2592), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(9), Mul(Int(9842525), Pow(10, 6))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.THOU] = Mul(
+        Rat(Int(9), Int(250)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.YOCTOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 28)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(9), Mul(Int(9842525), Pow(10, 18))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Mul(Int(36), Pow(10, 25)), Int(393701)), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YARD][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(9), Mul(Int(9842525), Pow(10, 15))), Sym("yd")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ANGSTROM] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 26))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ATTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 28))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 28)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 26))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 26))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 29))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 33))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.PICOMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 25))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 31)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 28))), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOCTOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 34), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 22), Int(1495978707)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 42), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 26), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 23), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 25), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.EXAMETER] = Mul(
+        Pow(10, 6), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 39), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 18)), Int(3)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.GIGAMETER] = Mul(
+        Pow(10, 15), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 22), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 20)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 21), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(625), Pow(10, 18)), Int("5912956545363")), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 20)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MEGAMETER] = Mul(
+        Pow(10, 18), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 24), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 30), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MILE] = Mul(
+        Rat(Mul(Int(559234375), Pow(10, 13)), Int(9)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 27), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 33), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Mul(Int(125), Pow(10, 12)), Int(3857097)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PETAMETER] = Mul(
+        Pow(10, 9), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 36), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 20)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.TERAMETER] = Mul(
+        Pow(10, 12), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.THOU] = Mul(
+        Mul(Int(393701), Pow(10, 17)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 18)), Int(9)), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 48), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 45), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.YOTTAMETER][UnitsLength.ZETTAMETER] = Mul(
+        Int(1000), Sym("yottam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ANGSTROM] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Int(1), Mul(Int(1495978707), Pow(10, 23))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ATTOMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.CENTIMETER] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.DECAMETER] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.DECIMETER] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.EXAMETER] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.FEMTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.FOOT] = Mul(
+        Rat(Int(393701), Mul(Int(12), Pow(10, 25))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.GIGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.HECTOMETER] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.INCH] = Mul(
+        Rat(Int(393701), Pow(10, 25)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.KILOMETER] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Int(1), Mul(Int("94607304725808"), Pow(10, 23))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.LINE] = Mul(
+        Rat(Int(1181103), Mul(Int(25), Pow(10, 23))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MEGAMETER] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.METER] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MICROMETER] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MILE] = Mul(
+        Rat(Int(35791), Mul(Int(576), Pow(10, 26))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.MILLIMETER] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.NANOMETER] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Int(1), Mul(Int(30856776), Pow(10, 30))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PETAMETER] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.PICOMETER] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.POINT] = Mul(
+        Rat(Int(3543309), Mul(Int(125), Pow(10, 22))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.TERAMETER] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.THOU] = Mul(
+        Rat(Int(393701), Pow(10, 28)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YARD] = Mul(
+        Rat(Int(393701), Mul(Int(36), Pow(10, 25))), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YOCTOMETER] = Mul(
+        Int(1000), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZEPTOMETER][UnitsLength.ZETTAMETER] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptom")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ANGSTROM] = Mul(
+        Pow(10, 31), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ASTRONOMICALUNIT] = Mul(
+        Rat(Pow(10, 19), Int(1495978707)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ATTOMETER] = Mul(
+        Pow(10, 39), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.CENTIMETER] = Mul(
+        Pow(10, 23), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.DECAMETER] = Mul(
+        Pow(10, 20), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.DECIMETER] = Mul(
+        Pow(10, 22), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.EXAMETER] = Mul(
+        Int(1000), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.FEMTOMETER] = Mul(
+        Pow(10, 36), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.FOOT] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 15)), Int(3)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.GIGAMETER] = Mul(
+        Pow(10, 12), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.HECTOMETER] = Mul(
+        Pow(10, 19), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.INCH] = Mul(
+        Mul(Int(393701), Pow(10, 17)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.KILOMETER] = Mul(
+        Pow(10, 18), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.LIGHTYEAR] = Mul(
+        Rat(Mul(Int(625), Pow(10, 15)), Int("5912956545363")), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.LINE] = Mul(
+        Mul(Int(4724412), Pow(10, 17)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MEGAMETER] = Mul(
+        Pow(10, 15), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.METER] = Mul(
+        Pow(10, 21), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MICROMETER] = Mul(
+        Pow(10, 27), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MILE] = Mul(
+        Rat(Mul(Int(559234375), Pow(10, 10)), Int(9)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.MILLIMETER] = Mul(
+        Pow(10, 24), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.NANOMETER] = Mul(
+        Pow(10, 30), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PARSEC] = Mul(
+        Rat(Mul(Int(125), Pow(10, 9)), Int(3857097)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PETAMETER] = Mul(
+        Pow(10, 6), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.PICOMETER] = Mul(
+        Pow(10, 33), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.POINT] = Mul(
+        Mul(Int(28346472), Pow(10, 17)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.TERAMETER] = Mul(
+        Pow(10, 9), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.THOU] = Mul(
+        Mul(Int(393701), Pow(10, 14)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YARD] = Mul(
+        Rat(Mul(Int(9842525), Pow(10, 15)), Int(9)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YOCTOMETER] = Mul(
+        Pow(10, 45), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.YOTTAMETER] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettam")
+    )  # nopep8
+    CONVERSIONS[UnitsLength.ZETTAMETER][UnitsLength.ZEPTOMETER] = Mul(
+        Pow(10, 42), Sym("zettam")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -2083,9 +3076,7 @@ class LengthI(_omero_model.Length, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsLength, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.LengthI):
             # This is a copy-constructor call.
@@ -2133,5 +3124,6 @@ class LengthI(_omero_model.Length, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.LengthI = LengthI

--- a/src/omero_model_PermissionsI.py
+++ b/src/omero_model_PermissionsI.py
@@ -14,6 +14,7 @@ import omero.constants.permissions as ocp
 
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Permissions_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -30,7 +31,6 @@ object #0 (::omero::model::Permissions)
 
 
 class PermissionsI(_omero_model.Permissions):
-
     def __init__(self, l=None):
         super(PermissionsI, self).__init__()
         self.__immutable = False
@@ -49,9 +49,9 @@ class PermissionsI(_omero_model.Permissions):
     def set(self, mask, shift, on):
         self.throwIfImmutable()
         if on:
-            self._perm1 = (self._perm1 | (0 | (mask << shift)))
+            self._perm1 = self._perm1 | (0 | (mask << shift))
         else:
-            self._perm1 = (self._perm1 & (-1 ^ (mask << shift)))
+            self._perm1 = self._perm1 & (-1 ^ (mask << shift))
 
     # shift 8; mask 4
     def isUserRead(self):
@@ -165,8 +165,9 @@ class PermissionsI(_omero_model.Permissions):
         takes a string.
         """
         import re
+
         base = r"([rR\-_])([aAwW\-_])"
-        regex = re.compile(r"^(L?)%s$" % (base*3))
+        regex = re.compile(r"^(L?)%s$" % (base * 3))
         match = regex.match(perms)
         if match is None:
             raise ValueError("Invalid permission string: %s" % perms)
@@ -237,8 +238,9 @@ class PermissionsI(_omero_model.Permissions):
         if it's true.
         """
         if self.__immutable:
-            raise _omero.ClientError("ImmutablePermissions: %s" %
-                                     self.__str__())
+            raise _omero.ClientError(
+                "ImmutablePermissions: %s" % self.__str__()
+            )
 
     def ice_postUnmarshal(self):
         """
@@ -274,12 +276,15 @@ class PermissionsI(_omero_model.Permissions):
                 else:
                     raise
 
+
 _omero_model.PermissionsI = PermissionsI
 
 
 def _test():
     import doctest
+
     doctest.testmod()
+
 
 if __name__ == "__main__":
     _test()

--- a/src/omero_model_PowerI.py
+++ b/src/omero_model_PowerI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Power_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,846 +52,1266 @@ class PowerI(_omero_model.Power, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.NANOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.PICOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 6), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Int(1000), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attow"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 16), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 13), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 4), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MILLIWATT] = \
-        Mul(Int(10), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 7), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 10), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 22), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 19), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centiw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 19), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Int(1000), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.DECIWATT] = \
-        Mul(Int(100), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 16), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 7), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 4), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 10), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 13), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.WATT] = \
-        Mul(Int(10), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 25), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 22), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decaw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 17), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.CENTIWATT] = \
-        Mul(Int(10), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 14), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 5), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MILLIWATT] = \
-        Mul(Int(100), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 8), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 11), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 23), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 20), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("deciw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 36), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 20), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 17), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 19), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 33), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Pow(10, 9), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 16), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 15), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Pow(10, 12), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 24), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 21), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 27), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.PETAWATT] = \
-        Mul(Int(1000), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 30), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.TERAWATT] = \
-        Mul(Pow(10, 6), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 18), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 42), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 39), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exaw"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Int(1000), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.NANOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.PICOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 9), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 6), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtow"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 27), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 11), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 8), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 10), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 24), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 7), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 6), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Int(1000), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 15), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 12), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 18), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 21), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 9), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 33), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 30), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigaw"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 20), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 4), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.DECAWATT] = \
-        Mul(Int(10), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.DECIWATT] = \
-        Mul(Int(1000), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 17), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 8), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 5), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 11), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 14), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.WATT] = \
-        Mul(Int(100), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 26), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 23), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 21), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 5), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.DECAWATT] = \
-        Mul(Int(100), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 4), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 18), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Int(10), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 9), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 6), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 12), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 15), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.WATT] = \
-        Mul(Int(1000), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 27), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 24), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilow"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 24), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 8), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 5), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 7), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 21), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 4), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.KILOWATT] = \
-        Mul(Int(1000), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 12), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 9), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 15), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 18), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 6), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 30), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 27), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megaw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 12), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 9), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.NANOWATT] = \
-        Mul(Int(1000), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 6), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 18), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 15), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("microw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 15), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 12), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.MICROWATT] = \
-        Mul(Int(1000), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 6), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 9), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 21), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 18), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("milliw"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 9), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 6), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.PICOWATT] = \
-        Mul(Int(1000), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 15), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 12), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanow"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 33), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 17), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 14), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 16), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 30), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Pow(10, 6), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 13), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 12), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Pow(10, 9), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 21), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 18), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 24), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 27), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.TERAWATT] = \
-        Mul(Int(1000), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 15), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 39), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 36), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petaw"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 6), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Int(1000), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.NANOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 12), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 9), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picow"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 30), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 14), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 11), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 13), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 27), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Int(1000), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 10), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 9), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Pow(10, 6), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 18), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 15), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 21), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 24), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 12), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 36), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 33), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("teraw"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 18), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.CENTIWATT] = \
-        Mul(Int(100), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Int(10)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.DECIWATT] = \
-        Mul(Int(10), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 15), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Int(100)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 6), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.MILLIWATT] = \
-        Mul(Int(1000), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 9), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 12), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 24), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 21), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.WATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("w"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.NANOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.PICOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctow"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 42), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 26), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 23), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 25), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.EXAWATT] = \
-        Mul(Pow(10, 6), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 39), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Pow(10, 15), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 22), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 21), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Pow(10, 18), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 30), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 27), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 33), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.PETAWATT] = \
-        Mul(Pow(10, 9), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 36), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.TERAWATT] = \
-        Mul(Pow(10, 12), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 24), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 48), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 45), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Int(1000), Sym("yottaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.ATTOWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.CENTIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.DECAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.DECIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.EXAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.GIGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.HECTOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.KILOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MEGAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MICROWATT] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MILLIWATT] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.NANOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.PETAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.PICOWATT] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.TERAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.WATT] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Int(1000), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.ZETTAWATT] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptow"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.ATTOWATT] = \
-        Mul(Pow(10, 39), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.CENTIWATT] = \
-        Mul(Pow(10, 23), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.DECAWATT] = \
-        Mul(Pow(10, 20), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.DECIWATT] = \
-        Mul(Pow(10, 22), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.EXAWATT] = \
-        Mul(Int(1000), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.FEMTOWATT] = \
-        Mul(Pow(10, 36), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.GIGAWATT] = \
-        Mul(Pow(10, 12), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.HECTOWATT] = \
-        Mul(Pow(10, 19), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.KILOWATT] = \
-        Mul(Pow(10, 18), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MEGAWATT] = \
-        Mul(Pow(10, 15), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MICROWATT] = \
-        Mul(Pow(10, 27), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MILLIWATT] = \
-        Mul(Pow(10, 24), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.NANOWATT] = \
-        Mul(Pow(10, 30), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.PETAWATT] = \
-        Mul(Pow(10, 6), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.PICOWATT] = \
-        Mul(Pow(10, 33), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.TERAWATT] = \
-        Mul(Pow(10, 9), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.WATT] = \
-        Mul(Pow(10, 21), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.YOCTOWATT] = \
-        Mul(Pow(10, 45), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.YOTTAWATT] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettaw"))  # nopep8
-    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.ZEPTOWATT] = \
-        Mul(Pow(10, 42), Sym("zettaw"))  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.NANOWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.PICOWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 6), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Int(1000), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ATTOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 16), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 13), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 4), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.MILLIWATT] = Mul(
+        Int(10), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 7), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 10), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Int(100)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 22), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 19), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.CENTIWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centiw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 19), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.CENTIWATT] = Mul(
+        Int(1000), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.DECIWATT] = Mul(
+        Int(100), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 16), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Int(100)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 7), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 4), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 10), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 13), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.WATT] = Mul(
+        Int(10), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 25), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 22), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 17), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.CENTIWATT] = Mul(
+        Int(10), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Int(100)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 14), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 5), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.MILLIWATT] = Mul(
+        Int(100), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 8), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 11), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 23), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 20), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.DECIWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("deciw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 36), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 20), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 17), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 19), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 33), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.GIGAWATT] = Mul(
+        Pow(10, 9), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 16), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 15), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MEGAWATT] = Mul(
+        Pow(10, 12), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 24), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 21), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 27), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.PETAWATT] = Mul(
+        Int(1000), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 30), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.TERAWATT] = Mul(
+        Pow(10, 6), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 18), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 42), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 39), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.EXAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ATTOWATT] = Mul(
+        Int(1000), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.NANOWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.PICOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 9), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 6), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.FEMTOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 27), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 11), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 8), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 10), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 24), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 7), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 6), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MEGAWATT] = Mul(
+        Int(1000), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 15), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 12), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 18), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 21), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 9), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 33), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 30), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.GIGAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 20), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 4), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.DECAWATT] = Mul(
+        Int(10), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.DECIWATT] = Mul(
+        Int(1000), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 17), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 8), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 5), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 11), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 14), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.WATT] = Mul(
+        Int(100), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 26), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 23), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.HECTOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 21), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 5), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.DECAWATT] = Mul(
+        Int(100), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 4), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 18), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.HECTOWATT] = Mul(
+        Int(10), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 9), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 6), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 12), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 15), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.WATT] = Mul(
+        Int(1000), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 27), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 24), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.KILOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 24), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 8), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 5), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 7), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 21), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 4), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.KILOWATT] = Mul(
+        Int(1000), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 12), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 9), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 15), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 18), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 6), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 30), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 27), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MEGAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 12), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 9), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.NANOWATT] = Mul(
+        Int(1000), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 6), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 18), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 15), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MICROWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("microw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 15), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Int(100)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 12), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.MICROWATT] = Mul(
+        Int(1000), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 6), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 9), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 21), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 18), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.MILLIWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("milliw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 9), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 6), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.PICOWATT] = Mul(
+        Int(1000), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 15), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 12), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.NANOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 33), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 17), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 14), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 16), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 30), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.GIGAWATT] = Mul(
+        Pow(10, 6), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 13), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 12), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MEGAWATT] = Mul(
+        Pow(10, 9), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 21), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 18), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 24), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 27), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.TERAWATT] = Mul(
+        Int(1000), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 15), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 39), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 36), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PETAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 6), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Int(1000), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.NANOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 12), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 9), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.PICOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 30), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 14), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 11), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 13), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 27), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.GIGAWATT] = Mul(
+        Int(1000), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 10), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 9), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MEGAWATT] = Mul(
+        Pow(10, 6), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 18), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 15), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 21), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 24), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 12), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 36), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 33), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.TERAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("teraw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 18), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.CENTIWATT] = Mul(
+        Int(100), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Int(10)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.DECIWATT] = Mul(
+        Int(10), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 15), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Int(100)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 6), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.MILLIWATT] = Mul(
+        Int(1000), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 9), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 12), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 24), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 21), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.WATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("w")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ATTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.NANOWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.PICOWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOCTOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 42), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 26), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 23), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 25), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.EXAWATT] = Mul(
+        Pow(10, 6), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 39), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.GIGAWATT] = Mul(
+        Pow(10, 15), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 22), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 21), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MEGAWATT] = Mul(
+        Pow(10, 18), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 30), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 27), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 33), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.PETAWATT] = Mul(
+        Pow(10, 9), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 36), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.TERAWATT] = Mul(
+        Pow(10, 12), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 24), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 48), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 45), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.YOTTAWATT][UnitsPower.ZETTAWATT] = Mul(
+        Int(1000), Sym("yottaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.ATTOWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.CENTIWATT] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.DECAWATT] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.DECIWATT] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.EXAWATT] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.FEMTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.GIGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.HECTOWATT] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.KILOWATT] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MEGAWATT] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MICROWATT] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.MILLIWATT] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.NANOWATT] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.PETAWATT] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.PICOWATT] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.TERAWATT] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.WATT] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.YOCTOWATT] = Mul(
+        Int(1000), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZEPTOWATT][UnitsPower.ZETTAWATT] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptow")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.ATTOWATT] = Mul(
+        Pow(10, 39), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.CENTIWATT] = Mul(
+        Pow(10, 23), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.DECAWATT] = Mul(
+        Pow(10, 20), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.DECIWATT] = Mul(
+        Pow(10, 22), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.EXAWATT] = Mul(
+        Int(1000), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.FEMTOWATT] = Mul(
+        Pow(10, 36), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.GIGAWATT] = Mul(
+        Pow(10, 12), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.HECTOWATT] = Mul(
+        Pow(10, 19), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.KILOWATT] = Mul(
+        Pow(10, 18), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MEGAWATT] = Mul(
+        Pow(10, 15), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MICROWATT] = Mul(
+        Pow(10, 27), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.MILLIWATT] = Mul(
+        Pow(10, 24), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.NANOWATT] = Mul(
+        Pow(10, 30), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.PETAWATT] = Mul(
+        Pow(10, 6), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.PICOWATT] = Mul(
+        Pow(10, 33), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.TERAWATT] = Mul(
+        Pow(10, 9), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.WATT] = Mul(
+        Pow(10, 21), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.YOCTOWATT] = Mul(
+        Pow(10, 45), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.YOTTAWATT] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettaw")
+    )  # nopep8
+    CONVERSIONS[UnitsPower.ZETTAWATT][UnitsPower.ZEPTOWATT] = Mul(
+        Pow(10, 42), Sym("zettaw")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -926,9 +1347,7 @@ class PowerI(_omero_model.Power, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsPower, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.PowerI):
             # This is a copy-constructor call.
@@ -976,5 +1395,6 @@ class PowerI(_omero_model.Power, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.PowerI = PowerI

--- a/src/omero_model_PressureI.py
+++ b/src/omero_model_PressureI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Pressure_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,1990 +52,2982 @@ class PressureI(_omero_model.Pressure, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ATTOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 18)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.BAR] = \
-        Mul(Rat(Int(4053), Int(4000)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(4053), Int(40)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.CENTIPASCAL] = \
-        Mul(Int(10132500), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(20265), Int(2)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(4053), Int(400)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECIPASCAL] = \
-        Mul(Int(1013250), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 16))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 15)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 7))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(4053), Int(4)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 6))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(4053), Int(40)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 9))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 4))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MICROPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 6)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(4053), Int(4)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLIPASCAL] = \
-        Mul(Int(101325000), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Int(25)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(965), Pow(10, 9)), Int(1269737023)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.NANOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 9)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 13))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PICOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 12)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(120625), Pow(10, 9)), Int("8208044396629")), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PASCAL] = \
-        Mul(Int(101325), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 10))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.TORR] = \
-        Mul(Int(760), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 24)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 22))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Mul(Int(101325), Pow(10, 21)), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(4), Pow(10, 19))), Sym("atm"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 18))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 29)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Mul(Int("133322387415"), Pow(10, 9))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 7))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 6), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Int(1000), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(4000), Int(4053)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 23), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.CENTIBAR] = \
-        Mul(Int(100), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 7), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 4), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECIBAR] = \
-        Mul(Int(10), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 6), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 20), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Int(1000), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.KILOPASCAL] = \
-        Mul(Int(100), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 11), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLIBAR] = \
-        Mul(Int(1000), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 8), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(3040), Int(4053)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 13)), Int("26664477483")), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 14), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 17), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 14)), Int("172368932329209")), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 5), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 29), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 26), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("bar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(40), Int(4053)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 21), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 5), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Int(100), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 4), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 18), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Int(10), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.KILOPASCAL] = \
-        Sym("cbar")  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 9), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLIBAR] = \
-        Mul(Int(10), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 6), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(152), Int(20265)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 11)), Int("26664477483")), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 12), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 15), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PASCAL] = \
-        Mul(Int(1000), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.TORR] = \
-        Mul(Rat(Int(30400), Int(4053)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 27), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 24), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("cbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Int(10132500)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 16), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 13), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 4), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Int(10), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Int(253312500)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 6)), Int("26664477483")), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 7), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 10), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 7)), Int("172368932329209")), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(38), Int(506625)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 22), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 19), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(2), Int(20265)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 19), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Int(1000), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Int(100), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 16), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 7), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 4), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(38), Int(506625)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 9)), Int("26664477483")), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 10), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 13), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 10)), Int("172368932329209")), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Int(10), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(304), Int(4053)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 25), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 22), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(400), Int(4053)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 22), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.CENTIBAR] = \
-        Mul(Int(10), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 6), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Int(1000), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 5), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 19), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Int(100), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.KILOPASCAL] = \
-        Mul(Int(10), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 10), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLIBAR] = \
-        Mul(Int(100), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 7), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(304), Int(4053)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 12)), Int("26664477483")), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 13), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 16), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 13)), Int("172368932329209")), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 4), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.TORR] = \
-        Mul(Rat(Int(304000), Int(4053)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 28), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 25), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("dbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Int(1013250)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 17), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Int(10), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 14), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 5), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Int(100), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Int(25331250)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 7)), Int("26664477483")), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 8), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 11), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 8)), Int("172368932329209")), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(76), Int(101325)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 23), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 20), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("decipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 16)), Int(4053)), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 36), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 13), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 15), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 20), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 17), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 14), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 19), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 33), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Pow(10, 9), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 16), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Pow(10, 10), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 15), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Pow(10, 7), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 12), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 24), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 16), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 21), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 26)), Int("26664477483")), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 27), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Int(1000), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 30), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 27)), Int("172368932329209")), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 18), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Pow(10, 6), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 42), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 39), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 15))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Int(1000), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Mul(Int("133322387415"), Pow(10, 6))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 4))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 9), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 6), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 7)), Int(4053)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 27), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 4), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 6), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 11), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 8), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 5), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 10), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 24), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 7), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Int(10), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 6), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Int(1000), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 15), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 7), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 12), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 17)), Int("26664477483")), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 18), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 21), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 18)), Int("172368932329209")), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 9), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 33), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 30), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(4), Int(4053)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 20), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 4), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Int(10), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Int(1000), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 17), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 8), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLIBAR] = \
-        Sym("hectopa")  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 5), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(76), Int(101325)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 10)), Int("26664477483")), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 11), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 14), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Int(100), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(3040), Int(4053)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 26), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 23), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 6)), Int(4053)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 26), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.BAR] = \
-        Mul(Int(1000), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 5), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 10), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 7), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 4), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 9), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 23), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 6), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 5), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Int(100), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 14), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 6), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 11), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 16)), Int("26664477483")), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 17), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 20), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 17)), Int("172368932329209")), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 8), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 32), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 29), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("kbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(40), Int(4053)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 21), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.CENTIBAR] = \
-        Sym("kilopa")  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 5), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Int(100), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 4), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 18), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Int(10), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 9), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Int(10), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 6), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(152), Int(20265)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 11)), Int("26664477483")), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 12), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 15), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Int(1000), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(30400), Int(4053)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 27), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 24), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 9)), Int(4053)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 29), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.BAR] = \
-        Mul(Pow(10, 6), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 8), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 13), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 10), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 7), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 12), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 26), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Int(100), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 9), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.KILOBAR] = \
-        Mul(Int(1000), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 8), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 5), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 17), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 9), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 14), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 19)), Int("26664477483")), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 20), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 23), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 20)), Int("172368932329209")), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 11), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 10)), Int(4053)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 35), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 32), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("megabar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 4)), Int(4053)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 24), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.BAR] = \
-        Mul(Int(10), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Int(1000), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 8), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 5), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Int(100), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 7), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 21), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 4), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Int(1000), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 12), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 4), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 9), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(30400), Int(4053)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 14)), Int("26664477483")), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 15), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 18), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 15)), Int("172368932329209")), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 6), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 30), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 27), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 6))), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 12), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 9), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(200), Int("26664477483")), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Int(1000), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 6), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(25000), Int("172368932329209")), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Int("2533125000")), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 18), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 15), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("micropa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(4), Int(4053)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 20), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Int(10)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 4), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECAPASCAL] = \
-        Mul(Int(10), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECIPASCAL] = \
-        Mul(Int(1000), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 17), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.HECTOPASCAL] = \
-        Sym("mbar")  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 8), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 5), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(76), Int(101325)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 10)), Int("26664477483")), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 11), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 14), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PASCAL] = \
-        Mul(Int(100), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.TORR] = \
-        Mul(Rat(Int(3040), Int(4053)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 26), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 23), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("mbar"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Int(101325000)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 15), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 12), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Int(1000), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Int("2533125000")), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 5)), Int("26664477483")), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 6), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 9), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 6)), Int("172368932329209")), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Int(2533125)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 21), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 18), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("millipa"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(25), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 18)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.BAR] = \
-        Mul(Rat(Int(4053), Int(3040)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(20265), Int(152)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(253312500), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(506625), Int(38)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(4053), Int(304)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(25331250), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 15)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 5))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(101325), Int(76)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 4))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(20265), Int(152)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 7))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(4053), Int(30400)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 6)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(101325), Int(76)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int("2533125000"), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(24125), Pow(10, 9)), Int("24125003437")), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(3015625), Pow(10, 9)), Int("155952843535951")), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(2533125), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.TORR] = \
-        Mul(Int(1000), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 24)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 20))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 17))), Sym("mtorr"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1269737023), Mul(Int(965), Pow(10, 9))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ATTOPASCAL] = \
-        Mul(Mul(Int("133322387415"), Pow(10, 9)), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.BAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 13))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 11))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 6))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 9))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 12))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 7))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 26))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Mul(Int("133322387415"), Pow(10, 6)), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 17))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 10))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 16))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 11))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 19))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 14))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int("26664477483"), Int(200)), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 10))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 5))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 9))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.NANOPASCAL] = \
-        Mul(Int("133322387415"), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 23))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PICOPASCAL] = \
-        Mul(Int("133322387415000"), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PSI] = \
-        Mul(Rat(Int("158717127875"), Int("8208044396629")), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 20))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.TORR] = \
-        Mul(Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 6))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Mul(Int("133322387415"), Pow(10, 15)), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 32))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Mul(Int("133322387415"), Pow(10, 12)), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int("26664477483"), Mul(Int(2), Pow(10, 29))), Sym("mmhg"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 9))), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 9), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 6), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Int("133322387415")), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Int(1000), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(25), Int("172368932329209")), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 15), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 12), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 13)), Int(4053)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 33), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 10), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 12), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 17), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 14), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 11), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 16), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 30), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Pow(10, 6), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 13), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Pow(10, 7), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 12), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Pow(10, 4), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 9), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 21), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 13), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 18), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 23)), Int("26664477483")), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 24), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 27), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 24)), Int("172368932329209")), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 15), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Int(1000), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 39), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 36), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 12))), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 6), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Int(1000), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Int("133322387415000")), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(1), Int("6894757293168360")), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 12), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 9), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int("8208044396629"), Mul(Int(120625), Pow(10, 9))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ATTOPASCAL] = \
-        Mul(Mul(Int("689475729316836"), Pow(10, 7)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.BAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 14))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 12))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 7))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 10))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 13))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 8))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 27))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Mul(Int("689475729316836"), Pow(10, 4)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 18))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 11))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 17))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 12))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 20))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 15))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Int(25000)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 11))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 6))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 9))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MMHG] = \
-        Mul(Rat(Int("8208044396629"), Int("158717127875")), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Int(25)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 24))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PICOPASCAL] = \
-        Mul(Int("6894757293168360"), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 21))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.TORR] = \
-        Mul(Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 6))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Mul(Int("689475729316836"), Pow(10, 13)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 33))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Mul(Int("689475729316836"), Pow(10, 10)), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 30))), Sym("psi"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Int(101325)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 18), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Int(100), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Int(10)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Int(10), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 15), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Int(100)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 6), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Int(100)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Int(1000), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Int(2533125)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 8)), Int("26664477483")), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 9), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 12), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 9)), Int("172368932329209")), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(152), Int(20265)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 24), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 21), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("pa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 10)), Int(4053)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 30), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 7), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 9), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 14), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 11), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 8), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 13), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 27), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Int(1000), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 10), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Pow(10, 4), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 9), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Int(10), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 6), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 18), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 10), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 15), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 20)), Int("26664477483")), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 21), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 24), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 21)), Int("172368932329209")), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 12), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 36), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 33), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("terapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Int(760)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ATTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 15)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.BAR] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 4))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(4053), Int(30400)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(506625), Int(38)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(4053), Int(304)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(4053), Int(304000)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(101325), Int(76)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 17))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(4053), Int(3040)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 7))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(4053), Int(30400)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 10))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 5))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int("2533125000"), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(4053), Int(3040)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(2533125), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(24125), Pow(10, 6)), Int("24125003437")), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 6)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(3015625), Pow(10, 6)), Int("155952843535951")), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(20265), Int(152)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 23))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Rat(Mul(Int(2533125), Pow(10, 18)), Int(19)), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(4053), Mul(Int(304), Pow(10, 20))), Sym("torr"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 24))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 29)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 28)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 32)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 35)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 24))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Mul(Int("133322387415"), Pow(10, 15))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 13))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 22)), Int(4053)), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 42), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 19), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 21), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 26), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 23), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 20), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 25), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Pow(10, 6), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 39), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Pow(10, 15), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 22), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Pow(10, 16), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 21), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Pow(10, 13), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 18), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 30), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 22), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 27), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 32)), Int("26664477483")), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 33), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Pow(10, 9), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 36), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 33)), Int("172368932329209")), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 24), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Pow(10, 12), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 23)), Int(4053)), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 48), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 45), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Int(1000), Sym("yottapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Int(1), Mul(Int(101325), Pow(10, 21))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.BAR] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Rat(Int(1), Pow(10, 29)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Rat(Int(1), Pow(10, 32)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Int(1), Mul(Int("133322387415"), Pow(10, 12))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 10))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Int(1000), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ZETTAPASCAL] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptopa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ATMOSPHERE] = \
-        Mul(Rat(Mul(Int(4), Pow(10, 19)), Int(4053)), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ATTOPASCAL] = \
-        Mul(Pow(10, 39), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.BAR] = \
-        Mul(Pow(10, 16), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.CENTIBAR] = \
-        Mul(Pow(10, 18), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.CENTIPASCAL] = \
-        Mul(Pow(10, 23), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECAPASCAL] = \
-        Mul(Pow(10, 20), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECIBAR] = \
-        Mul(Pow(10, 17), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECIPASCAL] = \
-        Mul(Pow(10, 22), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.EXAPASCAL] = \
-        Mul(Int(1000), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.FEMTOPASCAL] = \
-        Mul(Pow(10, 36), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.GIGAPASCAL] = \
-        Mul(Pow(10, 12), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.HECTOPASCAL] = \
-        Mul(Pow(10, 19), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.KILOBAR] = \
-        Mul(Pow(10, 13), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.KILOPASCAL] = \
-        Mul(Pow(10, 18), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MEGABAR] = \
-        Mul(Pow(10, 10), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MEGAPASCAL] = \
-        Mul(Pow(10, 15), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MICROPASCAL] = \
-        Mul(Pow(10, 27), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLIBAR] = \
-        Mul(Pow(10, 19), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLIPASCAL] = \
-        Mul(Pow(10, 24), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLITORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MMHG] = \
-        Mul(Rat(Mul(Int(2), Pow(10, 29)), Int("26664477483")), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.NANOPASCAL] = \
-        Mul(Pow(10, 30), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PETAPASCAL] = \
-        Mul(Pow(10, 6), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PICOPASCAL] = \
-        Mul(Pow(10, 33), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PSI] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 30)), Int("172368932329209")), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PASCAL] = \
-        Mul(Pow(10, 21), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.TERAPASCAL] = \
-        Mul(Pow(10, 9), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.TORR] = \
-        Mul(Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.YOCTOPASCAL] = \
-        Mul(Pow(10, 45), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.YOTTAPASCAL] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettapa"))  # nopep8
-    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ZEPTOPASCAL] = \
-        Mul(Pow(10, 42), Sym("zettapa"))  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ATTOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 18)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.BAR] = Mul(
+        Rat(Int(4053), Int(4000)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(4053), Int(40)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.CENTIPASCAL] = Mul(
+        Int(10132500), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(20265), Int(2)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(4053), Int(400)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.DECIPASCAL] = Mul(
+        Int(1013250), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 16))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.FEMTOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 15)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 7))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(4053), Int(4)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 6))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(4053), Int(40)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 9))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 4))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MICROPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 6)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(4053), Int(4)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLIPASCAL] = Mul(
+        Int(101325000), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Int(25)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(965), Pow(10, 9)), Int(1269737023)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.NANOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 9)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 13))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PICOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 12)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(120625), Pow(10, 9)), Int("8208044396629")), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.PASCAL] = Mul(
+        Int(101325), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 10))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.TORR] = Mul(
+        Int(760), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.YOCTOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 24)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 22))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Mul(Int(101325), Pow(10, 21)), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATMOSPHERE][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(4), Pow(10, 19))), Sym("atm")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 18))), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 29)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Mul(Int("133322387415"), Pow(10, 9))), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 7))), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 6), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Int(1000), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ATTOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(4000), Int(4053)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 23), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.CENTIBAR] = Mul(
+        Int(100), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 7), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 4), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECIBAR] = Mul(
+        Int(10), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 6), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 20), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.HECTOPASCAL] = Mul(
+        Int(1000), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.KILOPASCAL] = Mul(
+        Int(100), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 11), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLIBAR] = Mul(
+        Int(1000), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 8), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(3040), Int(4053)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 13)), Int("26664477483")), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 14), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 17), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 14)), Int("172368932329209")), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 5), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 29), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 26), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.BAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("bar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(40), Int(4053)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 21), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 5), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECAPASCAL] = Mul(
+        Int(100), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 4), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 18), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.HECTOPASCAL] = Mul(
+        Int(10), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.KILOPASCAL] = Sym(
+        "cbar"
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 9), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLIBAR] = Mul(
+        Int(10), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 6), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(152), Int(20265)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 11)), Int("26664477483")), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 12), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 15), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.PASCAL] = Mul(
+        Int(1000), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.TORR] = Mul(
+        Rat(Int(30400), Int(4053)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 27), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 24), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIBAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("cbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Int(10132500)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 16), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 13), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 4), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Int(10), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Int(253312500)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 6)), Int("26664477483")), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 7), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 10), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 7)), Int("172368932329209")), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(38), Int(506625)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 22), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 19), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.CENTIPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(2), Int(20265)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 19), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Int(1000), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Int(100), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 16), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 7), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 4), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(38), Int(506625)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 9)), Int("26664477483")), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 10), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 13), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 10)), Int("172368932329209")), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Int(10), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(304), Int(4053)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 25), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 22), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(400), Int(4053)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 22), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.CENTIBAR] = Mul(
+        Int(10), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 6), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.DECAPASCAL] = Mul(
+        Int(1000), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 5), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 19), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.HECTOPASCAL] = Mul(
+        Int(100), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.KILOPASCAL] = Mul(
+        Int(10), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 10), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLIBAR] = Mul(
+        Int(100), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 7), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(304), Int(4053)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 12)), Int("26664477483")), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 13), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 16), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 13)), Int("172368932329209")), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 4), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.TORR] = Mul(
+        Rat(Int(304000), Int(4053)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 28), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 25), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIBAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("dbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Int(1013250)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 17), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Int(10), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 14), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 5), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Int(100), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Int(25331250)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 7)), Int("26664477483")), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 8), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 11), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 8)), Int("172368932329209")), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(76), Int(101325)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 23), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 20), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.DECIPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("decipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 16)), Int(4053)), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 36), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 13), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 15), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 20), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 17), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 14), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 19), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 33), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Pow(10, 9), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 16), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Pow(10, 10), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 15), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Pow(10, 7), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 12), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 24), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 16), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 21), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 26)), Int("26664477483")), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 27), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Int(1000), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 30), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 27)), Int("172368932329209")), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 18), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Pow(10, 6), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 42), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 39), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.EXAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 15))), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Int(1000), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 15))), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Mul(Int("133322387415"), Pow(10, 6))), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 4))), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 9), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 6), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.FEMTOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 7)), Int(4053)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 27), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 4), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 6), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 11), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 8), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 5), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 10), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 24), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 7), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Int(10), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 6), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Int(1000), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 15), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 7), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 12), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 17)), Int("26664477483")), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 18), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 21), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 18)), Int("172368932329209")), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 9), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 33), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 30), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.GIGAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(4), Int(4053)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 20), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 4), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Int(10), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Int(1000), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 17), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 8), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLIBAR] = Sym(
+        "hectopa"
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 5), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(76), Int(101325)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 10)), Int("26664477483")), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 11), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 14), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Int(100), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(3040), Int(4053)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 26), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 23), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.HECTOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 6)), Int(4053)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 26), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.BAR] = Mul(
+        Int(1000), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 5), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 10), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 7), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 4), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 9), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 23), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 6), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 5), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Int(100), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 14), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 6), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 11), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 4)), Int(4053)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 16)), Int("26664477483")), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 17), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 20), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 17)), Int("172368932329209")), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 8), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 32), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 29), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOBAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("kbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(40), Int(4053)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 21), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.CENTIBAR] = Sym(
+        "kilopa"
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 5), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Int(100), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 4), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 18), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Int(10), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 9), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Int(10), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 6), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(152), Int(20265)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 11)), Int("26664477483")), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 12), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 15), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 12)), Int("172368932329209")), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Int(1000), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(30400), Int(4053)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 27), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 24), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.KILOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 9)), Int(4053)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 29), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.BAR] = Mul(
+        Pow(10, 6), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 8), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 13), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 10), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 7), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 12), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 26), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Int(100), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 9), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.KILOBAR] = Mul(
+        Int(1000), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 8), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 5), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 17), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 9), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 14), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 7)), Int(4053)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 19)), Int("26664477483")), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 20), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 23), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 20)), Int("172368932329209")), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 11), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 10)), Int(4053)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 35), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 32), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGABAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("megabar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 4)), Int(4053)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 24), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.BAR] = Mul(
+        Int(10), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Int(1000), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 8), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 5), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Int(100), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 7), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 21), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 4), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Int(1000), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 12), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 4), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 9), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(30400), Int(4053)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 14)), Int("26664477483")), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 15), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 18), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 15)), Int("172368932329209")), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 6), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 5)), Int(4053)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 30), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 27), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MEGAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 6))), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 12), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 9), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(200), Int("26664477483")), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Int(1000), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 6), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(25000), Int("172368932329209")), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Int("2533125000")), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 18), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 15), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MICROPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("micropa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(4), Int(4053)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 20), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Int(10)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 4), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECAPASCAL] = Mul(
+        Int(10), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.DECIPASCAL] = Mul(
+        Int(1000), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 17), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.HECTOPASCAL] = Sym(
+        "mbar"
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 8), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 5), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(76), Int(101325)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 10)), Int("26664477483")), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 11), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 14), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 11)), Int("172368932329209")), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.PASCAL] = Mul(
+        Int(100), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.TORR] = Mul(
+        Rat(Int(3040), Int(4053)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 26), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 23), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIBAR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("mbar")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Int(101325000)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 15), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 12), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Int(1000), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Int("2533125000")), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 5)), Int("26664477483")), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 6), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 9), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 6)), Int("172368932329209")), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Int(2533125)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 21), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 18), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLIPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("millipa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(25), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ATTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 18)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.BAR] = Mul(
+        Rat(Int(4053), Int(3040)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(20265), Int(152)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(253312500), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(506625), Int(38)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(4053), Int(304)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(25331250), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 15)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 5))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(101325), Int(76)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 4))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(20265), Int(152)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 7))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(4053), Int(30400)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 6)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(101325), Int(76)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int("2533125000"), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(24125), Pow(10, 9)), Int("24125003437")), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(3015625), Pow(10, 9)), Int("155952843535951")), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(2533125), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.TORR] = Mul(
+        Int(1000), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 24)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 20))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MILLITORR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 17))), Sym("mtorr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1269737023), Mul(Int(965), Pow(10, 9))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ATTOPASCAL] = Mul(
+        Mul(Int("133322387415"), Pow(10, 9)), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.BAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 13))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 11))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 6))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 9))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 12))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 7))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 26))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.FEMTOPASCAL] = Mul(
+        Mul(Int("133322387415"), Pow(10, 6)), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 17))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 10))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 16))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 11))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 19))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 14))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int("26664477483"), Int(200)), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 10))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 5))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 9))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.NANOPASCAL] = Mul(
+        Int("133322387415"), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 23))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PICOPASCAL] = Mul(
+        Int("133322387415000"), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PSI] = Mul(
+        Rat(Int("158717127875"), Int("8208044396629")), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.PASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 8))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 20))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.TORR] = Mul(
+        Rat(Int("24125003437"), Mul(Int(24125), Pow(10, 6))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.YOCTOPASCAL] = Mul(
+        Mul(Int("133322387415"), Pow(10, 15)), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 32))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Mul(Int("133322387415"), Pow(10, 12)), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.MMHG][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int("26664477483"), Mul(Int(2), Pow(10, 29))), Sym("mmhg")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 9))), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 9), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 6), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Int("133322387415")), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Int(1000), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(25), Int("172368932329209")), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 6))), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 15), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 12), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.NANOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 13)), Int(4053)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 33), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 10), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 12), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 17), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 14), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 11), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 16), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 30), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Pow(10, 6), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 13), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Pow(10, 7), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 12), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Pow(10, 4), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 9), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 21), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 13), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 18), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 23)), Int("26664477483")), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 24), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 27), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 24)), Int("172368932329209")), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 15), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Int(1000), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 14)), Int(4053)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 39), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 36), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PETAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 12))), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 6), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Int(1000), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 12))), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Int("133322387415000")), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(1), Int("6894757293168360")), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 9))), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 12), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 9), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PICOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int("8208044396629"), Mul(Int(120625), Pow(10, 9))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ATTOPASCAL] = Mul(
+        Mul(Int("689475729316836"), Pow(10, 7)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.BAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 14))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 12))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 7))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 10))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 13))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 8))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 27))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.FEMTOPASCAL] = Mul(
+        Mul(Int("689475729316836"), Pow(10, 4)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 18))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 11))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 17))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 12))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 20))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 15))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int("172368932329209"), Int(25000)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 11))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 6))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 9))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.MMHG] = Mul(
+        Rat(Int("8208044396629"), Int("158717127875")), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int("172368932329209"), Int(25)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 24))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PICOPASCAL] = Mul(
+        Int("6894757293168360"), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.PASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 9))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 21))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.TORR] = Mul(
+        Rat(Int("155952843535951"), Mul(Int(3015625), Pow(10, 6))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.YOCTOPASCAL] = Mul(
+        Mul(Int("689475729316836"), Pow(10, 13)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 33))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Mul(Int("689475729316836"), Pow(10, 10)), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PSI][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int("172368932329209"), Mul(Int(25), Pow(10, 30))), Sym("psi")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Int(101325)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 18), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Int(100), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Int(10)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Int(10), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 15), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Int(100)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 6), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Int(100)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Int(1000), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Int(2533125)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 8)), Int("26664477483")), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 9), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 12), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 9)), Int("172368932329209")), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(152), Int(20265)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 24), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 21), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.PASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("pa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 10)), Int(4053)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 30), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 7), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 9), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 14), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 11), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 8), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 13), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 27), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Int(1000), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 10), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Pow(10, 4), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 9), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Int(10), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 6), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 18), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 10), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 15), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 8)), Int(4053)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 20)), Int("26664477483")), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 21), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 24), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 21)), Int("172368932329209")), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 12), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 11)), Int(4053)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 36), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 33), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TERAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("terapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Int(760)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ATTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 15)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.BAR] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 4))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(4053), Int(30400)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(506625), Int(38)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(4053), Int(304)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(4053), Int(304000)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(101325), Int(76)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 17))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.FEMTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 12)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 8))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(4053), Int(3040)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 7))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(4053), Int(30400)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 10))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 5))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int("2533125000"), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(4053), Int(3040)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(2533125), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(1), Int(1000)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(24125), Pow(10, 6)), Int("24125003437")), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 6)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 14))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 9)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(3015625), Pow(10, 6)), Int("155952843535951")), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(20265), Int(152)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 11))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.YOCTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 21)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 23))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Rat(Mul(Int(2533125), Pow(10, 18)), Int(19)), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.TORR][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(4053), Mul(Int(304), Pow(10, 20))), Sym("torr")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 24))), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 29)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 28)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 32)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 35)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 24))), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Mul(Int("133322387415"), Pow(10, 15))), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 13))), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOCTOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 22)), Int(4053)), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 42), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 19), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 21), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 26), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 23), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 20), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 25), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Pow(10, 6), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 39), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Pow(10, 15), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 22), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Pow(10, 16), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 21), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Pow(10, 13), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 18), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 30), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 22), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 27), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 32)), Int("26664477483")), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 33), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Pow(10, 9), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 36), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 33)), Int("172368932329209")), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 24), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Pow(10, 12), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 23)), Int(4053)), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 48), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 45), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.YOTTAPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Int(1000), Sym("yottapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Int(1), Mul(Int(101325), Pow(10, 21))), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.BAR] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Rat(Int(1), Pow(10, 29)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Rat(Int(1), Pow(10, 32)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 21))), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Int(1), Mul(Int("133322387415"), Pow(10, 12))), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Int(1), Mul(Int("689475729316836"), Pow(10, 10))), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.PASCAL] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Int(19), Mul(Int(2533125), Pow(10, 18))), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Int(1000), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZEPTOPASCAL][UnitsPressure.ZETTAPASCAL] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptopa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ATMOSPHERE] = Mul(
+        Rat(Mul(Int(4), Pow(10, 19)), Int(4053)), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ATTOPASCAL] = Mul(
+        Pow(10, 39), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.BAR] = Mul(
+        Pow(10, 16), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.CENTIBAR] = Mul(
+        Pow(10, 18), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.CENTIPASCAL] = Mul(
+        Pow(10, 23), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECAPASCAL] = Mul(
+        Pow(10, 20), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECIBAR] = Mul(
+        Pow(10, 17), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.DECIPASCAL] = Mul(
+        Pow(10, 22), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.EXAPASCAL] = Mul(
+        Int(1000), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.FEMTOPASCAL] = Mul(
+        Pow(10, 36), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.GIGAPASCAL] = Mul(
+        Pow(10, 12), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.HECTOPASCAL] = Mul(
+        Pow(10, 19), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.KILOBAR] = Mul(
+        Pow(10, 13), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.KILOPASCAL] = Mul(
+        Pow(10, 18), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MEGABAR] = Mul(
+        Pow(10, 10), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MEGAPASCAL] = Mul(
+        Pow(10, 15), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MICROPASCAL] = Mul(
+        Pow(10, 27), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLIBAR] = Mul(
+        Pow(10, 19), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLIPASCAL] = Mul(
+        Pow(10, 24), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MILLITORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 17)), Int(4053)), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.MMHG] = Mul(
+        Rat(Mul(Int(2), Pow(10, 29)), Int("26664477483")), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.NANOPASCAL] = Mul(
+        Pow(10, 30), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PETAPASCAL] = Mul(
+        Pow(10, 6), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PICOPASCAL] = Mul(
+        Pow(10, 33), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PSI] = Mul(
+        Rat(Mul(Int(25), Pow(10, 30)), Int("172368932329209")), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.PASCAL] = Mul(
+        Pow(10, 21), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.TERAPASCAL] = Mul(
+        Pow(10, 9), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.TORR] = Mul(
+        Rat(Mul(Int(304), Pow(10, 20)), Int(4053)), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.YOCTOPASCAL] = Mul(
+        Pow(10, 45), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.YOTTAPASCAL] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettapa")
+    )  # nopep8
+    CONVERSIONS[UnitsPressure.ZETTAPASCAL][UnitsPressure.ZEPTOPASCAL] = Mul(
+        Pow(10, 42), Sym("zettapa")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -2081,9 +3074,7 @@ class PressureI(_omero_model.Pressure, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsPressure, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.PressureI):
             # This is a copy-constructor call.
@@ -2131,5 +3122,6 @@ class PressureI(_omero_model.Pressure, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.PressureI = PressureI

--- a/src/omero_model_TemperatureI.py
+++ b/src/omero_model_TemperatureI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Temperature_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,30 +52,42 @@ class TemperatureI(_omero_model.Temperature, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.FAHRENHEIT] = \
-        Add(Mul(Rat(Int(9), Int(5)), Sym("c")), Int(32))  # nopep8
-    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.KELVIN] = \
-        Add(Sym("c"), Rat(Int(5463), Int(20)))  # nopep8
-    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.RANKINE] = \
-        Add(Mul(Rat(Int(9), Int(5)), Sym("c")), Rat(Int(49167), Int(100)))  # nopep8
-    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.CELSIUS] = \
-        Add(Mul(Rat(Int(5), Int(9)), Sym("f")), Rat(Int(-160), Int(9)))  # nopep8
-    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.KELVIN] = \
-        Add(Mul(Rat(Int(5), Int(9)), Sym("f")), Rat(Int(45967), Int(180)))  # nopep8
-    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.RANKINE] = \
-        Add(Sym("f"), Rat(Int(45967), Int(100)))  # nopep8
-    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.CELSIUS] = \
-        Add(Sym("k"), Rat(Int(-5463), Int(20)))  # nopep8
-    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.FAHRENHEIT] = \
-        Add(Mul(Rat(Int(9), Int(5)), Sym("k")), Rat(Int(-45967), Int(100)))  # nopep8
-    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.RANKINE] = \
-        Mul(Rat(Int(9), Int(5)), Sym("k"))  # nopep8
-    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.CELSIUS] = \
-        Add(Mul(Rat(Int(5), Int(9)), Sym("r")), Rat(Int(-5463), Int(20)))  # nopep8
-    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.FAHRENHEIT] = \
-        Add(Sym("r"), Rat(Int(-45967), Int(100)))  # nopep8
-    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.KELVIN] = \
-        Mul(Rat(Int(5), Int(9)), Sym("r"))  # nopep8
+    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.FAHRENHEIT] = Add(
+        Mul(Rat(Int(9), Int(5)), Sym("c")), Int(32)
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.KELVIN] = Add(
+        Sym("c"), Rat(Int(5463), Int(20))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.CELSIUS][UnitsTemperature.RANKINE] = Add(
+        Mul(Rat(Int(9), Int(5)), Sym("c")), Rat(Int(49167), Int(100))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.CELSIUS] = Add(
+        Mul(Rat(Int(5), Int(9)), Sym("f")), Rat(Int(-160), Int(9))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.KELVIN] = Add(
+        Mul(Rat(Int(5), Int(9)), Sym("f")), Rat(Int(45967), Int(180))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.FAHRENHEIT][UnitsTemperature.RANKINE] = Add(
+        Sym("f"), Rat(Int(45967), Int(100))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.CELSIUS] = Add(
+        Sym("k"), Rat(Int(-5463), Int(20))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.FAHRENHEIT] = Add(
+        Mul(Rat(Int(9), Int(5)), Sym("k")), Rat(Int(-45967), Int(100))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.KELVIN][UnitsTemperature.RANKINE] = Mul(
+        Rat(Int(9), Int(5)), Sym("k")
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.CELSIUS] = Add(
+        Mul(Rat(Int(5), Int(9)), Sym("r")), Rat(Int(-5463), Int(20))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.FAHRENHEIT] = Add(
+        Sym("r"), Rat(Int(-45967), Int(100))
+    )  # nopep8
+    CONVERSIONS[UnitsTemperature.RANKINE][UnitsTemperature.KELVIN] = Mul(
+        Rat(Int(5), Int(9)), Sym("r")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -93,9 +106,7 @@ class TemperatureI(_omero_model.Temperature, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsTemperature, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.TemperatureI):
             # This is a copy-constructor call.
@@ -143,5 +154,6 @@ class TemperatureI(_omero_model.Temperature, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.TemperatureI = TemperatureI

--- a/src/omero_model_TimeI.py
+++ b/src/omero_model_TimeI.py
@@ -29,6 +29,7 @@ from builtins import str
 from past.builtins import basestring
 import Ice
 import IceImport
+
 IceImport.load("omero_model_Time_ice")
 _omero = Ice.openModule("omero")
 _omero_model = Ice.openModule("omero.model")
@@ -51,1110 +52,1662 @@ class TimeI(_omero_model.Time, UnitBase):
     CONVERSIONS = dict()
     for val in UNIT_VALUES:
         CONVERSIONS[val] = dict()
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 20))), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 20))), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 19))), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 6), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Int(1000), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("attos"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 16), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 4))), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 13), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 4))), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 4), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MILLISECOND] = \
-        Mul(Int(10), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Int(6000)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 7), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 10), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Int(100)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 22), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 19), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("centis"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.ATTOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 20)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.CENTISECOND] = \
-        Mul(Mul(Int(864), Pow(10, 4)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.DECASECOND] = \
-        Mul(Int(8640), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.DECISECOND] = \
-        Mul(Int(864000), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(27), Mul(Int(3125), Pow(10, 11))), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.FEMTOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 17)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(27), Int(312500)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.HECTOSECOND] = \
-        Mul(Int(864), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.HOUR] = \
-        Mul(Int(24), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(432), Int(5)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(54), Int(625)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.MICROSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 8)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.MILLISECOND] = \
-        Mul(Mul(Int(864), Pow(10, 5)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.MINUTE] = \
-        Mul(Int(1440), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.NANOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 11)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(27), Mul(Int(3125), Pow(10, 8))), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.PICOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 14)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.SECOND] = \
-        Mul(Int(86400), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(27), Mul(Int(3125), Pow(10, 5))), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.YOCTOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 26)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(27), Mul(Int(3125), Pow(10, 17))), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.ZEPTOSECOND] = \
-        Mul(Mul(Int(864), Pow(10, 23)), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DAY][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(27), Mul(Int(3125), Pow(10, 14))), Sym("d"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 19), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Int(1000), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(8640)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.DECISECOND] = \
-        Mul(Int(100), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 16), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Int(360)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 7), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 4), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Int(6)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 10), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 13), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.SECOND] = \
-        Mul(Int(10), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 25), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 22), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("decas"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 17), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.CENTISECOND] = \
-        Mul(Int(10), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(864000)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Int(100)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 14), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Int(36000)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 5), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MILLISECOND] = \
-        Mul(Int(100), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Int(600)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 8), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 11), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 23), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 20), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("decis"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 36), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 20), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Mul(Int(3125), Pow(10, 11)), Int(27)), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 17), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 19), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 33), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Pow(10, 9), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 16), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 14)), Int(9)), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 15), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Pow(10, 12), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 24), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 21), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 16)), Int(3)), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 27), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.PETASECOND] = \
-        Mul(Int(1000), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 30), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 18), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.TERASECOND] = \
-        Mul(Pow(10, 6), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 42), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 39), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("exas"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Int(1000), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 17))), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 17)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 17))), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 16))), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 9), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 6), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("femtos"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 27), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 11), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(312500), Int(27)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 8), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 10), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 24), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 7), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 5)), Int(9)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 6), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Int(1000), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 15), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 12), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 7)), Int(3)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 18), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 21), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 9), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 33), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 30), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("gigas"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 20), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 4), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(864)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Int(10), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Int(1000), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 16)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 17), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Int(36)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 8), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 5), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(5), Int(3)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 11), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 14), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.SECOND] = \
-        Mul(Int(100), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 26), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 23), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("hectos"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ATTOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 20)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.CENTISECOND] = \
-        Mul(Mul(Int(36), Pow(10, 4)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(24)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DECASECOND] = \
-        Mul(Int(360), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DECISECOND] = \
-        Mul(Int(36000), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 14))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.FEMTOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 17)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 5))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.HECTOSECOND] = \
-        Mul(Int(36), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(18), Int(5)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(9), Int(2500)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MICROSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 8)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MILLISECOND] = \
-        Mul(Mul(Int(36), Pow(10, 5)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MINUTE] = \
-        Mul(Int(60), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.NANOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 11)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 11))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.PICOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 14)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.SECOND] = \
-        Mul(Int(3600), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 8))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.YOCTOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 26)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 20))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ZEPTOSECOND] = \
-        Mul(Mul(Int(36), Pow(10, 23)), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(9), Mul(Int(25), Pow(10, 17))), Sym("h"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 21), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 5), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(5), Int(432)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Int(100), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 4), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 18), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Int(10), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(5), Int(18)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 9), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 6), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(50), Int(3)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 12), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 15), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.SECOND] = \
-        Mul(Int(1000), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 27), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 24), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("kilos"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 24), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 8), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(625), Int(54)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 5), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 7), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 21), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 4), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(2500), Int(9)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Int(1000), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 12), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 9), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 4)), Int(3)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 15), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 18), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 6), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 30), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 27), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("megas"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 12), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 8))), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 9), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 8))), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 7))), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Int(1000), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 6), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 18), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 15), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("micros"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 15), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 5))), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 4)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Int(100)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 12), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 5)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 5))), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MICROSECOND] = \
-        Mul(Int(1000), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 4))), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 6), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 9), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 21), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 18), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("millis"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ATTOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 19)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.CENTISECOND] = \
-        Mul(Int(6000), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(1440)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DECASECOND] = \
-        Mul(Int(6), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DECISECOND] = \
-        Mul(Int(600), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 16))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.FEMTOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 16)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 7))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(3), Int(5)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Int(60)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(3), Int(50)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 4))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MICROSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 7)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MILLISECOND] = \
-        Mul(Mul(Int(6), Pow(10, 4)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.NANOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 10)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 13))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.PICOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 13)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.SECOND] = \
-        Mul(Int(60), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 10))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.YOCTOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 25)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 22))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ZEPTOSECOND] = \
-        Mul(Mul(Int(6), Pow(10, 22)), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(3), Mul(Int(5), Pow(10, 19))), Sym("m"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 9), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 7)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 11))), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 8)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 6), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 11))), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 10))), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Int(1000), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 15), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 12), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("nanos"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 33), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 17), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Mul(Int(3125), Pow(10, 8)), Int(27)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 14), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 16), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 30), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Pow(10, 6), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 13), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 11)), Int(9)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 12), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Pow(10, 9), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 21), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 18), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 13)), Int(3)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 24), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 27), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 15), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.TERASECOND] = \
-        Mul(Int(1000), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 39), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 36), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("petas"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 6), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 10)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 14))), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 13)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 11)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Int(1000), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 14)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 14))), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 13))), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 12), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 9), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("picos"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 18), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.CENTISECOND] = \
-        Mul(Int(100), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Int(86400)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Int(10)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DECISECOND] = \
-        Mul(Int(10), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 15), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Int(100)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Int(3600)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 6), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MILLISECOND] = \
-        Mul(Int(1000), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Int(60)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 9), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 12), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 24), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 21), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("s"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 30), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 14), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Mul(Int(3125), Pow(10, 5)), Int(27)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 11), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 13), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 27), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Int(1000), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 10), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 8)), Int(9)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 9), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Pow(10, 6), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 18), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 15), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 10)), Int(3)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 21), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 24), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 12), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 36), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 33), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("teras"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 26))), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 25)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 26)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 26))), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 25))), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 48)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("yoctos"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 42), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 26), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Mul(Int(3125), Pow(10, 17)), Int(27)), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 23), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 25), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.EXASECOND] = \
-        Mul(Pow(10, 6), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 39), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Pow(10, 15), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 22), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 20)), Int(9)), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 21), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Pow(10, 18), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 30), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 27), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 22)), Int(3)), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 33), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.PETASECOND] = \
-        Mul(Pow(10, 9), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 36), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 24), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.TERASECOND] = \
-        Mul(Pow(10, 12), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 48), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 45), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Int(1000), Sym("yottas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.CENTISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 19)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DAY] = \
-        Mul(Rat(Int(1), Mul(Int(864), Pow(10, 23))), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DECASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 22)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DECISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 20)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.EXASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 39)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 6)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.GIGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 30)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 23)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Int(1), Mul(Int(36), Pow(10, 23))), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.KILOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 24)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MEGASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 27)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MICROSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 15)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MILLISECOND] = \
-        Mul(Rat(Int(1), Pow(10, 18)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Int(1), Mul(Int(6), Pow(10, 22))), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.NANOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 12)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.PETASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 36)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.PICOSECOND] = \
-        Mul(Rat(Int(1), Pow(10, 9)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.SECOND] = \
-        Mul(Rat(Int(1), Pow(10, 21)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.TERASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 33)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Int(1000), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 45)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.ZETTASECOND] = \
-        Mul(Rat(Int(1), Pow(10, 42)), Sym("zeptos"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.ATTOSECOND] = \
-        Mul(Pow(10, 39), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.CENTISECOND] = \
-        Mul(Pow(10, 23), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DAY] = \
-        Mul(Rat(Mul(Int(3125), Pow(10, 14)), Int(27)), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DECASECOND] = \
-        Mul(Pow(10, 20), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DECISECOND] = \
-        Mul(Pow(10, 22), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.EXASECOND] = \
-        Mul(Int(1000), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.FEMTOSECOND] = \
-        Mul(Pow(10, 36), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.GIGASECOND] = \
-        Mul(Pow(10, 12), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.HECTOSECOND] = \
-        Mul(Pow(10, 19), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.HOUR] = \
-        Mul(Rat(Mul(Int(25), Pow(10, 17)), Int(9)), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.KILOSECOND] = \
-        Mul(Pow(10, 18), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MEGASECOND] = \
-        Mul(Pow(10, 15), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MICROSECOND] = \
-        Mul(Pow(10, 27), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MILLISECOND] = \
-        Mul(Pow(10, 24), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MINUTE] = \
-        Mul(Rat(Mul(Int(5), Pow(10, 19)), Int(3)), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.NANOSECOND] = \
-        Mul(Pow(10, 30), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.PETASECOND] = \
-        Mul(Pow(10, 6), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.PICOSECOND] = \
-        Mul(Pow(10, 33), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.SECOND] = \
-        Mul(Pow(10, 21), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.TERASECOND] = \
-        Mul(Pow(10, 9), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.YOCTOSECOND] = \
-        Mul(Pow(10, 45), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.YOTTASECOND] = \
-        Mul(Rat(Int(1), Int(1000)), Sym("zettas"))  # nopep8
-    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.ZEPTOSECOND] = \
-        Mul(Pow(10, 42), Sym("zettas"))  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 20))), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 20))), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 19))), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 6), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Int(1000), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ATTOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("attos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 16), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 4))), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 13), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 4))), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 4), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MILLISECOND] = Mul(
+        Int(10), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Int(6000)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 7), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 10), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Int(100)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 22), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 19), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.CENTISECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("centis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.ATTOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 20)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.CENTISECOND] = Mul(
+        Mul(Int(864), Pow(10, 4)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.DECASECOND] = Mul(
+        Int(8640), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.DECISECOND] = Mul(
+        Int(864000), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(27), Mul(Int(3125), Pow(10, 11))), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.FEMTOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 17)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(27), Int(312500)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.HECTOSECOND] = Mul(
+        Int(864), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.HOUR] = Mul(
+        Int(24), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(432), Int(5)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(54), Int(625)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.MICROSECOND] = Mul(
+        Mul(Int(864), Pow(10, 8)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.MILLISECOND] = Mul(
+        Mul(Int(864), Pow(10, 5)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.MINUTE] = Mul(
+        Int(1440), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.NANOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 11)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(27), Mul(Int(3125), Pow(10, 8))), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.PICOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 14)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.SECOND] = Mul(
+        Int(86400), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(27), Mul(Int(3125), Pow(10, 5))), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.YOCTOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 26)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(27), Mul(Int(3125), Pow(10, 17))), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.ZEPTOSECOND] = Mul(
+        Mul(Int(864), Pow(10, 23)), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DAY][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(27), Mul(Int(3125), Pow(10, 14))), Sym("d")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 19), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.CENTISECOND] = Mul(
+        Int(1000), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(8640)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.DECISECOND] = Mul(
+        Int(100), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 16), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Int(360)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Int(100)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 7), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 4), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Int(6)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 10), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 13), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.SECOND] = Mul(
+        Int(10), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 25), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 22), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("decas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 17), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.CENTISECOND] = Mul(
+        Int(10), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(864000)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Int(100)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 14), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Int(36000)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 5), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MILLISECOND] = Mul(
+        Int(100), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Int(600)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 8), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 11), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 23), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 20), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.DECISECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("decis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 36), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 20), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DAY] = Mul(
+        Rat(Mul(Int(3125), Pow(10, 11)), Int(27)), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 17), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 19), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 33), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.GIGASECOND] = Mul(
+        Pow(10, 9), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 16), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 14)), Int(9)), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 15), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MEGASECOND] = Mul(
+        Pow(10, 12), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 24), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 21), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 16)), Int(3)), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 27), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.PETASECOND] = Mul(
+        Int(1000), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 30), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 18), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.TERASECOND] = Mul(
+        Pow(10, 6), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 42), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 39), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.EXASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("exas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Int(1000), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 17))), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 17)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 17))), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 16))), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 9), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 6), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.FEMTOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("femtos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 27), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 11), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(312500), Int(27)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 8), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 10), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 24), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 7), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 5)), Int(9)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 6), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MEGASECOND] = Mul(
+        Int(1000), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 15), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 12), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 7)), Int(3)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 18), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 21), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 9), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 33), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 30), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.GIGASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("gigas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 20), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 4), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(864)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DECASECOND] = Mul(
+        Int(10), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.DECISECOND] = Mul(
+        Int(1000), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 16)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 17), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Int(36)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 8), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 5), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(5), Int(3)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 11), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 14), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.SECOND] = Mul(
+        Int(100), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 26), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 23), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HECTOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("hectos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ATTOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 20)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.CENTISECOND] = Mul(
+        Mul(Int(36), Pow(10, 4)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(24)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DECASECOND] = Mul(
+        Int(360), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.DECISECOND] = Mul(
+        Int(36000), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 14))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.FEMTOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 17)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 5))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.HECTOSECOND] = Mul(
+        Int(36), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(18), Int(5)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(9), Int(2500)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MICROSECOND] = Mul(
+        Mul(Int(36), Pow(10, 8)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MILLISECOND] = Mul(
+        Mul(Int(36), Pow(10, 5)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.MINUTE] = Mul(
+        Int(60), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.NANOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 11)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 11))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.PICOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 14)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.SECOND] = Mul(
+        Int(3600), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 8))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.YOCTOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 26)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 20))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ZEPTOSECOND] = Mul(
+        Mul(Int(36), Pow(10, 23)), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.HOUR][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(9), Mul(Int(25), Pow(10, 17))), Sym("h")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 21), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 5), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(5), Int(432)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DECASECOND] = Mul(
+        Int(100), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 4), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 18), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Int(10), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(5), Int(18)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 9), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 6), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(50), Int(3)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 12), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 15), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.SECOND] = Mul(
+        Int(1000), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 27), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 24), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.KILOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("kilos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 24), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 8), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(625), Int(54)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 5), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 7), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 21), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 4), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(2500), Int(9)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.KILOSECOND] = Mul(
+        Int(1000), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 12), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 9), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 4)), Int(3)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 15), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 18), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 6), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 30), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 27), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MEGASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("megas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 12), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 8))), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 9), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 8))), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 7))), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.NANOSECOND] = Mul(
+        Int(1000), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 6), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 18), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 15), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MICROSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("micros")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 15), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 5))), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 4)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Int(100)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 12), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 5)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 5))), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MICROSECOND] = Mul(
+        Int(1000), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 4))), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 6), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 9), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 21), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 18), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MILLISECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("millis")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ATTOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 19)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.CENTISECOND] = Mul(
+        Int(6000), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(1440)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DECASECOND] = Mul(
+        Int(6), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.DECISECOND] = Mul(
+        Int(600), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 16))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.FEMTOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 16)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 7))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(3), Int(5)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Int(60)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(3), Int(50)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 4))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MICROSECOND] = Mul(
+        Mul(Int(6), Pow(10, 7)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.MILLISECOND] = Mul(
+        Mul(Int(6), Pow(10, 4)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.NANOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 10)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 13))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.PICOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 13)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.SECOND] = Mul(
+        Int(60), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 10))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.YOCTOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 25)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 22))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ZEPTOSECOND] = Mul(
+        Mul(Int(6), Pow(10, 22)), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.MINUTE][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(3), Mul(Int(5), Pow(10, 19))), Sym("m")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 9), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 7)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 11))), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 8)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 6), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 11))), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 10))), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Int(1000), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 15), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 12), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.NANOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("nanos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 33), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 17), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DAY] = Mul(
+        Rat(Mul(Int(3125), Pow(10, 8)), Int(27)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 14), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 16), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 30), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.GIGASECOND] = Mul(
+        Pow(10, 6), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 13), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 11)), Int(9)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 12), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MEGASECOND] = Mul(
+        Pow(10, 9), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 21), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 18), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 13)), Int(3)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 24), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 27), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 15), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.TERASECOND] = Mul(
+        Int(1000), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 39), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 36), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PETASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("petas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 6), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 10)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 14))), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 13)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 11)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Int(1000), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 14)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 14))), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 13))), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 12), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 9), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.PICOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("picos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 18), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.CENTISECOND] = Mul(
+        Int(100), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Int(86400)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Int(10)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.DECISECOND] = Mul(
+        Int(10), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 15), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Int(100)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Int(3600)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 6), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MILLISECOND] = Mul(
+        Int(1000), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Int(60)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 9), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 12), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 24), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 21), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.SECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("s")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 30), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 14), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DAY] = Mul(
+        Rat(Mul(Int(3125), Pow(10, 5)), Int(27)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 11), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 13), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 27), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.GIGASECOND] = Mul(
+        Int(1000), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 10), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 8)), Int(9)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 9), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MEGASECOND] = Mul(
+        Pow(10, 6), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 18), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 15), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 10)), Int(3)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 21), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 24), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 12), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 36), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 33), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.TERASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("teras")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 26))), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 25)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 26)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 26))), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 25))), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 48)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOCTOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("yoctos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 42), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 26), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DAY] = Mul(
+        Rat(Mul(Int(3125), Pow(10, 17)), Int(27)), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 23), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 25), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.EXASECOND] = Mul(
+        Pow(10, 6), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 39), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.GIGASECOND] = Mul(
+        Pow(10, 15), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 22), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 20)), Int(9)), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 21), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MEGASECOND] = Mul(
+        Pow(10, 18), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 30), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 27), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 22)), Int(3)), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 33), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.PETASECOND] = Mul(
+        Pow(10, 9), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 36), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 24), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.TERASECOND] = Mul(
+        Pow(10, 12), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 48), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 45), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.YOTTASECOND][UnitsTime.ZETTASECOND] = Mul(
+        Int(1000), Sym("yottas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.ATTOSECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.CENTISECOND] = Mul(
+        Rat(Int(1), Pow(10, 19)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DAY] = Mul(
+        Rat(Int(1), Mul(Int(864), Pow(10, 23))), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DECASECOND] = Mul(
+        Rat(Int(1), Pow(10, 22)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.DECISECOND] = Mul(
+        Rat(Int(1), Pow(10, 20)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.EXASECOND] = Mul(
+        Rat(Int(1), Pow(10, 39)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 6)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.GIGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 30)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.HECTOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 23)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.HOUR] = Mul(
+        Rat(Int(1), Mul(Int(36), Pow(10, 23))), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.KILOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 24)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MEGASECOND] = Mul(
+        Rat(Int(1), Pow(10, 27)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MICROSECOND] = Mul(
+        Rat(Int(1), Pow(10, 15)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MILLISECOND] = Mul(
+        Rat(Int(1), Pow(10, 18)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Int(1), Mul(Int(6), Pow(10, 22))), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.NANOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 12)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.PETASECOND] = Mul(
+        Rat(Int(1), Pow(10, 36)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.PICOSECOND] = Mul(
+        Rat(Int(1), Pow(10, 9)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.SECOND] = Mul(
+        Rat(Int(1), Pow(10, 21)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.TERASECOND] = Mul(
+        Rat(Int(1), Pow(10, 33)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Int(1000), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 45)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZEPTOSECOND][UnitsTime.ZETTASECOND] = Mul(
+        Rat(Int(1), Pow(10, 42)), Sym("zeptos")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.ATTOSECOND] = Mul(
+        Pow(10, 39), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.CENTISECOND] = Mul(
+        Pow(10, 23), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DAY] = Mul(
+        Rat(Mul(Int(3125), Pow(10, 14)), Int(27)), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DECASECOND] = Mul(
+        Pow(10, 20), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.DECISECOND] = Mul(
+        Pow(10, 22), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.EXASECOND] = Mul(
+        Int(1000), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.FEMTOSECOND] = Mul(
+        Pow(10, 36), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.GIGASECOND] = Mul(
+        Pow(10, 12), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.HECTOSECOND] = Mul(
+        Pow(10, 19), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.HOUR] = Mul(
+        Rat(Mul(Int(25), Pow(10, 17)), Int(9)), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.KILOSECOND] = Mul(
+        Pow(10, 18), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MEGASECOND] = Mul(
+        Pow(10, 15), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MICROSECOND] = Mul(
+        Pow(10, 27), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MILLISECOND] = Mul(
+        Pow(10, 24), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.MINUTE] = Mul(
+        Rat(Mul(Int(5), Pow(10, 19)), Int(3)), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.NANOSECOND] = Mul(
+        Pow(10, 30), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.PETASECOND] = Mul(
+        Pow(10, 6), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.PICOSECOND] = Mul(
+        Pow(10, 33), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.SECOND] = Mul(
+        Pow(10, 21), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.TERASECOND] = Mul(
+        Pow(10, 9), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.YOCTOSECOND] = Mul(
+        Pow(10, 45), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.YOTTASECOND] = Mul(
+        Rat(Int(1), Int(1000)), Sym("zettas")
+    )  # nopep8
+    CONVERSIONS[UnitsTime.ZETTASECOND][UnitsTime.ZEPTOSECOND] = Mul(
+        Pow(10, 42), Sym("zettas")
+    )  # nopep8
     del val
 
     SYMBOLS = dict()
@@ -1193,9 +1746,7 @@ class TimeI(_omero_model.Time, UnitBase):
         elif isinstance(unit, basestring):
             target = getattr(UnitsTime, unit)
         else:
-            raise Exception("Unknown unit: %s (%s)" % (
-                unit, type(unit)
-            ))
+            raise Exception("Unknown unit: %s (%s)" % (unit, type(unit)))
 
         if isinstance(value, _omero_model.TimeI):
             # This is a copy-constructor call.
@@ -1243,5 +1794,6 @@ class TimeI(_omero_model.Time, UnitBase):
 
     def __str__(self):
         return self._base_string(self.getValue(), self.getUnit())
+
 
 _omero_model.TimeI = TimeI

--- a/src/omero_model_UnitBase.py
+++ b/src/omero_model_UnitBase.py
@@ -27,8 +27,9 @@ the unit implementations.
 
 from builtins import str
 from builtins import object
-class UnitBase(object):
 
+
+class UnitBase(object):
     def _base_string(self, v, u):
         if v is not None:
             return "%s %s" % (v, str(u))

--- a/src/omero_sys_ParametersI.py
+++ b/src/omero_sys_ParametersI.py
@@ -86,8 +86,7 @@ class ParametersI(omero.sys.Parameters):
         False otherwise.
         """
         if self.theFilter:
-            return None != self.theFilter.limit or \
-                None != self.theFilter.offset
+            return None != self.theFilter.limit or None != self.theFilter.offset
         return False
 
     def getOffset(self):
@@ -358,5 +357,6 @@ class ParametersI(omero.sys.Parameters):
     def addString(self, name, stringValue):
         self.add(name, rstring(stringValue))
         return self
+
 
 _omero_sys.ParametersI = ParametersI

--- a/src/runProcessor.py
+++ b/src/runProcessor.py
@@ -14,5 +14,6 @@ from omero.processor import ProcessorI
 
 if __name__ == "__main__":
     app = omero.util.Server(
-        ProcessorI, "ProcessorAdapter", Ice.Identity("Processor", ""))
+        ProcessorI, "ProcessorAdapter", Ice.Identity("Processor", "")
+    )
     sys.exit(app.main(sys.argv))

--- a/src/runTables.py
+++ b/src/runTables.py
@@ -20,7 +20,6 @@ if __name__ == "__main__":
     omero.tables.TableI.__module__ = "omero.tables"
 
     class TablesDependency(Dependency):
-
         def __init__(self):
             Dependency.__init__(self, "tables")
 
@@ -40,7 +39,10 @@ if __name__ == "__main__":
                 return "error"
 
     app = omero.util.Server(
-        omero.tables.TablesI, "TablesAdapter", Ice.Identity("Tables", ""),
-        dependencies=(Dependency("numpy"), TablesDependency()))
+        omero.tables.TablesI,
+        "TablesAdapter",
+        Ice.Identity("Tables", ""),
+        dependencies=(Dependency("numpy"), TablesDependency()),
+    )
 
     sys.exit(app.main(sys.argv))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,3 @@
-
 #
 # --repeat argument for py.test taken from:
 # http://stackoverflow.com/questions/21764473/
@@ -13,8 +12,8 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption(
-        '--repeat', action='store',
-        help='Number of times to repeat each test')
+        "--repeat", action="store", help="Number of times to repeat each test"
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -24,12 +23,12 @@ def pytest_generate_tests(metafunc):
         # We're going to duplicate these tests by parametrizing them,
         # which requires that each test has a fixture to accept the parameter.
         # We can add a new fixture like so:
-        metafunc.fixturenames.append('tmp_ct')
+        metafunc.fixturenames.append("tmp_ct")
 
         # Now we parametrize. This is what happens when we do e.g.,
         # @pytest.mark.parametrize('tmp_ct', range(count))
         # def test_foo(): pass
-        metafunc.parametrize('tmp_ct', list(range(count)))
+        metafunc.parametrize("tmp_ct", list(range(count)))
 
         # If ICE_CONFIG is not set, then set it to a default file
         if "ICE_CONFIG" not in os.environ:
@@ -37,11 +36,8 @@ def pytest_generate_tests(metafunc):
 
 
 class Methods(object):
-
     @classmethod
-    def assertAlmostEqual(self, first, second,
-                          places=None,
-                          delta=None):
+    def assertAlmostEqual(self, first, second, places=None, delta=None):
         # Copied largely from unittest
         """Fail if the two objects are unequal as determined by their
            difference rounded to the given number of decimal places
@@ -64,19 +60,15 @@ class Methods(object):
             if abs(first - second) <= delta:
                 return
 
-            standardMsg = '%s != %s within %s delta' % (first,
-                                                        second,
-                                                        delta)
+            standardMsg = "%s != %s within %s delta" % (first, second, delta)
         else:
             if places is None:
                 places = 7
 
-            if round(abs(second-first), places) == 0:
+            if round(abs(second - first), places) == 0:
                 return
 
-            standardMsg = '%s != %s within %r places' % (first,
-                                                         second,
-                                                         places)
+            standardMsg = "%s != %s within %r places" % (first, second, places)
         raise Exception(standardMsg)
 
 

--- a/test/unit/clitest/mocks.py
+++ b/test/unit/clitest/mocks.py
@@ -22,7 +22,6 @@ LOG = logging.getLogger("climocks")
 
 
 class MockCLI(CLI):
-
     def __init__(self, *args, **kwargs):
         self.__expect = []
         self.__output = []
@@ -46,8 +45,10 @@ class MockCLI(CLI):
                 return V
 
         # Not found
-        msg = """Couldn't find key: "%s". Options: %s""" % \
-            (key, [x[0] for x in self.__expect])
+        msg = """Couldn't find key: "%s". Options: %s""" % (
+            key,
+            [x[0] for x in self.__expect],
+        )
         print(msg)
         raise Exception(msg)
 

--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -32,27 +32,26 @@ topics = list(cli.topics.keys())
 
 
 class TestBasics(object):
-
     def testHelp(self):
         self.args = ["help", "-h"]
         cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('recursive', [None, "--recursive"])
+    @pytest.mark.parametrize("recursive", [None, "--recursive"])
     def testHelpAll(self, recursive):
         self.args = ["help", "--all"]
         if recursive:
             self.args.append(recursive)
         cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('recursive', [None, "--recursive"])
-    @pytest.mark.parametrize('command', commands)
+    @pytest.mark.parametrize("recursive", [None, "--recursive"])
+    @pytest.mark.parametrize("command", commands)
     def testHelpCommand(self, command, recursive):
         self.args = ["help", command]
         if recursive:
             self.args.append(recursive)
         cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('topic', topics)
+    @pytest.mark.parametrize("topic", topics)
     def testHelpTopic(self, topic):
         self.args = ["help", topic, "-h"]
         cli.invoke(self.args, strict=True)
@@ -68,14 +67,15 @@ class TestBasics(object):
         cli.invoke(["version"], strict=True)
 
     def testLoadGlob(object, monkeypatch, tmp_path, capsys):
-        (tmp_path / 'etc').mkdir()
-        (tmp_path / 'etc' / 'grid').mkdir()
-        monkeypatch.setenv('OMERODIR', str(tmp_path))
-        for i in 'abc':
-            (tmp_path / (i + 'a.omero')).write_text(
-                'config set {i} {i}'.format(i=i))
-        cli.invoke(["load", "--glob", str(tmp_path / '*.omero')], strict=True)
+        (tmp_path / "etc").mkdir()
+        (tmp_path / "etc" / "grid").mkdir()
+        monkeypatch.setenv("OMERODIR", str(tmp_path))
+        for i in "abc":
+            (tmp_path / (i + "a.omero")).write_text(
+                "config set {i} {i}".format(i=i)
+            )
+        cli.invoke(["load", "--glob", str(tmp_path / "*.omero")], strict=True)
         cli.invoke(["config", "get"], strict=True)
         captured = capsys.readouterr()
         lines = captured.out.splitlines()
-        assert lines == ['a=a', 'b=b', 'c=c']
+        assert lines == ["a=a", "b=b", "c=c"]

--- a/test/unit/clitest/test_chgrp.py
+++ b/test/unit/clitest/test_chgrp.py
@@ -25,7 +25,6 @@ from omero.plugins.chgrp import ChgrpControl
 
 
 class TestChgrp(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("chgrp", ChgrpControl, "TEST")

--- a/test/unit/clitest/test_cli.py
+++ b/test/unit/clitest/test_cli.py
@@ -18,7 +18,6 @@ from omero.plugins.basics import LoadControl
 
 
 class TestCli(object):
-
     def testMultipleLoad(self):
         """
         In DropBox, the loading of multiple CLIs seems to
@@ -53,7 +52,7 @@ class TestCli(object):
         assert len(threads) == len(set([t.cmp for t in threads]))
 
     def testLoad(self, tmpdir):
-        tmpfile = tmpdir.join('test')
+        tmpfile = tmpdir.join("test")
         tmpfile.write("foo")
         self.cli = CLI()
         self.cli.register("load", LoadControl, "help")

--- a/test/unit/clitest/test_db.py
+++ b/test/unit/clitest/test_db.py
@@ -10,6 +10,7 @@
 """
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import object
@@ -25,19 +26,18 @@ import getpass
 import builtins
 
 OMERODIR = False
-if 'OMERODIR' in os.environ:
-    OMERODIR = os.environ.get('OMERODIR')
+if "OMERODIR" in os.environ:
+    OMERODIR = os.environ.get("OMERODIR")
 
 hash_map = {
-    ('0', ''): 'PJueOtwuTPHB8Nq/1rFVxg==',
-    ('0', '--no-salt'): 'vvFwuczAmpyoRC0Nsv8FCw==',
-    ('1', ''): 'pvL5Tyr9tCD2esF938sHEQ==',
-    ('1', '--no-salt'): 'vvFwuczAmpyoRC0Nsv8FCw==',
+    ("0", ""): "PJueOtwuTPHB8Nq/1rFVxg==",
+    ("0", "--no-salt"): "vvFwuczAmpyoRC0Nsv8FCw==",
+    ("1", ""): "pvL5Tyr9tCD2esF938sHEQ==",
+    ("1", "--no-salt"): "vvFwuczAmpyoRC0Nsv8FCw==",
 }
 
 
 class TestDatabase(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("db", DatabaseControl, "TEST")
@@ -57,18 +57,18 @@ class TestDatabase(object):
                 for x in ("version", "patch"):
                     key = "omero.db." + x
                     if line.startswith(key):
-                        self.data[x] = line[len(key)+1:]
+                        self.data[x] = line[len(key) + 1 :]
 
         self.file = create_path()
         self.script_file = ""
         if "version" in self.data and "patch" in self.data:
             self.script_file = "%(version)s__%(patch)s.sql" % self.data
         if os.path.isfile(self.script_file):
-            os.rename(self.script_file, self.script_file + '.bak')
+            os.rename(self.script_file, self.script_file + ".bak")
         assert not os.path.isfile(self.script_file)
 
         self.mox = mox.Mox()
-        self.mox.StubOutWithMock(getpass, 'getpass')
+        self.mox.StubOutWithMock(getpass, "getpass")
         try:
             self.mox.StubOutWithMock(__builtins__, "raw_input")
         except AttributeError:
@@ -79,8 +79,8 @@ class TestDatabase(object):
         self.file.remove()
         if os.path.isfile(self.script_file):
             os.remove(self.script_file)
-        if os.path.isfile(self.script_file + '.bak'):
-            os.rename(self.script_file + '.bak', self.script_file)
+        if os.path.isfile(self.script_file + ".bak"):
+            os.rename(self.script_file + ".bak", self.script_file)
 
         self.mox.UnsetStubs()
         self.mox.VerifyAll()
@@ -92,8 +92,7 @@ class TestDatabase(object):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize(
-        'subcommand', DatabaseControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", DatabaseControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)
@@ -121,9 +120,9 @@ class TestDatabase(object):
         self.password("")
 
     @pytest.mark.skipif(OMERODIR is False, reason="self.password() fails")
-    @pytest.mark.parametrize('no_salt', ['', '--no-salt'])
-    @pytest.mark.parametrize('user_id', ['', '0', '1'])
-    @pytest.mark.parametrize('password', ['', 'ome'])
+    @pytest.mark.parametrize("no_salt", ["", "--no-salt"])
+    @pytest.mark.parametrize("user_id", ["", "0", "1"])
+    @pytest.mark.parametrize("password", ["", "ome"])
     def testPassword(self, user_id, password, no_salt, capsys):
         args = ""
         if user_id:
@@ -141,9 +140,9 @@ class TestDatabase(object):
         assert out.strip() == self.password_output(user_id, no_salt)
 
     @pytest.mark.skip(reason="Can't read omero.db.version")
-    @pytest.mark.parametrize('file_arg', ['', '-f', '--file'])
-    @pytest.mark.parametrize('no_salt', ['', '--no-salt'])
-    @pytest.mark.parametrize('password', ['', '--password ome'])
+    @pytest.mark.parametrize("file_arg", ["", "-f", "--file"])
+    @pytest.mark.parametrize("no_salt", ["", "--no-salt"])
+    @pytest.mark.parametrize("password", ["", "--password ome"])
     def testScript(self, no_salt, file_arg, password, capsys):
         """
         Recommended usage of db script
@@ -165,27 +164,28 @@ class TestDatabase(object):
         self.cli.invoke(args, strict=True)
 
         out, err = capsys.readouterr()
-        assert 'Using %s for version' % self.data['version'] in err
-        assert 'Using %s for patch' % self.data['patch'] in err
+        assert "Using %s for version" % self.data["version"] in err
+        assert "Using %s for patch" % self.data["patch"] in err
         if password:
-            assert 'Using password from commandline' in err
+            assert "Using password from commandline" in err
 
         with open(output) as f:
             lines = f.readlines()
             for line in lines:
-                if line.startswith('insert into password values (0'):
+                if line.startswith("insert into password values (0"):
                     assert line.strip() == self.script_output(no_salt)
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs omero.db.profile")
-    @pytest.mark.parametrize('file_arg', ['', '-f', '--file'])
-    @pytest.mark.parametrize('no_salt', ['', '--no-salt'])
-    @pytest.mark.parametrize('pos_args', [
-        '%s %s %s', '--version %s --patch %s --password %s'])
+    @pytest.mark.parametrize("file_arg", ["", "-f", "--file"])
+    @pytest.mark.parametrize("no_salt", ["", "--no-salt"])
+    @pytest.mark.parametrize(
+        "pos_args", ["%s %s %s", "--version %s --patch %s --password %s"]
+    )
     def testScriptDeveloperArgs(self, pos_args, no_salt, file_arg, capsys):
         """
         Deprecated and developer usage of db script
         """
-        arg_values = ('VERSION', 'PATCH', 'PASSWORD')
+        arg_values = ("VERSION", "PATCH", "PASSWORD")
         args = "db script " + pos_args % arg_values
         if no_salt:
             args += " %s" % no_salt
@@ -201,33 +201,36 @@ class TestDatabase(object):
 
         out, err = capsys.readouterr()
 
-        assert 'Using %s for version' % (arg_values[0]) in err
-        assert 'Using %s for patch' % (arg_values[1]) in err
-        assert 'Using password from commandline' in err
-        assert 'Invalid Database version/patch' in err
+        assert "Using %s for version" % (arg_values[0]) in err
+        assert "Using %s for patch" % (arg_values[1]) in err
+        assert "Using password from commandline" in err
+        assert "Invalid Database version/patch" in err
 
     def password_ending(self, user, id):
-        if id and id != '0':
+        if id and id != "0":
             rv = "user %s: " % id
         else:
             rv = "%s user: " % user
         return "password for OMERO " + rv
 
     def expectPassword(self, pw, user="root", id=None):
-        getpass.getpass("Please enter %s" %
-                        self.password_ending(user, id)).AndReturn(pw)
+        getpass.getpass(
+            "Please enter %s" % self.password_ending(user, id)
+        ).AndReturn(pw)
 
     def expectConfirmation(self, pw, user="root", id=None):
-        getpass.getpass("Please re-enter %s" %
-                        self.password_ending(user, id)).AndReturn(pw)
+        getpass.getpass(
+            "Please re-enter %s" % self.password_ending(user, id)
+        ).AndReturn(pw)
 
     def password_output(self, user_id, no_salt):
-        update_msg = "UPDATE password SET hash = \'%s\'" \
-            " WHERE experimenter_id = %s;"
+        update_msg = (
+            "UPDATE password SET hash = '%s'" " WHERE experimenter_id = %s;"
+        )
         if not user_id:
             user_id = "0"
         return update_msg % (hash_map[(user_id, no_salt)], user_id)
 
     def script_output(self, no_salt):
-        root_password_msg = "insert into password values (0,\'%s\');"
+        root_password_msg = "insert into password values (0,'%s');"
         return root_password_msg % (hash_map[("0", no_salt)])

--- a/test/unit/clitest/test_download.py
+++ b/test/unit/clitest/test_download.py
@@ -26,7 +26,6 @@ from omero.cli import CLI, NonZeroReturnCode
 
 
 class TestDownload(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("download", DownloadControl, "TEST")
@@ -37,9 +36,9 @@ class TestDownload(object):
         self.cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize(
-        'bad_input',
-        ['-1', 'OriginalFile:-1', 'FileAnnotation:-1', 'Image:-1'])
+        "bad_input", ["-1", "OriginalFile:-1", "FileAnnotation:-1", "Image:-1"]
+    )
     def testInvalidInput(self, bad_input):
-        self.args += [bad_input, '-']
+        self.args += [bad_input, "-"]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)

--- a/test/unit/clitest/test_export.py
+++ b/test/unit/clitest/test_export.py
@@ -22,25 +22,21 @@ omeroDir = old_div(path(os.getcwd()), "build")
 
 
 class MockCLI(CLI):
-
     def conn(self, args):
         return MockClient()
 
 
 class MockClient(object):
-
     def getSession(self, *args):
         return MockSession()
 
 
 class MockSession(object):
-
     def createExporter(self):
         return MockExporter()
 
 
 class MockExporter(object):
-
     def all(self, *args, **kwargs):
         pass
 
@@ -54,7 +50,6 @@ class MockExporter(object):
 
 
 class TestExport(object):
-
     def setup_method(self, method):
         self.cli = MockCLI()
         self.cli.register("x", ExportControl, "TEST")

--- a/test/unit/clitest/test_fs.py
+++ b/test/unit/clitest/test_fs.py
@@ -27,7 +27,6 @@ from omero.plugins.fs import FsControl
 
 
 class TestTag(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("fs", FsControl, "TEST")
@@ -37,7 +36,7 @@ class TestTag(object):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('subcommand', FsControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", FsControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)

--- a/test/unit/clitest/test_group.py
+++ b/test/unit/clitest/test_group.py
@@ -26,7 +26,6 @@ from omero.cli import CLI
 
 
 class TestGroup(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("group", GroupControl, "TEST")

--- a/test/unit/clitest/test_hql.py
+++ b/test/unit/clitest/test_hql.py
@@ -27,7 +27,6 @@ from omero.plugins.hql import HqlControl, BLACKLISTED_KEYS, WHITELISTED_VALUES
 
 
 class TestHql(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("hql", HqlControl, "TEST")
@@ -49,27 +48,27 @@ class TestHql(object):
 
     @pytest.mark.parametrize(
         ("value", "outcome"),
-        [("owner=None;group=None", {}),
-         ("owner=1", {"details": "owner=1"})])
+        [("owner=None;group=None", {}), ("owner=1", {"details": "owner=1"})],
+    )
     def testFilterDetails(self, value, outcome):
         output = self.cli.controls["hql"].filter({"_details": value})
         assert output == outcome
 
     @pytest.mark.parametrize("multi_value", [[0, 1]])
     def testFilterMultiValue(self, multi_value):
-        output = self.cli.controls["hql"].filter({'key': multi_value})
+        output = self.cli.controls["hql"].filter({"key": multi_value})
         assert output == {}
 
     @pytest.mark.parametrize("empty_value", [None, [], {}])
     def testFilterEmptyValue(self, empty_value):
-        output = self.cli.controls["hql"].filter({'key': empty_value})
+        output = self.cli.controls["hql"].filter({"key": empty_value})
         assert output == {}
 
     @pytest.mark.parametrize("value", WHITELISTED_VALUES)
     def testFilterWhitelist(self, value):
-        output = self.cli.controls["hql"].filter({'key': value})
-        assert output == {'key': value}
+        output = self.cli.controls["hql"].filter({"key": value})
+        assert output == {"key": value}
 
     def testFilterStrip(self):
-        output = self.cli.controls["hql"].filter({'_key': 1})
-        assert output == {'key': 1}
+        output = self.cli.controls["hql"].filter({"_key": 1})
+        assert output == {"key": 1}

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
@@ -23,14 +24,17 @@ from omero_ext.path import path
 import omero.clients
 import uuid
 from omero.cli import CLI, NonZeroReturnCode
+
 # Workaround for a poorly named module
 try:
-    plugin = __import__('omero.plugins.import', globals(), locals(),
-                        ['ImportControl'], -1)
+    plugin = __import__(
+        "omero.plugins.import", globals(), locals(), ["ImportControl"], -1
+    )
 except ValueError:
     # Python 3
-    plugin = __import__('omero.plugins.import', globals(), locals(),
-                        ['ImportControl'], 0)
+    plugin = __import__(
+        "omero.plugins.import", globals(), locals(), ["ImportControl"], 0
+    )
 
 ImportControl = plugin.ImportControl
 CommandArguments = plugin.CommandArguments
@@ -38,11 +42,11 @@ CommandArguments = plugin.CommandArguments
 help_arguments = ("-h", "--javahelp", "--java-help", "--advanced-help")
 
 OMERODIR = False
-if 'OMERODIR' in os.environ:
-    OMERODIR = os.environ.get('OMERODIR')
+if "OMERODIR" in os.environ:
+    OMERODIR = os.environ.get("OMERODIR")
+
 
 class MockClient(omero.clients.BaseClient):
-
     def setSessionId(self, uuid):
         self._uuid = uuid
 
@@ -51,7 +55,6 @@ class MockClient(omero.clients.BaseClient):
 
 
 class TestImport(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("import", ImportControl, "TEST")
@@ -72,26 +75,40 @@ class TestImport(object):
             ds_store.write("")
         return child
 
-    def mkfakescreen(self, screen_dir, nplates=2, nruns=2, nwells=2,
-                     nfields=4, with_ds_store=False):
+    def mkfakescreen(
+        self,
+        screen_dir,
+        nplates=2,
+        nruns=2,
+        nwells=2,
+        nfields=4,
+        with_ds_store=False,
+    ):
 
         fieldfiles = []
         for iplate in range(nplates):
             plate_dir = self.mkdir(
-                screen_dir, "Plate00%s" % str(iplate),
-                with_ds_store=with_ds_store)
+                screen_dir,
+                "Plate00%s" % str(iplate),
+                with_ds_store=with_ds_store,
+            )
             for irun in range(nruns):
                 run_dir = self.mkdir(
-                    plate_dir, "Run00%s" % str(irun),
-                    with_ds_store=with_ds_store)
+                    plate_dir,
+                    "Run00%s" % str(irun),
+                    with_ds_store=with_ds_store,
+                )
                 for iwell in range(nwells):
                     well_dir = self.mkdir(
-                        run_dir, "WellA00%s" % str(iwell),
-                        with_ds_store=with_ds_store)
+                        run_dir,
+                        "WellA00%s" % str(iwell),
+                        with_ds_store=with_ds_store,
+                    )
                     for ifield in range(nfields):
-                        fieldfile = (old_div(well_dir, ("Field00%s.fake" %
-                                                 str(ifield))))
-                        fieldfile.write('')
+                        fieldfile = old_div(
+                            well_dir, ("Field00%s.fake" % str(ifield))
+                        )
+                        fieldfile.write("")
                         fieldfiles.append(fieldfile)
         return fieldfiles
 
@@ -102,14 +119,17 @@ class TestImport(object):
         tiffiles = []
         for angle in range(1, nangles + 1):
             for timepoint in range(1, ntimepoints + 1):
-                tiffile = (old_div(spim_dir, ("spim_TL%s_Angle%s.fake" %
-                                       (str(timepoint), str(angle)))))
-                tiffile.write('')
+                tiffile = old_div(
+                    spim_dir,
+                    ("spim_TL%s_Angle%s.fake" % (str(timepoint), str(angle))),
+                )
+                tiffile.write("")
                 print(str(tiffile))
                 tiffiles.append(tiffile)
         patternfile = old_div(spim_dir, "spim.pattern")
-        patternfile.write("spim_TL<1-%s>_Angle<1-%s>.fake"
-                          % (str(ntimepoints), str(nangles)))
+        patternfile.write(
+            "spim_TL<1-%s>_Angle<1-%s>.fake" % (str(ntimepoints), str(nangles))
+        )
         assert len(tiffiles) == nangles * ntimepoints
         return patternfile, tiffiles
 
@@ -123,26 +143,32 @@ class TestImport(object):
                 assert args.file == "/tmp/dropbox.out"
 
         self.cli.register("mock-import", MockImportControl, "HELP")
-        self.args = ['-s', 'localhost', '-p', '4064', '-k',
-                     'b0742975-03a1-4f6d-b0ac-639943f1a147']
-        self.args += ['mock-import', '---errs=/tmp/dropbox.err']
-        self.args += ['---file=/tmp/dropbox.out']
-        self.args += ['--', '/OMERO/DropBox/root/test.fake']
+        self.args = [
+            "-s",
+            "localhost",
+            "-p",
+            "4064",
+            "-k",
+            "b0742975-03a1-4f6d-b0ac-639943f1a147",
+        ]
+        self.args += ["mock-import", "---errs=/tmp/dropbox.err"]
+        self.args += ["---file=/tmp/dropbox.out"]
+        self.args += ["--", "/OMERO/DropBox/root/test.fake"]
 
         self.cli.invoke(self.args)
 
-    @pytest.mark.parametrize('help_argument', help_arguments)
+    @pytest.mark.parametrize("help_argument", help_arguments)
     def testHelp(self, help_argument):
         """Test help arguments"""
         self.args += [help_argument]
         self.cli.invoke(self.args)
 
-    @pytest.mark.parametrize('clientdir_exists', [True, False])
+    @pytest.mark.parametrize("clientdir_exists", [True, False])
     def testImportNoClientDirFails(self, tmpdir, clientdir_exists):
         """Test fake screen import"""
 
         fakefile = tmpdir.join("test.fake")
-        fakefile.write('')
+        fakefile.write("")
 
         if clientdir_exists:
             self.args += ["--clientdir", str(tmpdir)]
@@ -161,7 +187,7 @@ class TestImport(object):
         dir2 = old_div(dir1, "b")
         dir2.mkdir()
         fakefile = old_div(dir2, "test.fake")
-        fakefile.write('')
+        fakefile.write("")
 
         self.add_client_dir()
         self.args += ["-f", "--debug=ERROR"]
@@ -185,7 +211,7 @@ class TestImport(object):
         """Test fake image import"""
 
         fakefile = tmpdir.join("test.fake")
-        fakefile.write('')
+        fakefile.write("")
 
         self.add_client_dir()
         self.args += ["-f", "--debug=ERROR"]
@@ -193,24 +219,29 @@ class TestImport(object):
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
-        outputlines = str(o).split('\n')
-        reader = 'loci.formats.in.FakeReader'
+        outputlines = str(o).split("\n")
+        reader = "loci.formats.in.FakeReader"
         assert outputlines[-2] == str(fakefile)
-        assert outputlines[-3] == \
-            "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
+        assert outputlines[-3] == "# Group: %s SPW: false Reader: %s" % (
+            str(fakefile),
+            reader,
+        )
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
-    @pytest.mark.parametrize('params', (
-        ("-l", "only_fakes.txt", True),
-        ("-l", "no_fakes.txt", False),
-        ("--readers", "only_fakes.txt", True),
-        ("--readers", "no_fakes.txt", False),
-    ))
+    @pytest.mark.parametrize(
+        "params",
+        (
+            ("-l", "only_fakes.txt", True),
+            ("-l", "no_fakes.txt", False),
+            ("--readers", "only_fakes.txt", True),
+            ("--readers", "no_fakes.txt", False),
+        ),
+    )
     def testImportReaders(self, tmpdir, capfd, params):
         """Test fake image import"""
 
         fakefile = tmpdir.join("test.fake")
-        fakefile.write('')
+        fakefile.write("")
 
         flag, filename, status = params
         filename = path(__file__).parent / "readers" / filename
@@ -221,11 +252,13 @@ class TestImport(object):
         if status:
             self.cli.invoke(self.args, strict=True)
             o, e = capfd.readouterr()
-            outputlines = str(o).split('\n')
-            reader = 'loci.formats.in.FakeReader'
+            outputlines = str(o).split("\n")
+            reader = "loci.formats.in.FakeReader"
             assert outputlines[-2] == str(fakefile)
-            assert outputlines[-3] == \
-                "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
+            assert outputlines[-3] == "# Group: %s SPW: false Reader: %s" % (
+                str(fakefile),
+                reader,
+            )
         else:
             with pytest.raises(NonZeroReturnCode):
                 self.cli.invoke(self.args, strict=True)
@@ -233,14 +266,13 @@ class TestImport(object):
             assert "parsed into 0 group" in e
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
-    @pytest.mark.parametrize('with_ds_store', (True, False))
+    @pytest.mark.parametrize("with_ds_store", (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
         """Test fake screen import"""
 
         screen_dir = tmpdir.join("screen.fake")
         screen_dir.mkdir()
-        fieldfiles = self.mkfakescreen(
-            screen_dir, with_ds_store=with_ds_store)
+        fieldfiles = self.mkfakescreen(screen_dir, with_ds_store=with_ds_store)
 
         self.add_client_dir()
         self.args += ["-f", "--debug=ERROR"]
@@ -248,12 +280,13 @@ class TestImport(object):
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
-        outputlines = str(o).split('\n')
-        reader = 'loci.formats.in.FakeReader'
-        assert outputlines[-len(fieldfiles)-2] == \
-            "# Group: %s SPW: true Reader: %s" % (str(fieldfiles[0]), reader)
+        outputlines = str(o).split("\n")
+        reader = "loci.formats.in.FakeReader"
+        assert outputlines[
+            -len(fieldfiles) - 2
+        ] == "# Group: %s SPW: true Reader: %s" % (str(fieldfiles[0]), reader)
         for i in range(len(fieldfiles)):
-            assert outputlines[-1-len(fieldfiles)+i] == str(fieldfiles[i])
+            assert outputlines[-1 - len(fieldfiles) + i] == str(fieldfiles[i])
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testImportPattern(self, tmpdir, capfd):
@@ -267,19 +300,20 @@ class TestImport(object):
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
-        outputlines = str(o).split('\n')
-        reader = 'loci.formats.in.FilePatternReader'
+        outputlines = str(o).split("\n")
+        reader = "loci.formats.in.FilePatternReader"
         print(o)
-        assert outputlines[-len(tiffiles)-3] == \
-            "# Group: %s SPW: false Reader: %s" % (str(patternfile), reader)
-        assert outputlines[-len(tiffiles)-2] == str(patternfile)
+        assert outputlines[
+            -len(tiffiles) - 3
+        ] == "# Group: %s SPW: false Reader: %s" % (str(patternfile), reader)
+        assert outputlines[-len(tiffiles) - 2] == str(patternfile)
         for i in range(len(tiffiles)):
-            assert outputlines[-1-len(tiffiles)+i] == str(tiffiles[i])
+            assert outputlines[-1 - len(tiffiles) + i] == str(tiffiles[i])
 
-    @pytest.mark.parametrize('hostname', ['localhost', 'servername'])
-    @pytest.mark.parametrize('port', [None, 4064, 14064])
+    @pytest.mark.parametrize("hostname", ["localhost", "servername"])
+    @pytest.mark.parametrize("port", [None, 4064, 14064])
     def testLoginArguments(self, monkeypatch, hostname, port, tmpdir):
-        self.args += ['test.fake']
+        self.args += ["test.fake"]
         sessionid = str(uuid.uuid4())
 
         def new_client(x):
@@ -289,29 +323,35 @@ class TestImport(object):
                 c = MockClient(hostname)
             c.setSessionId(sessionid)
             return c
-        monkeypatch.setattr(self.cli, 'conn', new_client)
-        ice_config = old_div(tmpdir, 'ice.config')
-        ice_config.write('omero.host=%s\nomero.port=%g' % (
-            hostname, (port or 4064)))
+
+        monkeypatch.setattr(self.cli, "conn", new_client)
+        ice_config = old_div(tmpdir, "ice.config")
+        ice_config.write(
+            "omero.host=%s\nomero.port=%g" % (hostname, (port or 4064))
+        )
         monkeypatch.setenv("ICE_CONFIG", "%s" % ice_config)
         args = self.cli.parser.parse_args(self.args)
         command_args = CommandArguments(self.cli, args)
 
-        expected_args = ['-s', '%s' % hostname]
-        expected_args += ['-p', '%s' % (port or 4064)]
-        expected_args += ['-k', '%s' % sessionid]
-        expected_args += ['test.fake']
+        expected_args = ["-s", "%s" % hostname]
+        expected_args += ["-p", "%s" % (port or 4064)]
+        expected_args += ["-k", "%s" % sessionid]
+        expected_args += ["test.fake"]
         assert command_args.java_args() == expected_args
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testLogPrefix(self, tmpdir, capfd):
         fakefile = tmpdir.join("test.fake")
-        fakefile.write('')
+        fakefile.write("")
         prefix = tmpdir.join("log")
 
         self.add_client_dir()
-        self.args += ["-f", "---logprefix=%s" % prefix,
-                      "---file=out", "---errs=errs"]
+        self.args += [
+            "-f",
+            "---logprefix=%s" % prefix,
+            "---file=out",
+            "---errs=errs",
+        ]
         self.args += [str(fakefile)]
         self.cli.invoke(self.args, strict=True)
 
@@ -320,10 +360,12 @@ class TestImport(object):
         assert e == ""
 
         outlines = prefix.join("out").read().split("\n")
-        reader = 'loci.formats.in.FakeReader'
+        reader = "loci.formats.in.FakeReader"
         assert outlines[-2] == str(fakefile)
-        assert outlines[-3] == \
-            "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
+        assert outlines[-3] == "# Group: %s SPW: false Reader: %s" % (
+            str(fakefile),
+            reader,
+        )
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testYamlOutput(self, tmpdir, capfd):
@@ -332,7 +374,7 @@ class TestImport(object):
         from io import StringIO
 
         fakefile = tmpdir.join("test.fake")
-        fakefile.write('')
+        fakefile.write("")
         self.add_client_dir()
         self.args += ["-f", "--output=yaml", str(fakefile)]
         self.cli.invoke(self.args, strict=True)
@@ -381,6 +423,7 @@ class TestImport(object):
         class MockImportControl(ImportControl):
             def do_import(self, command_args, xargs):
                 assert "--name=testname" in command_args.java_args()
+
         self.cli.register("mock-import", MockImportControl, "HELP")
 
         self.args = ["mock-import", "-f", "---bulk=%s" % b]
@@ -397,8 +440,7 @@ class TestImport(object):
         class MockImportControl(ImportControl):
             def do_import(self, command_args, xargs):
                 cmd = command_args.java_args()
-                assert "--name=meta_one" in cmd or \
-                       "--name=meta_two" in cmd
+                assert "--name=meta_one" in cmd or "--name=meta_two" in cmd
 
         self.cli.register("mock-import", MockImportControl, "HELP")
 
@@ -434,12 +476,15 @@ class TestImport(object):
 
         class MockImportControl(ImportControl):
             def do_import(self, command_args, xargs):
-                assert ("--checksum-algorithm=File-Size-64" in
-                        command_args.java_args())
+                assert (
+                    "--checksum-algorithm=File-Size-64"
+                    in command_args.java_args()
+                )
                 assert "--parallel-upload=10" in command_args.java_args()
                 assert "--parallel-fileset=5" in command_args.java_args()
                 assert "--transfer=ln_s" in command_args.java_args()
                 assert "--exclude=clientpath" in command_args.java_args()
+
         self.cli.register("mock-import", MockImportControl, "HELP")
 
         self.args = ["mock-import", "-f", "---bulk=%s" % b]
@@ -447,7 +492,7 @@ class TestImport(object):
         self.cli.invoke(self.args, strict=True)
 
     @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
-    @pytest.mark.parametrize('skip', plugin.SKIP_CHOICES)
+    @pytest.mark.parametrize("skip", plugin.SKIP_CHOICES)
     def testBulkSkip(self, skip):
         """Test skip arguments"""
         t = path(__file__).parent / "bulk_import" / "test_skip"
@@ -456,17 +501,17 @@ class TestImport(object):
         class MockImportControl(ImportControl):
             def do_import(self, command_args, xargs):
                 if skip in ["all", "checksum"]:
-                    assert ("--checksum-algorithm=File-Size-64" in
-                            command_args.java_args())
+                    assert (
+                        "--checksum-algorithm=File-Size-64"
+                        in command_args.java_args()
+                    )
                 if skip in ["all", "minmax"]:
-                    assert ("--no-stats-info" in
-                            command_args.java_args())
+                    assert "--no-stats-info" in command_args.java_args()
                 if skip in ["all", "thumbnails"]:
-                    assert ("--no-thumbnails" in
-                            command_args.java_args())
+                    assert "--no-thumbnails" in command_args.java_args()
                 if skip in ["all", "upgrade"]:
-                    assert ("--no-upgrade-check" in
-                            command_args.java_args())
+                    assert "--no-upgrade-check" in command_args.java_args()
+
         self.cli.register("mock-import", MockImportControl, "HELP")
 
         self.args = ["mock-import", "-f", "---bulk=%s" % b]

--- a/test/unit/clitest/test_ldap.py
+++ b/test/unit/clitest/test_ldap.py
@@ -26,7 +26,6 @@ import pytest
 
 
 class TestLdap(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("ldap", LdapControl, "TEST")
@@ -36,7 +35,7 @@ class TestLdap(object):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('subcommand', LdapControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", LdapControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)

--- a/test/unit/clitest/test_obj.py
+++ b/test/unit/clitest/test_obj.py
@@ -39,7 +39,6 @@ from mox3 import mox
 
 
 class MockCLI(CLI):
-
     def conn(self, *args, **kwargs):
         return self.get_client()
 
@@ -54,7 +53,6 @@ class MockCLI(CLI):
 
 
 class TxBase(object):
-
     def setup_method(self, method):
         self.mox = mox.Mox()
         self.client = self.mox.CreateMock(BaseClient)
@@ -72,7 +70,9 @@ class TxBase(object):
 
     def queries(self, obj):
         self.sf.getQueryService().AndReturn(self.query)
-        self.query.get(mox.IgnoreArg(), mox.IgnoreArg(), mox.IgnoreArg()).AndReturn(obj)
+        self.query.get(
+            mox.IgnoreArg(), mox.IgnoreArg(), mox.IgnoreArg()
+        ).AndReturn(obj)
 
     def saves(self, obj):
         self.sf.getUpdateService().AndReturn(self.update)
@@ -80,7 +80,6 @@ class TxBase(object):
 
 
 class TestNewObjectTxAction(TxBase):
-
     def test_unknown_class(self):
         self.saves(ProjectI(1, False))
         self.mox.ReplayAll()
@@ -91,7 +90,6 @@ class TestNewObjectTxAction(TxBase):
 
 
 class TestObjControl(TxBase):
-
     def setup_method(self, method):
         super(TestObjControl, self).setup_method(method)
         self.cli.register("obj", ObjControl, "TEST")
@@ -107,15 +105,17 @@ class TestObjControl(TxBase):
         self.queries(ProjectI(1, True))
         self.saves(ProjectI(1, False))
         self.mox.ReplayAll()
-        self.cli.invoke(("obj update Project:1 name=bar "
-                        "description=loooong"), strict=True)
+        self.cli.invoke(
+            ("obj update Project:1 name=bar " "description=loooong"),
+            strict=True,
+        )
         assert self.cli._out == ["Project:1"]
 
     def testHelp(self):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('subcommand', ObjControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", ObjControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)

--- a/test/unit/clitest/test_prefs.py
+++ b/test/unit/clitest/test_prefs.py
@@ -28,6 +28,7 @@ try:
 except:
     basestring = str
 
+
 @pytest.fixture
 def configxml(monkeypatch):
     class MockConfigXml(object):
@@ -39,11 +40,11 @@ def configxml(monkeypatch):
 
         def close(self):
             pass
+
     monkeypatch.setattr("omero.config.ConfigXml", MockConfigXml)
 
 
 class TestPrefs(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("config", PrefsControl, HELP)
@@ -53,13 +54,12 @@ class TestPrefs(object):
     def config(self):
         return ConfigXml(filename=str(self.p))
 
-    def assertStdoutStderr(self, capsys, out='', err='', strip_warning=False):
+    def assertStdoutStderr(self, capsys, out="", err="", strip_warning=False):
         o, e = capsys.readouterr()
         if strip_warning:
-            assert(e.startswith('WARNING: '))
-            e = '\n'.join(e.split('\n')[1:])
-        assert (o.strip() == out and
-                e.strip() == err)
+            assert e.startswith("WARNING: ")
+            e = "\n".join(e.split("\n")[1:])
+        assert o.strip() == out and e.strip() == err
 
     def invoke(self, s):
         if isinstance(s, basestring):
@@ -70,7 +70,7 @@ class TestPrefs(object):
         self.invoke("-h")
         assert 0 == self.cli.rv
 
-    @pytest.mark.parametrize('subcommand', PrefsControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", PrefsControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.invoke("%s -h" % subcommand)
         assert 0 == self.cli.rv
@@ -103,9 +103,9 @@ class TestPrefs(object):
         self.invoke("set A B")
         self.assertStdoutStderr(capsys)
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='B')
+        self.assertStdoutStderr(capsys, out="B")
         self.invoke("get")
-        self.assertStdoutStderr(capsys, out='A=B')
+        self.assertStdoutStderr(capsys, out="A=B")
         self.invoke("set A")
         self.assertStdoutStderr(capsys)
         self.invoke("keys")
@@ -122,29 +122,32 @@ class TestPrefs(object):
             "omero.Y.Password": "medium_password",
             "omero.Z.mypassword": "",
             "omero.Z.pass": "",
-            "omero.Z.password": ""}
+            "omero.Z.password": "",
+        }
         output_hidden_password = (
-            'omero.X.mypassword=********\n'
-            'omero.X.pass=********\n'
-            'omero.X.password=********\n'
-            'omero.X.regular=value\n'
-            'omero.Y.MyPassword=********\n'
-            'omero.Y.Pass=********\n'
-            'omero.Y.Password=********\n'
-            'omero.Z.mypassword=\n'
-            'omero.Z.pass=\n'
-            'omero.Z.password=')
+            "omero.X.mypassword=********\n"
+            "omero.X.pass=********\n"
+            "omero.X.password=********\n"
+            "omero.X.regular=value\n"
+            "omero.Y.MyPassword=********\n"
+            "omero.Y.Pass=********\n"
+            "omero.Y.Password=********\n"
+            "omero.Z.mypassword=\n"
+            "omero.Z.pass=\n"
+            "omero.Z.password="
+        )
         output_with_password = (
-            'omero.X.mypassword=long_password\n'
-            'omero.X.pass=shortpass\n'
-            'omero.X.password=medium_password\n'
-            'omero.X.regular=value\n'
-            'omero.Y.MyPassword=long_password\n'
-            'omero.Y.Pass=shortpass\n'
-            'omero.Y.Password=medium_password\n'
-            'omero.Z.mypassword=\n'
-            'omero.Z.pass=\n'
-            'omero.Z.password=')
+            "omero.X.mypassword=long_password\n"
+            "omero.X.pass=shortpass\n"
+            "omero.X.password=medium_password\n"
+            "omero.X.regular=value\n"
+            "omero.Y.MyPassword=long_password\n"
+            "omero.Y.Pass=shortpass\n"
+            "omero.Y.Password=medium_password\n"
+            "omero.Z.mypassword=\n"
+            "omero.Z.pass=\n"
+            "omero.Z.password="
+        )
 
         for k, v in config.items():
             self.cli.invoke(self.args + ["set", k, v], strict=True)
@@ -153,17 +156,20 @@ class TestPrefs(object):
         self.invoke("get --show-password")
         self.assertStdoutStderr(capsys, out=output_with_password)
         self.invoke("list")
-        self.assertStdoutStderr(capsys, out=output_hidden_password,
-                                strip_warning=True)
+        self.assertStdoutStderr(
+            capsys, out=output_hidden_password, strip_warning=True
+        )
         self.invoke("list --show-password")
-        self.assertStdoutStderr(capsys, out=output_with_password,
-                                strip_warning=True)
+        self.assertStdoutStderr(
+            capsys, out=output_with_password, strip_warning=True
+        )
 
-    @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
+    @pytest.mark.parametrize("argument", ["A=B", "A= B"])
     def testSetFails(self, capsys, argument):
         self.invoke("set %s" % argument)
         self.assertStdoutStderr(
-            capsys, err="\"=\" in key name. Did you mean \"...set A B\"?")
+            capsys, err='"=" in key name. Did you mean "...set A B"?'
+        )
 
     def testKeys(self, capsys):
         self.invoke("keys")
@@ -201,7 +207,8 @@ class TestPrefs(object):
             # Different property/value pair should fail
             self.invoke("load %s" % to_load)
         self.assertStdoutStderr(
-            capsys, err="Duplicate property: A ('B' => 'C')")
+            capsys, err="Duplicate property: A ('B' => 'C')"
+        )
 
         # Quiet load
         self.invoke("load -q %s" % to_load)
@@ -211,8 +218,9 @@ class TestPrefs(object):
 
     def testLoadDoesNotExist(self):
         # ticket:7273
-        pytest.raises(NonZeroReturnCode, self.invoke,
-                      "load THIS_FILE_SHOULD_NOT_EXIST")
+        pytest.raises(
+            NonZeroReturnCode, self.invoke, "load THIS_FILE_SHOULD_NOT_EXIST"
+        )
 
     def testLoadMultiLine(self, capsys):
         to_load = create_path()
@@ -222,8 +230,9 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out="A=BC")
 
     @pytest.mark.parametrize(
-        'validkeyvalue',
-        [('A', 'B'), ('A', 'B=C'), ('A.B', 'C.D'), ('A.B', "'C.D'")])
+        "validkeyvalue",
+        [("A", "B"), ("A", "B=C"), ("A.B", "C.D"), ("A.B", "'C.D'")],
+    )
     def testLoadWhitelist(self, capsys, validkeyvalue):
         valid_key, valid_value = validkeyvalue
         to_load = create_path()
@@ -233,10 +242,9 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out=valid_value)
 
     @pytest.mark.parametrize(
-        ('invalidline', 'invalidkey'),
-        [('E F G', 'E F G'),
-         ('E!F=G', 'E!F'),
-         ('E = F', 'E')])
+        ("invalidline", "invalidkey"),
+        [("E F G", "E F G"), ("E!F=G", "E!F"), ("E = F", "E")],
+    )
     def testLoadInvalidKey(self, capsys, invalidline, invalidkey):
         self.invoke("set A B")
         self.assertStdoutStderr(capsys)
@@ -246,25 +254,28 @@ class TestPrefs(object):
         with pytest.raises(NonZeroReturnCode):
             self.invoke("load %s" % to_load)
         self.assertStdoutStderr(
-            capsys, err="Illegal property name: %s" % invalidkey)
+            capsys, err="Illegal property name: %s" % invalidkey
+        )
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=B")
 
     @pytest.mark.parametrize(
-        'valid_key_value',
-        [('A', 'B'), ('A', 'B=C'), ('A.B', 'C.D'), ('A.B', "'C.D'")])
+        "valid_key_value",
+        [("A", "B"), ("A", "B=C"), ("A.B", "C.D"), ("A.B", "'C.D'")],
+    )
     def testSetWhitelist(self, capsys, valid_key_value):
         valid_key, valid_value = valid_key_value
         self.invoke(["set", valid_key, valid_value])
         self.invoke(["get", valid_key])
         self.assertStdoutStderr(capsys, out=valid_value)
 
-    @pytest.mark.parametrize('invalid_key', ['E F', 'E!F', 'E '])
+    @pytest.mark.parametrize("invalid_key", ["E F", "E!F", "E "])
     def testSetInvalidKey(self, capsys, invalid_key):
         with pytest.raises(NonZeroReturnCode):
             self.invoke(["set", invalid_key, "test"])
         self.assertStdoutStderr(
-            capsys, err="Illegal property name: %s" % invalid_key.strip())
+            capsys, err="Illegal property name: %s" % invalid_key.strip()
+        )
 
     def testSetFromFile(self, capsys):
         to_load = create_path()
@@ -287,7 +298,7 @@ class TestPrefs(object):
         self.invoke("drop x")
         self.assertStdoutStderr(capsys)
         self.invoke("all")
-        self.assertStdoutStderr(capsys, 'y\ndefault')
+        self.assertStdoutStderr(capsys, "y\ndefault")
 
     def testDropFails(self, capsys):
         self.invoke("drop x")
@@ -299,8 +310,10 @@ class TestPrefs(object):
         start another process. Rather than using invoke, we
         manage things ourselves here.
         """
+
         def fake_edit_path(tmp_file, tmp_text):
             pass
+
         args = self.cli.parser.parse_args("config edit".split())
         control = self.cli.controls["config"]
         config = self.config()
@@ -320,8 +333,8 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out="A=B")
 
     @pytest.mark.parametrize(
-        ('initval', 'newval'),
-        [('1', '2'), ('\"1\"', '\"2\"'), ('test', 'test')])
+        ("initval", "newval"), [("1", "2"), ('"1"', '"2"'), ("test", "test")]
+    )
     def testAppendFails(self, initval, newval):
         self.invoke("set A %s" % initval)
         with pytest.raises(NonZeroReturnCode):
@@ -332,114 +345,123 @@ class TestPrefs(object):
             self.invoke("remove A x")
 
     @pytest.mark.parametrize(
-        ('initval', 'newval'),
-        [('1', '1'), ('[\"1\"]', '1'), ('[1]', '\"1\"')])
+        ("initval", "newval"), [("1", "1"), ('["1"]', "1"), ("[1]", '"1"')]
+    )
     def testRemoveFails(self, initval, newval):
         self.invoke("set A %s" % initval)
         with pytest.raises(NonZeroReturnCode):
             self.invoke("remove A %s" % newval)
 
-    @pytest.mark.parametrize('report', ['--report', ''])
+    @pytest.mark.parametrize("report", ["--report", ""])
     def testAppendRemove(self, report, capsys):
         self.invoke("append %s A 1" % report)
-        self.assertReportStdout(report, capsys, 'Appended A:1')
+        self.assertReportStdout(report, capsys, "Appended A:1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1]')
-        self.invoke("append %s A \"y\"" % report)
+        self.assertStdoutStderr(capsys, out="[1]")
+        self.invoke('append %s A "y"' % report)
         self.assertReportStdout(report, capsys, 'Appended A:"y"')
         self.invoke("get A")
         self.assertStdoutStderr(capsys, out='[1, "y"]')
-        self.invoke("remove %s A \"y\"" % report)
+        self.invoke('remove %s A "y"' % report)
         self.assertReportStdout(report, capsys, 'Removed A:"y"')
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1]')
+        self.assertStdoutStderr(capsys, out="[1]")
         self.invoke("remove %s A 1" % report)
-        self.assertReportStdout(report, capsys, 'Removed A:1')
+        self.assertReportStdout(report, capsys, "Removed A:1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[]')
+        self.assertStdoutStderr(capsys, out="[]")
 
     def assertReportStdout(self, report, capsys, out):
         if report and out:
-            self.assertStdoutStderr(capsys, out='Changed: %s' % out)
+            self.assertStdoutStderr(capsys, out="Changed: %s" % out)
         else:
-            self.assertStdoutStderr(capsys, out='')
+            self.assertStdoutStderr(capsys, out="")
 
-    @pytest.mark.parametrize('report', ['--report', ''])
+    @pytest.mark.parametrize("report", ["--report", ""])
     def testAppendSet(self, report, capsys):
         self.invoke("append %s --set A 1" % report)
-        self.assertReportStdout(report, capsys, 'Appended A:1')
+        self.assertReportStdout(report, capsys, "Appended A:1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1]')
+        self.assertStdoutStderr(capsys, out="[1]")
         self.invoke("append %s --set A 2" % report)
-        self.assertReportStdout(report, capsys, 'Appended A:2')
+        self.assertReportStdout(report, capsys, "Appended A:2")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1, 2]')
+        self.assertStdoutStderr(capsys, out="[1, 2]")
         self.invoke("append %s --set A 1" % report)
-        self.assertReportStdout(report, capsys, '')
+        self.assertReportStdout(report, capsys, "")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1, 2]')
+        self.assertStdoutStderr(capsys, out="[1, 2]")
         self.invoke("append %s A 1" % report)
-        self.assertReportStdout(report, capsys, 'Appended A:1')
+        self.assertReportStdout(report, capsys, "Appended A:1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1, 2, 1]')
+        self.assertStdoutStderr(capsys, out="[1, 2, 1]")
 
     def testRemoveIdenticalValues(self, capsys):
         self.invoke("set A [1,1]")
         self.invoke("remove A 1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[1]')
+        self.assertStdoutStderr(capsys, out="[1]")
         self.invoke("remove A 1")
         self.invoke("get A")
-        self.assertStdoutStderr(capsys, out='[]')
+        self.assertStdoutStderr(capsys, out="[]")
 
     @pytest.mark.xfail
-    @pytest.mark.broken(reason = "migrate to omero-web")
-    @pytest.mark.usefixtures('configxml')
+    @pytest.mark.broken(reason="migrate to omero-web")
+    @pytest.mark.usefixtures("configxml")
     def testAppendWithDefault(self, monkeypatch, capsys):
         import json
-        monkeypatch.setattr("omeroweb.settings.CUSTOM_SETTINGS_MAPPINGS", {
-            "omero.web.test": ["TEST", "[1,2,3]", json.loads],
-            "omero.web.notalist": ["NOTALIST", "abc", str],
-        })
+
+        monkeypatch.setattr(
+            "omeroweb.settings.CUSTOM_SETTINGS_MAPPINGS",
+            {
+                "omero.web.test": ["TEST", "[1,2,3]", json.loads],
+                "omero.web.notalist": ["NOTALIST", "abc", str],
+            },
+        )
 
         self.invoke("append omero.web.test 4")
         self.invoke("get omero.web.test")
-        self.assertStdoutStderr(capsys, out='[1, 2, 3, 4]')
+        self.assertStdoutStderr(capsys, out="[1, 2, 3, 4]")
         self.invoke("append --set omero.web.test 2")
-        self.assertStdoutStderr(capsys, out='')
+        self.assertStdoutStderr(capsys, out="")
         self.invoke("get omero.web.test")
-        self.assertStdoutStderr(capsys, out='[1, 2, 3, 4]')
+        self.assertStdoutStderr(capsys, out="[1, 2, 3, 4]")
 
         self.invoke("append omero.web.unknown 1")
         self.invoke("get omero.web.unknown")
-        self.assertStdoutStderr(capsys, out='[1]')
+        self.assertStdoutStderr(capsys, out="[1]")
         with pytest.raises(NonZeroReturnCode):
             self.invoke("append omero.web.notalist 1")
 
     @pytest.mark.xfail
-    @pytest.mark.broken(reason = "migrate to omero-web")
-    @pytest.mark.usefixtures('configxml')
+    @pytest.mark.broken(reason="migrate to omero-web")
+    @pytest.mark.usefixtures("configxml")
     def testRemoveWithDefault(self, monkeypatch, capsys):
         import json
-        monkeypatch.setattr("omeroweb.settings.CUSTOM_SETTINGS_MAPPINGS", {
-            "omero.web.test": ["TEST", "[1,2,3]", json.loads],
-        })
+
+        monkeypatch.setattr(
+            "omeroweb.settings.CUSTOM_SETTINGS_MAPPINGS",
+            {"omero.web.test": ["TEST", "[1,2,3]", json.loads],},
+        )
         self.invoke("remove omero.web.test 2")
         self.invoke("get omero.web.test")
-        self.assertStdoutStderr(capsys, out='[1, 3]')
+        self.assertStdoutStderr(capsys, out="[1, 3]")
         self.invoke("remove omero.web.test 1")
         self.invoke("remove omero.web.test 3")
         self.invoke("get omero.web.test")
-        self.assertStdoutStderr(capsys, out='[]')
+        self.assertStdoutStderr(capsys, out="[]")
 
-    @pytest.mark.parametrize("data", (
-        ({}, ""),
-        ({"a": "b"}, "a=b"),
-        ({"a": "b", "a": "d"}, "a=d"),
-        ({"a": "b", "c": "d"}, "a=b\nc=d"),
-        ({"c": "d", "a": "b"}, "a=b\nc=d"),
-    ))
-    @pytest.mark.usefixtures('configxml')
+    @pytest.mark.parametrize(
+        "data",
+        (
+            ({}, ""),
+            ({"a": "b"}, "a=b"),
+            ({"a": "b", "a": "d"}, "a=d"),
+            ({"a": "b", "c": "d"}, "a=b\nc=d"),
+            ({"c": "d", "a": "b"}, "a=b\nc=d"),
+        ),
+    )
+    @pytest.mark.usefixtures("configxml")
     def testList(self, data, monkeypatch, capsys):
         for k, v in list(data[0].items()):
             self.invoke("set %s %s" % (k, v))
@@ -447,33 +469,52 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out=data[1], strip_warning=True)
 
     @pytest.mark.xfail
-    @pytest.mark.broken(reason = "needs whitespace fixing")
-    @pytest.mark.parametrize("data", (
-        ("omero.a=b\nomero.c=d\n##ignore=me\n",
-         "omero.a=b\nomero.c=d",
-         "a (1)\n\t\nc (1)"),
-        ("omero.whitelist=\\\nome.foo,\\\nome.bar\n### END",
-         "omero.whitelist=ome.foo,ome.bar",
-         "whitelist (1)"),
-        ("omero.whitelist=\\\nome.foo,\\\nome.bar\n",
-         "omero.whitelist=ome.foo,ome.bar",
-         "whitelist (1)"),
-        ("omero.whitelist=\\\nome.foo,\\\nome.bar",
-         "omero.whitelist=ome.foo,ome.bar",
-         "whitelist (1)"),
-        ("omero.user_mapping=\\\na=b,c=d",
-         "omero.user_mapping=a=b,c=d",
-         "user_mapping (1)"),
-        ("omero.whitelist=ome.foo\nIce.c=d\n",
-         "Ice.c=d\nomero.whitelist=ome.foo",
-         "whitelist (1)"),
-        ("omero.a=b\nomero.c=d\nomero.e=f\n##ignore=me\n",
-         "omero.a=b\nomero.c=d\nomero.e=f",
-         "a (1)\n\t\nc (1)\n\t\ne (1)"),
-        ("omero.a=b\nomero.c=d\nomero.e=f\n##ignore=me\n",
-         "omero.a=b\nomero.c=d\nomero.e=f",
-         "a (1)\n\t\nc (1)\n\t\ne (1)"),
-    ))
+    @pytest.mark.broken(reason="needs whitespace fixing")
+    @pytest.mark.parametrize(
+        "data",
+        (
+            (
+                "omero.a=b\nomero.c=d\n##ignore=me\n",
+                "omero.a=b\nomero.c=d",
+                "a (1)\n\t\nc (1)",
+            ),
+            (
+                "omero.whitelist=\\\nome.foo,\\\nome.bar\n### END",
+                "omero.whitelist=ome.foo,ome.bar",
+                "whitelist (1)",
+            ),
+            (
+                "omero.whitelist=\\\nome.foo,\\\nome.bar\n",
+                "omero.whitelist=ome.foo,ome.bar",
+                "whitelist (1)",
+            ),
+            (
+                "omero.whitelist=\\\nome.foo,\\\nome.bar",
+                "omero.whitelist=ome.foo,ome.bar",
+                "whitelist (1)",
+            ),
+            (
+                "omero.user_mapping=\\\na=b,c=d",
+                "omero.user_mapping=a=b,c=d",
+                "user_mapping (1)",
+            ),
+            (
+                "omero.whitelist=ome.foo\nIce.c=d\n",
+                "Ice.c=d\nomero.whitelist=ome.foo",
+                "whitelist (1)",
+            ),
+            (
+                "omero.a=b\nomero.c=d\nomero.e=f\n##ignore=me\n",
+                "omero.a=b\nomero.c=d\nomero.e=f",
+                "a (1)\n\t\nc (1)\n\t\ne (1)",
+            ),
+            (
+                "omero.a=b\nomero.c=d\nomero.e=f\n##ignore=me\n",
+                "omero.a=b\nomero.c=d\nomero.e=f",
+                "a (1)\n\t\nc (1)\n\t\ne (1)",
+            ),
+        ),
+    )
     def testFileParsing(self, tmpdir, capsys, data):
         input, defaults, keys = data
         cfg = tmpdir.join("test.cfg")
@@ -485,12 +526,15 @@ class TestPrefs(object):
         self.invoke("parse --file=%s --keys --no-web" % cfg)
         self.assertStdoutStderr(capsys, out=keys)
 
-    @pytest.mark.parametrize("data", (
-        (u"omero.ldap.base=ou=ascii\n", "ascii2"),
-        (u"omero.ldap.base=ou=ascii\n", "unicodé"),
-        (u"omero.ldap.base=ou=unicodé\n", "ascii"),
-        (u"omero.ldap.base=ou=unicodé\n", "unicodé2"),
-    ))
+    @pytest.mark.parametrize(
+        "data",
+        (
+            ("omero.ldap.base=ou=ascii\n", "ascii2"),
+            ("omero.ldap.base=ou=ascii\n", "unicodé"),
+            ("omero.ldap.base=ou=unicodé\n", "ascii"),
+            ("omero.ldap.base=ou=unicodé\n", "unicodé2"),
+        ),
+    )
     def testUnicode(self, tmpdir, capsys, data):
         input, update = data
         cfg = tmpdir.join("test.cfg")
@@ -511,11 +555,11 @@ class TestPrefs(object):
         # Fails, the last two properties are parsed as one:
         # 'd.e' = 'line1line2f.g=\\n'
         assert len(props) == 4
-        assert props[0].key == 'a'
-        assert props[0].val == '1'
-        assert props[1].key == 'b.c'
-        assert props[1].val == 'a b <!> c'
-        assert props[2].key == 'd.e'
-        assert props[2].val == 'line1line2'
-        assert props[3].key == 'f.g'
-        assert props[3].val == '\\n'
+        assert props[0].key == "a"
+        assert props[0].val == "1"
+        assert props[1].key == "b.c"
+        assert props[1].val == "a b <!> c"
+        assert props[2].key == "d.e"
+        assert props[2].val == "line1line2"
+        assert props[3].key == "f.g"
+        assert props[3].val == "\\n"

--- a/test/unit/clitest/test_rcode.py
+++ b/test/unit/clitest/test_rcode.py
@@ -20,7 +20,6 @@ omeroDir = old_div(path(os.getcwd()), "build")
 
 
 class TestRCode(object):
-
     class T(BaseControl):
         def __call__(self, *args):
             self.ctx.rv = 1

--- a/test/unit/clitest/test_script.py
+++ b/test/unit/clitest/test_script.py
@@ -26,7 +26,6 @@ import pytest
 
 
 class TestScript(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("script", ScriptControl, "TEST")

--- a/test/unit/clitest/test_sess.py
+++ b/test/unit/clitest/test_sess.py
@@ -38,12 +38,12 @@ testhost = "testhost"
 def istty(monkeypatch):
     def isatty(*args, **kwargs):
         return True
-    monkeypatch.setattr(sys.stdin, 'isatty', isatty)
+
+    monkeypatch.setattr(sys.stdin, "isatty", isatty)
     assert sys.stdin.isatty()
 
 
 class MyStore(SessionsStore):
-
     def __init__(self, *args, **kwargs):
         SessionsStore.__init__(self, *args, **kwargs)
         self.clients = []
@@ -63,8 +63,7 @@ class MyStore(SessionsStore):
             self.create_callback = None
         return_tuple, add_tuple, should_be_new = self.clients.pop(0)
 
-        assert should_be_new == new, ("should_be_new=%s wasn't!"
-                                      % should_be_new)
+        assert should_be_new == new, "should_be_new=%s wasn't!" % should_be_new
 
         if new:
             self.add(*add_tuple)
@@ -75,14 +74,13 @@ class MyStore(SessionsStore):
         return return_tuple
 
     def __del__(self):
-        assert len(self.clients) == 0, ("clients not empty! %s"
-                                        % self.clients)
-        assert len(self.exceptions) == 0, ("exceptions not empty! %s"
-                                           % self.exceptions)
+        assert len(self.clients) == 0, "clients not empty! %s" % self.clients
+        assert len(self.exceptions) == 0, (
+            "exceptions not empty! %s" % self.exceptions
+        )
 
 
 class MyClient(object):
-
     def __init__(self, user, group, props):
         self.sf = self
         self.userName = user
@@ -116,7 +114,6 @@ class MyClient(object):
 
 
 class MyCLI(CLI):
-
     def __init__(self, *args, **kwargs):
         CLI.__init__(self, *args, **kwargs)
         self.DIR = create_path(folder=True)
@@ -130,8 +127,15 @@ class MyCLI(CLI):
     def __del__(self):
         del self.STORE
 
-    def creates_client(self, name="testuser", host="testhost", sess="sess_id",
-                       port=None, group=None, new=True):
+    def creates_client(
+        self,
+        name="testuser",
+        host="testhost",
+        sess="sess_id",
+        port=None,
+        group=None,
+        new=True,
+    ):
         props = dict()
         if port:
             props["omero.port"] = port
@@ -141,8 +145,7 @@ class MyCLI(CLI):
             group = "mygroup"  # For use via IAdmin.EventContext
 
         # props = {"omero.group":group, "omero.port":port}
-        return_tuple = (MyClient(name, group, {"omero.host": host}), sess, 0,
-                        0)
+        return_tuple = (MyClient(name, group, {"omero.host": host}), sess, 0, 0)
         add_tuple = (host, name, sess, props)
         self.STORE.clients.append((return_tuple, add_tuple, new))
 
@@ -152,7 +155,7 @@ class MyCLI(CLI):
     def requests_host(self, host="testhost", port="4064"):
         self.REQRESP["Server: [localhost:%s]" % port] = host
 
-    def requests_user(self, user='testuser'):
+    def requests_user(self, user="testuser"):
         self.REQRESP["Username: [%s]" % get_user("Unknown")] = user
 
     def requests_pass(self, pasw="pasw"):
@@ -163,7 +166,9 @@ class MyCLI(CLI):
 
     def assertReqSize(self, test, size):
         assert size == self.requests_size(), "size!=%s: %s" % (
-            size, self.REQRESP)
+            size,
+            self.REQRESP,
+        )
 
     def input(self, prompt, hidden=False, required=False):
         if prompt not in self.REQRESP:
@@ -175,7 +180,6 @@ class MyCLI(CLI):
 
 
 class TestStore(object):
-
     def store(self, store_path=None):
         if not store_path:
             store_path = create_path(folder=True)
@@ -185,8 +189,8 @@ class TestStore(object):
         s = self.store()
         s.report()
 
-    @pytest.mark.parametrize('port', [None, '4064', '14064'])
-    @pytest.mark.parametrize('sudo', [None, 'root'])
+    @pytest.mark.parametrize("port", [None, "4064", "14064"])
+    @pytest.mark.parametrize("sudo", [None, "root"])
     def testAdd(self, port, sudo, tmpdir):
         s = self.store(tmpdir)
         props = {}
@@ -210,9 +214,9 @@ class TestStore(object):
         assert "localhost" == s.last_host()
         assert "4064" == s.last_port()
 
-    @pytest.mark.parametrize('name', [None, 'usr'])
-    @pytest.mark.parametrize('key', [None, 'uuid'])
-    @pytest.mark.parametrize('port', [None, '4064', '14064'])
+    @pytest.mark.parametrize("name", [None, "usr"])
+    @pytest.mark.parametrize("key", [None, "uuid"])
+    @pytest.mark.parametrize("port", [None, "4064", "14064"])
     def testSetCurrent(self, name, key, port, tmpdir):
         s = self.store(tmpdir)
         props = {}
@@ -225,7 +229,7 @@ class TestStore(object):
         assert (old_div(session_dir, "._LASTHOST_")).exists()
         assert "srv" == s.last_host()
         assert (old_div(session_dir, "._LASTPORT_")).exists()
-        assert (port or '4064') == s.last_port()
+        assert (port or "4064") == s.last_port()
 
         # Using helpers
         assert "srv" == s.host_file().text().strip()
@@ -237,7 +241,7 @@ class TestStore(object):
         # Using get_current
         lasthost, lastname, lastkey, lastport = s.get_current()
         assert lasthost == "srv"
-        assert lastport == (port or '4064')
+        assert lastport == (port or "4064")
         assert lastname == name
         if name:
             assert lastkey == key
@@ -273,7 +277,8 @@ class TestStore(object):
             "foo": "1",
             "omero.host": "a",
             "omero.user": "b",
-            "omero.sess": "c"}
+            "omero.sess": "c",
+        }
         assert expect == rv
 
     @pytest.mark.parametrize("ignore_nulls", [True, False])
@@ -282,22 +287,27 @@ class TestStore(object):
         s.add("a", "b", "c", {"omero.group": "1"})
         conflicts = s.conflicts("a", "b", "c", {}, ignore_nulls=ignore_nulls)
         if ignore_nulls:
-            assert conflicts == ''
+            assert conflicts == ""
         else:
-            assert conflicts == 'omero.group: 1!=None'
+            assert conflicts == "omero.group: 1!=None"
 
         conflicts = s.conflicts(
-            "a", "b", "c", {"omero.group": "2"}, ignore_nulls=ignore_nulls)
-        assert conflicts == 'omero.group: 1!=2'
+            "a", "b", "c", {"omero.group": "2"}, ignore_nulls=ignore_nulls
+        )
+        assert conflicts == "omero.group: 1!=2"
 
     @pytest.mark.parametrize("ignore_nulls", [True, False])
     def testMultiConflicts(self, ignore_nulls):
         s = self.store()
         s.add("a", "b", "c", {"omero.group": "1"})
-        conflicts = s.conflicts("a", "b", "c", {
-            "omero.group": "2", "omero.port": "14064"},
-            ignore_nulls=ignore_nulls)
-        assert conflicts == 'omero.port: None!=14064; omero.group: 1!=2'
+        conflicts = s.conflicts(
+            "a",
+            "b",
+            "c",
+            {"omero.group": "2", "omero.port": "14064"},
+            ignore_nulls=ignore_nulls,
+        )
+        assert conflicts == "omero.port: None!=14064; omero.group: 1!=2"
 
 
 class TestSessions(object):
@@ -313,13 +323,17 @@ class TestSessions(object):
     MATCHING_PORTS = [(None, 4064), (4064, None)]
     CONFLICTING_PORTS = [(None, 14064), (14064, None), (4064, 14064)]
     DIFFERENT_GROUPS = [
-        (None, "mygroup"), ("mygroup", None), ("mygroup", "mygroup2")]
+        (None, "mygroup"),
+        ("mygroup", None),
+        ("mygroup", "mygroup2"),
+    ]
 
     def get_conflict_message(self):
         return "Skipped session %s due to property conflicts: "
 
-    def get_conn_args(self, conn_type, host="testhost", name="testuser",
-                      port=None, group=None):
+    def get_conn_args(
+        self, conn_type, host="testhost", name="testuser", port=None, group=None
+    ):
         """Generated various forms of connection arguments"""
 
         if name:
@@ -360,7 +374,7 @@ class TestSessions(object):
         cli.invoke(["s", "login"])
         assert 0 == cli.rv
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def testLoginWithConnectionArguments(self, connection):
         cli = MyCLI()
         cli.requests_pass()
@@ -369,7 +383,7 @@ class TestSessions(object):
         cli.invoke(["s", "login"] + conn_args)
         assert 0 == cli.rv
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def testPasswordArgument(self, connection):
         cli = MyCLI()
         cli.creates_client(name="testuser")
@@ -377,7 +391,7 @@ class TestSessions(object):
         cli.invoke(["s", "login", "-w", "pasw"] + conn_args)
         assert 0 == cli.rv
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def testKeyArgument(self, connection):
         cli = MyCLI()
         cli.STORE.add("testhost", "testuser", "key", {})
@@ -386,9 +400,9 @@ class TestSessions(object):
         cli.invoke(["s", "login", "-k", "key"] + conn_args)
         assert 0 == cli.rv
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', ALL_PORTS)
-    @pytest.mark.parametrize('group', ALL_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", ALL_PORTS)
+    @pytest.mark.parametrize("group", ALL_GROUPS)
     def testReuseWorks(self, connection, port, group):
         """
         Test session reuse with the same port/group works
@@ -406,8 +420,8 @@ class TestSessions(object):
         cli.invoke(["s", "login"] + conn_args)
         assert cli.get_client() is not None
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('group', DIFFERENT_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("group", DIFFERENT_GROUPS)
     def testReuseFromDifferentGroupDoesntWork(self, connection, group, capsys):
         """
         Test session reuse with different groups fails
@@ -424,11 +438,11 @@ class TestSessions(object):
         cli.invoke(["s", "login"] + conn_args)
         cli.assertReqSize(self, 0)
         out, err = capsys.readouterr()
-        msg = (self.get_conflict_message() + 'omero.group: %s!=%s')
-        assert err.splitlines()[-2] == msg % ('testsessid', group[0], group[1])
+        msg = self.get_conflict_message() + "omero.group: %s!=%s"
+        assert err.splitlines()[-2] == msg % ("testsessid", group[0], group[1])
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', MATCHING_PORTS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", MATCHING_PORTS)
     def testReuseMatchingPorts(self, connection, port):
         """
         Test session reuse with matching ports works
@@ -444,8 +458,8 @@ class TestSessions(object):
         cli.invoke(["s", "login"] + conn_args)
         cli.assertReqSize(self, 0)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', CONFLICTING_PORTS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", CONFLICTING_PORTS)
     def testReuseFromDifferentPortDoesntWork(self, connection, port):
         """
         Test session reuse with mismatching ports fails
@@ -464,8 +478,9 @@ class TestSessions(object):
 
     def testInteractiveLoginNonDefaultPort(self):
         cli = MyCLI()
-        cli.STORE.add("testhost", "testuser", "testsessid",
-                      {"omero.port": "4444"})
+        cli.STORE.add(
+            "testhost", "testuser", "testsessid", {"omero.port": "4444"}
+        )
         cli.assertReqSize(self, 0)
         cli.creates_client(port="4444", new=False)
         cli.requests_host()
@@ -497,7 +512,7 @@ class TestSessions(object):
         cli.invoke("s login")  # Should work. No conflict
         del cli
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def testBadSessionKeyDies(self, connection):
         """
         As seen in ticket 4223, when a bad session is
@@ -524,7 +539,8 @@ class TestSessions(object):
         # Don't do creates_client, so the session key
         # is now bad.
         cli.throw_on_create(
-            Glacier2.PermissionDeniedException("MOCKKEY EXPIRED"))
+            Glacier2.PermissionDeniedException("MOCKKEY EXPIRED")
+        )
         try:
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
             assert False, "This must throw 'Bad session key'"
@@ -534,12 +550,13 @@ class TestSessions(object):
 
         del cli
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('name', [None, 'testuser'])
-    @pytest.mark.parametrize('password', [None, 'password'])
-    @pytest.mark.parametrize('group', [None, 'group'])
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("name", [None, "testuser"])
+    @pytest.mark.parametrize("password", [None, "password"])
+    @pytest.mark.parametrize("group", [None, "group"])
     def testSessionReattachWarning(
-            self, connection, name, password, group, capsys):
+        self, connection, name, password, group, capsys
+    ):
         """
         Test session re-attachment by key throws warnings for extra arguments
         """
@@ -557,8 +574,7 @@ class TestSessions(object):
         key_conn_args = self.get_conn_args(connection, name=name, group=group)
         if password:
             key_conn_args += ["-w", password]
-        cli.invoke(
-            ["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
+        cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
         out, err = capsys.readouterr()
         err = err.splitlines()
         if name:
@@ -568,9 +584,9 @@ class TestSessions(object):
         if password:
             assert "Ignoring password since session key set" in err
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', ALL_PORTS)
-    @pytest.mark.parametrize('group', ALL_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", ALL_PORTS)
+    @pytest.mark.parametrize("group", ALL_GROUPS)
     def testSessionReattachSameArguments(self, connection, port, group):
         """
         Test session re-attachment by key with the same group/port works
@@ -581,7 +597,8 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port, group=group)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port, group=group)
+            connection, name=None, port=port, group=group
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
@@ -589,9 +606,9 @@ class TestSessions(object):
         cli.creates_client(sess=MOCKKEY, new=False)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', MATCHING_PORTS)
-    @pytest.mark.parametrize('group', ALL_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", MATCHING_PORTS)
+    @pytest.mark.parametrize("group", ALL_GROUPS)
     def testSessionReattachDefaultPort(self, connection, port, group):
         """
         Test session re-attachment by key with matching ports
@@ -602,19 +619,21 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port[0], group=group)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[0], group=group)
+            connection, name=None, port=port[0], group=group
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
         cli.set_client(None)
         cli.creates_client(sess=MOCKKEY, new=False)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[1], group=group)
+            connection, name=None, port=port[1], group=group
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', ALL_PORTS)
-    @pytest.mark.parametrize('group', ALL_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", ALL_PORTS)
+    @pytest.mark.parametrize("group", ALL_GROUPS)
     def testSessionReattachServerMismatch(self, connection, port, group):
         """
         Test session re-attachment by key with mismatching hostnames fails
@@ -625,20 +644,22 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port, group=group)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port, group=group)
+            connection, name=None, port=port, group=group
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
         cli.set_client(None)
         cli.creates_client(sess=MOCKKEY, new=False)
         key_conn_args = self.get_conn_args(
-            connection, host="wrongserver",  name=None, port=port, group=group)
+            connection, host="wrongserver", name=None, port=port, group=group
+        )
         with pytest.raises(NonZeroReturnCode):
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', CONFLICTING_PORTS)
-    @pytest.mark.parametrize('group', ALL_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", CONFLICTING_PORTS)
+    @pytest.mark.parametrize("group", ALL_GROUPS)
     def testSessionReattachConflictingPort(self, connection, port, group):
         """
         Test session re-attachment fails with mismatching ports fails
@@ -649,20 +670,22 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port[0], group=group)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[0], group=group)
+            connection, name=None, port=port[0], group=group
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
         cli.set_client(None)
         cli.creates_client(sess=MOCKKEY, new=False)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[1], group=group)
+            connection, name=None, port=port[1], group=group
+        )
         with pytest.raises(NonZeroReturnCode):
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', ALL_PORTS)
-    @pytest.mark.parametrize('group', DIFFERENT_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", ALL_PORTS)
+    @pytest.mark.parametrize("group", DIFFERENT_GROUPS)
     def testSessionReattachDifferentGroup(self, connection, port, group):
         """
         Test session re-attachment by key with different groups works
@@ -673,19 +696,21 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port, group=group[0])
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port, group=group[0])
+            connection, name=None, port=port, group=group[0]
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
         cli.set_client(None)
         cli.creates_client(sess=MOCKKEY, new=False)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port, group=group[1])
+            connection, name=None, port=port, group=group[1]
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
-    @pytest.mark.parametrize('port', CONFLICTING_PORTS)
-    @pytest.mark.parametrize('group', DIFFERENT_GROUPS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", CONFLICTING_PORTS)
+    @pytest.mark.parametrize("group", DIFFERENT_GROUPS)
     def testSessionReattachFailsPortGroup(self, connection, port, group):
         """
         Test session re-attachment by key with mismatching ports and different
@@ -697,19 +722,21 @@ class TestSessions(object):
         # Connect using the session key (create a local session file)
         cli.creates_client(sess=MOCKKEY, port=port[0], group=group[0])
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[0], group=group[0])
+            connection, name=None, port=port[0], group=group[0]
+        )
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
         # Force new CLI instance using the same connection arguments
         cli.set_client(None)
         cli.creates_client(sess=MOCKKEY, new=False)
         key_conn_args = self.get_conn_args(
-            connection, name=None, port=port[1], group=group[1])
+            connection, name=None, port=port[1], group=group[1]
+        )
         with pytest.raises(NonZeroReturnCode):
             cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + key_conn_args)
 
-    @pytest.mark.parametrize('port', ALL_PORTS)
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("port", ALL_PORTS)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def testCopiedSessionWorks(self, connection, port):
         """
         Found by Colin while using a session key from a non-CLI-source.
@@ -728,7 +755,7 @@ class TestSessions(object):
         conn_args = self.get_conn_args(connection, port=port)
         cli.invoke(["s", "login", "-k", "%s" % MOCKKEY] + conn_args)
 
-    @pytest.mark.parametrize('connection', CONNECTION_TYPES)
+    @pytest.mark.parametrize("connection", CONNECTION_TYPES)
     def test5975(self, connection):
         """
         Runs various tests which try to force the stored user name
@@ -795,36 +822,40 @@ class TestSessions(object):
 
 
 class TestParseConn(object):
-
-    @pytest.mark.parametrize('default_user', [None, 'default_user'])
+    @pytest.mark.parametrize("default_user", [None, "default_user"])
     def testEmptyString(self, default_user):
         out_server, out_name, out_port = SessionsControl._parse_conn(
-            '', default_user)
+            "", default_user
+        )
 
         assert not out_server
         assert out_name == default_user
         assert not out_port
 
-    @pytest.mark.parametrize('default_user', [None, 'default_user'])
-    @pytest.mark.parametrize('port', ['bad_port', '12323414232'])
+    @pytest.mark.parametrize("default_user", [None, "default_user"])
+    @pytest.mark.parametrize("port", ["bad_port", "12323414232"])
     def testBadPort(self, default_user, port):
         out_server, out_name, out_port = SessionsControl._parse_conn(
-            'localhost:%s' % port, default_user)
+            "localhost:%s" % port, default_user
+        )
 
-        assert out_server == 'localhost:%s' % port
+        assert out_server == "localhost:%s" % port
         assert out_name == default_user
         assert not out_port
 
-    @pytest.mark.parametrize('default_user', [None, 'default_user'])
+    @pytest.mark.parametrize("default_user", [None, "default_user"])
     @pytest.mark.parametrize(
-        'user_prefix', ['', 'user@', 'üser-1£@', 'user:4@email@'])
-    @pytest.mark.parametrize('server', ['localhost', 'server.domain'])
-    @pytest.mark.parametrize('port_suffix', ['', ':4064', ':14064'])
-    def testConnectionString(self, default_user, user_prefix, server,
-                             port_suffix):
-        in_server = '%s%s%s' % (user_prefix, server, port_suffix)
+        "user_prefix", ["", "user@", "üser-1£@", "user:4@email@"]
+    )
+    @pytest.mark.parametrize("server", ["localhost", "server.domain"])
+    @pytest.mark.parametrize("port_suffix", ["", ":4064", ":14064"])
+    def testConnectionString(
+        self, default_user, user_prefix, server, port_suffix
+    ):
+        in_server = "%s%s%s" % (user_prefix, server, port_suffix)
         out_server, out_name, out_port = SessionsControl._parse_conn(
-            in_server, default_user)
+            in_server, default_user
+        )
         assert out_server == server
         if user_prefix:
             assert out_name == user_prefix[:-1]

--- a/test/unit/clitest/test_sessions.py
+++ b/test/unit/clitest/test_sessions.py
@@ -31,7 +31,6 @@ import pytest
 
 
 class TestSessions(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("sessions", SessionsControl, "TEST")
@@ -41,8 +40,7 @@ class TestSessions(object):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize(
-        "subcommand", SessionsControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", SessionsControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)
@@ -52,45 +50,67 @@ class TestSessions(object):
         from omero_ext.path import path
 
         # Default store sessions dir is under user dir
-        store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(get_user_dir()) / 'omero' / 'sessions'
+        store = self.cli.controls["sessions"].store(None)
+        assert store.dir == path(get_user_dir()) / "omero" / "sessions"
 
-    @pytest.mark.parametrize('environment', (
-        {'OMERO_USERDIR': None,
-         'OMERO_SESSION_DIR': None,
-         'OMERO_SESSIONDIR': None},
-        {'OMERO_USERDIR': None,
-         'OMERO_SESSION_DIR': 'session_dir',
-         'OMERO_SESSIONDIR': None},
-        {'OMERO_USERDIR': None,
-         'OMERO_SESSION_DIR': None,
-         'OMERO_SESSIONDIR': 'sessiondir'},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_SESSION_DIR': None,
-         'OMERO_SESSIONDIR': None},
-        {'OMERO_USERDIR': None,
-         'OMERO_SESSION_DIR': 'session_dir',
-         'OMERO_SESSIONDIR': 'sessiondir'},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_SESSION_DIR': 'session_dir',
-         'OMERO_SESSIONDIR': None},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_SESSION_DIR': None,
-         'OMERO_SESSIONDIR': 'sessiondir'},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_SESSION_DIR': 'session_dir',
-         'OMERO_SESSIONDIR': 'sessiondir'}))
-    @pytest.mark.parametrize('session_args', [None, 'session_dir'])
+    @pytest.mark.parametrize(
+        "environment",
+        (
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_SESSION_DIR": None,
+                "OMERO_SESSIONDIR": None,
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_SESSION_DIR": "session_dir",
+                "OMERO_SESSIONDIR": None,
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_SESSION_DIR": None,
+                "OMERO_SESSIONDIR": "sessiondir",
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_SESSION_DIR": None,
+                "OMERO_SESSIONDIR": None,
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_SESSION_DIR": "session_dir",
+                "OMERO_SESSIONDIR": "sessiondir",
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_SESSION_DIR": "session_dir",
+                "OMERO_SESSIONDIR": None,
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_SESSION_DIR": None,
+                "OMERO_SESSIONDIR": "sessiondir",
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_SESSION_DIR": "session_dir",
+                "OMERO_SESSIONDIR": "sessiondir",
+            },
+        ),
+    )
+    @pytest.mark.parametrize("session_args", [None, "session_dir"])
     def testCustomSessionsDir(
-            self, tmpdir, monkeypatch, environment,
-            session_args):
+        self, tmpdir, monkeypatch, environment, session_args
+    ):
         from argparse import Namespace
         from omero.util import get_user_dir
         from omero_ext.path import path
 
         for var in list(environment.keys()):
             if environment[var]:
-                monkeypatch.setenv(var, "%s%s%s" % (tmpdir, os.path.sep, environment.get(var)))
+                monkeypatch.setenv(
+                    var, "%s%s%s" % (tmpdir, os.path.sep, environment.get(var))
+                )
             else:
                 monkeypatch.delenv(var, raising=False)
 
@@ -99,21 +119,27 @@ class TestSessions(object):
         if session_args:
             setattr(args, session_args, old_div(tmpdir, session_args))
 
-        if environment.get('OMERO_SESSION_DIR') or session_args:
-            store = pytest.deprecated_call(self.cli.controls['sessions'].store, args)
+        if environment.get("OMERO_SESSION_DIR") or session_args:
+            store = pytest.deprecated_call(
+                self.cli.controls["sessions"].store, args
+            )
         else:
-            store = self.cli.controls['sessions'].store(args)
+            store = self.cli.controls["sessions"].store(args)
 
         # By order of precedence
-        if environment.get('OMERO_SESSIONDIR'):
-            sdir = old_div(path(tmpdir), environment.get('OMERO_SESSIONDIR'))
-        elif environment.get('OMERO_SESSION_DIR'):
-            sdir = (path(tmpdir) / environment.get('OMERO_SESSION_DIR') /
-                    'omero' / 'sessions')
+        if environment.get("OMERO_SESSIONDIR"):
+            sdir = old_div(path(tmpdir), environment.get("OMERO_SESSIONDIR"))
+        elif environment.get("OMERO_SESSION_DIR"):
+            sdir = (
+                path(tmpdir)
+                / environment.get("OMERO_SESSION_DIR")
+                / "omero"
+                / "sessions"
+            )
         elif session_args:
-            sdir = path(getattr(args, session_args)) / 'omero' / 'sessions'
-        elif environment.get('OMERO_USERDIR'):
-            sdir = path(tmpdir) / environment.get('OMERO_USERDIR') / 'sessions'
+            sdir = path(getattr(args, session_args)) / "omero" / "sessions"
+        elif environment.get("OMERO_USERDIR"):
+            sdir = path(tmpdir) / environment.get("OMERO_USERDIR") / "sessions"
         else:
-            sdir = path(get_user_dir()) / 'omero' / 'sessions'
+            sdir = path(get_user_dir()) / "omero" / "sessions"
         assert store.dir == str(sdir)

--- a/test/unit/clitest/test_tag.py
+++ b/test/unit/clitest/test_tag.py
@@ -26,7 +26,6 @@ from omero.plugins.tag import TagControl
 
 
 class TestTag(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("tag", TagControl, "TEST")
@@ -36,7 +35,7 @@ class TestTag(object):
         self.args += ["-h"]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.parametrize('subcommand', TagControl().get_subcommands())
+    @pytest.mark.parametrize("subcommand", TagControl().get_subcommands())
     def testSubcommandHelp(self, subcommand):
         self.args += [subcommand, "-h"]
         self.cli.invoke(self.args, strict=True)
@@ -57,9 +56,9 @@ class TestTag(object):
             self.cli.invoke(self.args, strict=True)
 
     @pytest.mark.parametrize(
-        ('object_arg', 'tag_arg'),
-        [('Image:1', 'test'), ('Image', '1'), ('Image:image', '1'),
-         ('1', '1')])
+        ("object_arg", "tag_arg"),
+        [("Image:1", "test"), ("Image", "1"), ("Image:image", "1"), ("1", "1")],
+    )
     def testLinkFails(self, object_arg, tag_arg):
         self.args += ["link", object_arg, tag_arg]
         with pytest.raises(NonZeroReturnCode):

--- a/test/unit/clitest/test_user.py
+++ b/test/unit/clitest/test_user.py
@@ -26,7 +26,6 @@ import pytest
 
 
 class TestUser(object):
-
     def setup_method(self, method):
         self.cli = CLI()
         self.cli.register("user", UserControl, "TEST")

--- a/test/unit/fstest/test_model.py
+++ b/test/unit/fstest/test_model.py
@@ -35,7 +35,6 @@ from omero.rtypes import rtime
 
 
 class TestModel(object):
-
     def mkentry(self, clientPath):
         originalFile = omero.model.OriginalFileI()
         parts = clientPath.split("/")
@@ -60,13 +59,13 @@ class TestModel(object):
 
         # This will be created server-side
         serverInfo = {}
-        serverInfo['bioformatsReader'] = rstring("ExampleReader")
-        serverInfo['bioformatsVersion'] = rstring("v4.4.5 git: abc123"),
-        serverInfo['omeroVersion'] = rstring("v.4.4.4 git: def456"),
-        serverInfo['osName'] = rstring("Linux"),
-        serverInfo['osArchitecture'] = rstring("amd64"),
-        serverInfo['osVersion'] = rstring("2.6.38-8-generic"),
-        serverInfo['locale'] = rstring("en_US")
+        serverInfo["bioformatsReader"] = rstring("ExampleReader")
+        serverInfo["bioformatsVersion"] = (rstring("v4.4.5 git: abc123"),)
+        serverInfo["omeroVersion"] = (rstring("v.4.4.4 git: def456"),)
+        serverInfo["osName"] = (rstring("Linux"),)
+        serverInfo["osArchitecture"] = (rstring("amd64"),)
+        serverInfo["osVersion"] = (rstring("2.6.38-8-generic"),)
+        serverInfo["locale"] = rstring("en_US")
 
         # Now that the basics are setup, we
         # need to link to all of the original files.

--- a/test/unit/gatewaytest/test_argument_errors.py
+++ b/test/unit/gatewaytest/test_argument_errors.py
@@ -33,7 +33,6 @@ import pytest
 
 
 class TestArgumentErrors(object):
-
     @classmethod
     @pytest.fixture(autouse=True)
     def setup_class(cls, tmpdir, monkeypatch):

--- a/test/unit/gatewaytest/test_build_query.py
+++ b/test/unit/gatewaytest/test_build_query.py
@@ -28,7 +28,7 @@ import pytest
 from omero.rtypes import wrap
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def gateway():
     """Create a BlitzGateway object."""
     return _BlitzGateway()
@@ -47,7 +47,7 @@ class TestBuildQuery(object):
         assert isinstance(wrapper(), BlitzObjectWrapper)
         assert query.startswith("select ")
         assert "where" not in query
-        assert 'None' not in query
+        assert "None" not in query
 
     @pytest.mark.parametrize("dtype", list(KNOWN_WRAPPERS.keys()))
     def test_filter_by_owner(self, gateway, dtype):
@@ -58,13 +58,13 @@ class TestBuildQuery(object):
         # Test using 'params' argument
         with_params = gateway.buildQuery(dtype, params=p)
         # Test using 'opts' dictionary
-        with_opts = gateway.buildQuery(dtype, opts={'owner': 1})
+        with_opts = gateway.buildQuery(dtype, opts={"owner": 1})
         for result in [with_params, with_opts]:
             query, params, wrapper = result
             assert isinstance(query, str)
             assert isinstance(params, Parameters)
             assert isinstance(wrapper(), BlitzObjectWrapper)
-            if dtype not in ('experimenter', 'experimentergroup'):
+            if dtype not in ("experimenter", "experimentergroup"):
                 assert "where owner" in query
             else:
                 assert "where owner" not in query
@@ -79,7 +79,7 @@ class TestBuildQuery(object):
         # Test using 'params' argument
         with_params = gateway.buildQuery(dtype, params=p)
         # Test using 'opts' dictionary
-        opts = {'offset': offset, 'limit': limit}
+        opts = {"offset": offset, "limit": limit}
         with_opts = gateway.buildQuery(dtype, opts=opts)
         for result in [with_params, with_opts]:
             query, params, wrapper = result

--- a/test/unit/gatewaytest/test_utils.py
+++ b/test/unit/gatewaytest/test_utils.py
@@ -19,8 +19,7 @@ from omero.gateway.utils import propertiesToDict
 import pytest
 
 
-class TestServiceOptsDict (object):
-
+class TestServiceOptsDict(object):
     def test_constructor(self):
         assert ServiceOptsDict() == {}
         assert ServiceOptsDict() is not {}
@@ -39,16 +38,15 @@ class TestServiceOptsDict (object):
 
         # ServiceOptsDict can be passed initializing data, but it needs to be
         # a dict
-        pytest.raises(AttributeError, ServiceOptsDict,
-                      kwargs={"data": "data"})
-        ServiceOptsDict(data={'option': 'a'})
+        pytest.raises(AttributeError, ServiceOptsDict, kwargs={"data": "data"})
+        ServiceOptsDict(data={"option": "a"})
 
     def test_keys(self):
         d = ServiceOptsDict()
         assert list(d.keys()) == []
 
         d = ServiceOptsDict({"omero.group": -1})
-        assert 'omero.group' in d
+        assert "omero.group" in d
 
         pytest.raises(TypeError, d.keys, None)
 
@@ -61,10 +59,18 @@ class TestServiceOptsDict (object):
 
         pytest.raises(TypeError, d.values, None)
 
-        d = ServiceOptsDict({
-            "a": None, "b": True, "c": "foo", "d": 1, "e": 1.45, "f": [],
-            "g": {}})
-        assert set(d.values()) == set(['foo', '1.45', '1'])
+        d = ServiceOptsDict(
+            {
+                "a": None,
+                "b": True,
+                "c": "foo",
+                "d": 1,
+                "e": 1.45,
+                "f": [],
+                "g": {},
+            }
+        )
+        assert set(d.values()) == set(["foo", "1.45", "1"])
 
     def test_items(self):
         d = ServiceOptsDict()
@@ -77,22 +83,22 @@ class TestServiceOptsDict (object):
 
     def test_has_key(self):
         d = ServiceOptsDict()
-        assert 'omero' not in d
+        assert "omero" not in d
 
         d = ServiceOptsDict({"omero.group": -1, "omero.user": 1})
         k = list(d.keys())
         k.sort()
-        assert k == ['omero.group', 'omero.user']
+        assert k == ["omero.group", "omero.user"]
 
     def test_contains(self):
         d = ServiceOptsDict()
-        assert not ('omero.group' in d)
-        assert 'omero.group' not in d
+        assert not ("omero.group" in d)
+        assert "omero.group" not in d
 
         d = ServiceOptsDict({"omero.group": -1, "omero.user": 1})
-        assert 'omero.group' in d
-        assert 'omero.user' in d
-        assert 'omero.share' not in d
+        assert "omero.group" in d
+        assert "omero.user" in d
+        assert "omero.share" not in d
 
     def test_len(self):
         d = ServiceOptsDict()
@@ -113,7 +119,7 @@ class TestServiceOptsDict (object):
 
         del d["omero.user"]
 
-        assert d == {"omero.group": "-1", 'foo': 'bar', "omero.share": "2"}
+        assert d == {"omero.group": "-1", "foo": "bar", "omero.share": "2"}
 
         pytest.raises(TypeError, d.__getitem__)
 
@@ -127,8 +133,8 @@ class TestServiceOptsDict (object):
         d["omero.group"] = "-1"
 
         # unicode
-        d = ServiceOptsDict({"omero.share": u'2', "omero.user": u'1'})
-        d["omero.group"] = u'-1'
+        d = ServiceOptsDict({"omero.share": "2", "omero.user": "1"})
+        d["omero.group"] = "-1"
 
         # int
         d = ServiceOptsDict({"omero.share": 1, "omero.user": 2})
@@ -136,9 +142,10 @@ class TestServiceOptsDict (object):
 
         # long
         import sys
+
         maxint = sys.maxsize
         d = ServiceOptsDict({"omero.group": (maxint + 1)})
-        d["omero.user"] = (maxint + 1)
+        d["omero.user"] = maxint + 1
 
         # Setter passed None as value remove from internal dict
         d = ServiceOptsDict({"omero.share": "2", "omero.user": "1"})
@@ -155,8 +162,10 @@ class TestServiceOptsDict (object):
         except:
             pass
         else:
-            self.fail("AttributeError: ServiceOptsDict argument must be a"
-                      " string, unicode or numeric type")
+            self.fail(
+                "AttributeError: ServiceOptsDict argument must be a"
+                " string, unicode or numeric type"
+            )
 
         try:
             d = ServiceOptsDict({"omero.group": []})
@@ -164,8 +173,10 @@ class TestServiceOptsDict (object):
         except:
             pass
         else:
-            self.fail("AttributeError: ServiceOptsDict argument must be a"
-                      " string, unicode or numeric type")
+            self.fail(
+                "AttributeError: ServiceOptsDict argument must be a"
+                " string, unicode or numeric type"
+            )
 
         try:
             d = ServiceOptsDict({"omero.group": {}})
@@ -173,12 +184,15 @@ class TestServiceOptsDict (object):
         except:
             pass
         else:
-            self.fail("AttributeError: ServiceOptsDict argument must be a"
-                      " string, unicode or numeric type")
+            self.fail(
+                "AttributeError: ServiceOptsDict argument must be a"
+                " string, unicode or numeric type"
+            )
 
     def test_clear(self):
         d = ServiceOptsDict(
-            {"omero.group": -1, "omero.user": 1, "omero.share": 2})
+            {"omero.group": -1, "omero.user": 1, "omero.share": 2}
+        )
         d.clear()
         assert d == {}
 
@@ -186,22 +200,21 @@ class TestServiceOptsDict (object):
 
     def test_repr(self):
         d = ServiceOptsDict()
-        assert repr(d) == '<ServiceOptsDict: {}>'
+        assert repr(d) == "<ServiceOptsDict: {}>"
         d["omero.group"] = -1
         assert repr(d) == "<ServiceOptsDict: {'omero.group': '-1'}>"
 
     def test_copy(self):
-
         def getHash(obj):
             return hex(id(obj))
 
         d = ServiceOptsDict(
-            {"omero.group": -1, "omero.user": 1, "omero.share": 2})
+            {"omero.group": -1, "omero.user": 1, "omero.share": 2}
+        )
         assert d.copy() == d
         assert getHash(d.copy()) != getHash(d)
         assert ServiceOptsDict().copy() == ServiceOptsDict()
-        assert getHash(ServiceOptsDict().copy()) != \
-            getHash(ServiceOptsDict())
+        assert getHash(ServiceOptsDict().copy()) != getHash(ServiceOptsDict())
         pytest.raises(TypeError, d.copy, None)
 
     def test_setter_an_getter(self):
@@ -229,80 +242,75 @@ class TestServiceOptsDict (object):
         assert d.get("omero.share") == d.getOmeroShare()
 
 
-class TestHelpers (object):
-
-    @pytest.mark.parametrize('true_val',
-                             [True, "true", "yes", "y", "t", "1", "on"])
+class TestHelpers(object):
+    @pytest.mark.parametrize(
+        "true_val", [True, "true", "yes", "y", "t", "1", "on"]
+    )
     def test_toBoolean_true(self, true_val):
         assert toBoolean(true_val)
 
     @pytest.mark.parametrize(
-        'false_val',
-        [False, "false", "f", "no", "n", "none", "0", "[]", "{}", "", "off"])
+        "false_val",
+        [False, "false", "f", "no", "n", "none", "0", "[]", "{}", "", "off"],
+    )
     def test_toBoolean_false(self, false_val):
         assert not toBoolean(false_val)
 
     def test_propertiesToDict(self):
-        d = {
-            '1.1': '11',
-            '1.2': '12',
-            '2.1': '21',
-            '3': '3'
-        }
+        d = {"1.1": "11", "1.2": "12", "2.1": "21", "3": "3"}
         dictprop = propertiesToDict(d)
         assert len(dictprop) == 3
-        assert set(['1', '2', '3']) - set(dictprop.keys()) == set()
-        assert len(dictprop['1']) == 2
-        assert len(dictprop['2']) == 1
-        assert dictprop['1']['1'] == 11
-        assert dictprop['1']['2'] == 12
-        assert dictprop['2']['1'] == 21
-        assert dictprop['3'] == 3
+        assert set(["1", "2", "3"]) - set(dictprop.keys()) == set()
+        assert len(dictprop["1"]) == 2
+        assert len(dictprop["2"]) == 1
+        assert dictprop["1"]["1"] == 11
+        assert dictprop["1"]["2"] == 12
+        assert dictprop["2"]["1"] == 21
+        assert dictprop["3"] == 3
 
     def test_propertiesToDictWithPrefix(self):
         d = {
-            'omero.prefix.str.1': 'mystring',
-            'omero.prefix.str.2': '1',
-            'omero.prefix.int.1': 1
+            "omero.prefix.str.1": "mystring",
+            "omero.prefix.str.2": "1",
+            "omero.prefix.int.1": 1,
         }
-        dictprop = propertiesToDict(d, prefix='omero.prefix.')
+        dictprop = propertiesToDict(d, prefix="omero.prefix.")
         assert len(dictprop) == 2
-        assert set(['str', 'int']) - set(dictprop.keys()) == set()
-        assert len(dictprop['str']) == 2
-        assert len(dictprop['int']) == 1
-        assert dictprop['int']['1'] == 1
-        assert dictprop['str']['1'] == 'mystring'
-        assert dictprop['str']['2'] == 1
+        assert set(["str", "int"]) - set(dictprop.keys()) == set()
+        assert len(dictprop["str"]) == 2
+        assert len(dictprop["int"]) == 1
+        assert dictprop["int"]["1"] == 1
+        assert dictprop["str"]["1"] == "mystring"
+        assert dictprop["str"]["2"] == 1
 
     def test_propertiesToDictBool(self):
         d = {
-            'omero.prefix.strbool.false1.enabled': 'False',
-            'omero.prefix.strbool.false2.enabled': 'false',
-            'omero.prefix.strbool.true1.enabled': 'True',
-            'omero.prefix.strbool.true2.enabled': 'true',
-            'omero.prefix.bool.1.enabled': False,
-            'omero.prefix.bool.2.enabled': True,
-            'omero.prefix.str.1.enabled': 't',
-            'omero.prefix.str.2.enabled': 'f'
+            "omero.prefix.strbool.false1.enabled": "False",
+            "omero.prefix.strbool.false2.enabled": "false",
+            "omero.prefix.strbool.true1.enabled": "True",
+            "omero.prefix.strbool.true2.enabled": "true",
+            "omero.prefix.bool.1.enabled": False,
+            "omero.prefix.bool.2.enabled": True,
+            "omero.prefix.str.1.enabled": "t",
+            "omero.prefix.str.2.enabled": "f",
         }
-        dictprop = propertiesToDict(d, prefix='omero.prefix.')
+        dictprop = propertiesToDict(d, prefix="omero.prefix.")
 
         assert len(dictprop) == 3
-        assert set(['strbool', 'bool', 'str']) - set(dictprop.keys()) == \
-            set()
+        assert set(["strbool", "bool", "str"]) - set(dictprop.keys()) == set()
 
-        assert not dictprop['strbool']['false1']['enabled']
-        assert isinstance(dictprop['strbool']['false1']['enabled'], bool)
-        assert not dictprop['strbool']['false2']['enabled']
-        assert isinstance(dictprop['strbool']['false2']['enabled'], bool)
-        assert dictprop['strbool']['true1']['enabled']
-        assert isinstance(dictprop['strbool']['true1']['enabled'], bool)
-        assert dictprop['strbool']['true2']['enabled']
-        assert isinstance(dictprop['strbool']['true2']['enabled'], bool)
-        assert not dictprop['bool']['1']['enabled']
-        assert isinstance(dictprop['bool']['1']['enabled'], bool)
-        assert dictprop['bool']['2']['enabled']
-        assert isinstance(dictprop['bool']['2']['enabled'], bool)
+        assert not dictprop["strbool"]["false1"]["enabled"]
+        assert isinstance(dictprop["strbool"]["false1"]["enabled"], bool)
+        assert not dictprop["strbool"]["false2"]["enabled"]
+        assert isinstance(dictprop["strbool"]["false2"]["enabled"], bool)
+        assert dictprop["strbool"]["true1"]["enabled"]
+        assert isinstance(dictprop["strbool"]["true1"]["enabled"], bool)
+        assert dictprop["strbool"]["true2"]["enabled"]
+        assert isinstance(dictprop["strbool"]["true2"]["enabled"], bool)
+        assert not dictprop["bool"]["1"]["enabled"]
+        assert isinstance(dictprop["bool"]["1"]["enabled"], bool)
+        assert dictprop["bool"]["2"]["enabled"]
+        assert isinstance(dictprop["bool"]["2"]["enabled"], bool)
 
-        assert dictprop['str']['1']['enabled'] == 't'
-        assert dictprop['str']['2']['enabled'] == 'f'
+        assert dictprop["str"]["1"]["enabled"] == "t"
+        assert dictprop["str"]["2"]["enabled"] == "f"

--- a/test/unit/scriptstest/test_parse.py
+++ b/test/unit/scriptstest/test_parse.py
@@ -20,8 +20,15 @@ import omero
 
 from omero.grid import JobParams
 from omero.scripts import (
-    String, List, Bool, Long, Set,
-    MissingInputs, ParseExit, compare_proto)
+    String,
+    List,
+    Bool,
+    Long,
+    Set,
+    MissingInputs,
+    ParseExit,
+    compare_proto,
+)
 from omero.scripts import client, parse_inputs, validate_inputs, parse_text
 from omero.scripts import group_params, rlist, rlong, rint, wrap, unwrap
 
@@ -33,9 +40,9 @@ except:
 
 
 class TestParse(object):
-
     def testParse(self):
         try:
+
             class mock(object):
                 def setAgent(self, *args):
                     pass
@@ -51,24 +58,50 @@ class TestParse(object):
 
                 def setOutput(self, *args):
                     pass
+
             script_client = client(
-                "testParse", "simple ping script", Long("a").inout(),
-                String("b").inout(), client=mock())
-            print("IN CLIENT: " + \
-                script_client.getProperty("omero.scripts.parse"))
+                "testParse",
+                "simple ping script",
+                Long("a").inout(),
+                String("b").inout(),
+                client=mock(),
+            )
+            print(
+                "IN CLIENT: " + script_client.getProperty("omero.scripts.parse")
+            )
             assert False, "Should have raised ParseExit"
         except ParseExit:
             pass
 
     def testMinMaxTicket2318(self):
         # Duplicating from some of the scripts to reproduce problem
-        def makeParam(paramClass, name, description=None, optional=True,
-                      min=None, max=None, values=None):
-            param = paramClass(name, optional, description=description,
-                               min=min, max=max, values=values)
+        def makeParam(
+            paramClass,
+            name,
+            description=None,
+            optional=True,
+            min=None,
+            max=None,
+            values=None,
+        ):
+            param = paramClass(
+                name,
+                optional,
+                description=description,
+                min=min,
+                max=max,
+                values=values,
+            )
             return param
-        p = makeParam(Long, "thumbSize", "The dimension of each thumbnail."
-                      " Default is 100", True, 10, 250)
+
+        p = makeParam(
+            Long,
+            "thumbSize",
+            "The dimension of each thumbnail." " Default is 100",
+            True,
+            10,
+            250,
+        )
         assert 10 == p.min.val
         assert 250 == p.max.val
 
@@ -206,10 +239,10 @@ if True:
             )"""
         params = parse_text(SCRIPT)
         inputs = {
-            "Merged_Colours": wrap(['Red', 'Green']),
+            "Merged_Colours": wrap(["Red", "Green"]),
             "Image_Labels": wrap("Datasets"),
             "Data_Type": wrap("Image"),
-            "IDs": rlist([rlong(1)])
+            "IDs": rlist([rlong(1)]),
         }
         errors = validate_inputs(params, inputs)
         assert "" == errors, errors
@@ -234,7 +267,8 @@ if True:
             "    scripts.Long('longParam', True, description='theDesc',"
             " min=rlong(1), max=rlong(10), values=[rlong(5)]) )",
             "    client.setOutput('returnMessage', rstring('Script ran"
-            " OK!'))"]
+            " OK!'))",
+        ]
         params = parse_text("\n".join(scriptLines))
         l = params.inputs["longParam"]
         assert None != l.prototype, str(l)

--- a/test/unit/scriptstest/test_prototypes.py
+++ b/test/unit/scriptstest/test_prototypes.py
@@ -17,7 +17,6 @@ from omero.rtypes import rmap, rint, rlong, rstring, rlist, rset, unwrap
 
 
 class TestPrototypes(object):
-
     def testRSetRInt(self):
         params = omero.grid.JobParams()
         param = omero.grid.Param()
@@ -108,14 +107,23 @@ class TestPrototypes(object):
     def testTicket2323Min(self):
         params = omero.grid.JobParams()
         # Copied from integration/scripts.py:testUploadOfficialScripts
-        param = Long('longParam', True, description='theDesc', min=int(1),
-                     max=int(10), values=[rlong(5)])
-        assert 1 == param.min.getValue(), \
-            "Min value not correct:" + str(param.min)
-        assert 10 == param.max.getValue(), \
-            "Max value not correct:" + str(param.max)
-        assert 5 == param.values.getValue()[0].getValue(), \
-            "First option value not correct:" + str(param.values)
+        param = Long(
+            "longParam",
+            True,
+            description="theDesc",
+            min=int(1),
+            max=int(10),
+            values=[rlong(5)],
+        )
+        assert 1 == param.min.getValue(), "Min value not correct:" + str(
+            param.min
+        )
+        assert 10 == param.max.getValue(), "Max value not correct:" + str(
+            param.max
+        )
+        assert (
+            5 == param.values.getValue()[0].getValue()
+        ), "First option value not correct:" + str(param.values)
 
         params.inputs = {"a": param}
         inputs = {"a": rlong(5)}
@@ -123,6 +131,7 @@ class TestPrototypes(object):
         assert "" == errors, errors
 
     def testTicket2323List(self):
-        param = List('listParam', True, description='theDesc',
-                     values=[rlong(5)])
+        param = List(
+            "listParam", True, description="theDesc", values=[rlong(5)]
+        )
         assert [5] == unwrap(param.values), str(param.values)

--- a/test/unit/tablestest/library.py
+++ b/test/unit/tablestest/library.py
@@ -15,7 +15,6 @@ from omero.util.temp_files import create_path
 
 
 class TestCase(object):
-
     def setup_method(self, method):
         self.dir = self.tmpdir()
 

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -47,7 +47,6 @@ class MockAdapter(object):
 
 
 class TestHdfStorage(TestCase):
-
     def setup_method(self, method):
         TestCase.setup_method(self, method)
         self.ic = Ice.initialize()
@@ -59,9 +58,9 @@ class TestHdfStorage(TestCase):
             of.register(self.ic)
 
     def cols(self):
-        a = omero.columns.LongColumnI('a', 'first', None)
-        b = omero.columns.LongColumnI('b', 'first', None)
-        c = omero.columns.LongColumnI('c', 'first', None)
+        a = omero.columns.LongColumnI("a", "first", None)
+        b = omero.columns.LongColumnI("b", "first", None)
+        c = omero.columns.LongColumnI("c", "first", None)
         return [a, b, c]
 
     def init(self, hdf, meta=False):
@@ -85,13 +84,10 @@ class TestHdfStorage(TestCase):
         return old_div(path(tmpdir), "test.h5")
 
     def testInvalidFile(self):
-        pytest.raises(
-            omero.ApiUsageException, HdfStorage, None, None)
-        pytest.raises(
-            omero.ApiUsageException, HdfStorage, '', self.lock)
+        pytest.raises(omero.ApiUsageException, HdfStorage, None, None)
+        pytest.raises(omero.ApiUsageException, HdfStorage, "", self.lock)
         bad = path(self.tmpdir()) / "doesntexist" / "test.h5"
-        pytest.raises(
-            omero.ApiUsageException, HdfStorage, bad, self.lock)
+        pytest.raises(omero.ApiUsageException, HdfStorage, bad, self.lock)
 
     def testValidFile(self):
         hdf = HdfStorage(self.hdfpath(), self.lock)
@@ -102,7 +98,7 @@ class TestHdfStorage(TestCase):
         hdf1 = HdfStorage(tmp, self.lock)
         with pytest.raises(omero.LockTimeout) as exc_info:
             HdfStorage(tmp, self.lock)
-        assert exc_info.value.message.startswith('Path already in HdfList: ')
+        assert exc_info.value.message.startswith("Path already in HdfList: ")
         hdf1.cleanup()
         hdf3 = HdfStorage(tmp, self.lock)
         hdf3.cleanup()
@@ -154,7 +150,7 @@ class TestHdfStorage(TestCase):
         self.append(hdf, {"a": 0, "b": 0, "c": 0})
         self.append(hdf, {"a": 0, "b": 4, "c": 0})
         self.append(hdf, {"a": 0, "b": 0, "c": 0})
-        hdf.getWhereList(time.time(), '(a==0)', None, 'b', None, None, None)
+        hdf.getWhereList(time.time(), "(a==0)", None, "b", None, None, None)
         # Doesn't work yet.
         hdf.cleanup()
 
@@ -162,14 +158,14 @@ class TestHdfStorage(TestCase):
         hdf = HdfStorage(self.hdfpath(), self.lock)
 
         with pytest.raises(omero.ApiUsageException) as exc:
-            hdf.initialize([omero.columns.LongColumnI('')], None)
-        assert exc.value.message.startswith('Column unnamed:')
+            hdf.initialize([omero.columns.LongColumnI("")], None)
+        assert exc.value.message.startswith("Column unnamed:")
 
         with pytest.raises(omero.ApiUsageException) as exc:
-            hdf.initialize([omero.columns.LongColumnI('__a')], None)
-        assert exc.value.message == 'Reserved column name: __a'
+            hdf.initialize([omero.columns.LongColumnI("__a")], None)
+        assert exc.value.message == "Reserved column name: __a"
 
-        hdf.initialize([omero.columns.LongColumnI('a')], None)
+        hdf.initialize([omero.columns.LongColumnI("a")], None)
         hdf.cleanup()
 
     def testInitializationOnInitializedFileFails(self):
@@ -205,37 +201,39 @@ class TestHdfStorage(TestCase):
         hdf.cleanup()
 
     @pytest.mark.xfail
-    @pytest.mark.broken(reason = "TODO after python3 migration")
+    @pytest.mark.broken(reason="TODO after python3 migration")
     def testGetSetMetaMap(self):
         hdf = HdfStorage(self.hdfpath(), self.lock)
         self.init(hdf, False)
 
-        hdf.add_meta_map({'a': rint(1)})
+        hdf.add_meta_map({"a": rint(1)})
         m1 = hdf.get_meta_map()
         assert len(m1) == 3
-        assert m1['__initialized'].val > 0
-        assert m1['__version'] == rstring('2')
-        assert m1['a'] == rint(1)
+        assert m1["__initialized"].val > 0
+        assert m1["__version"] == rstring("2")
+        assert m1["a"] == rint(1)
 
         with pytest.raises(omero.ApiUsageException) as exc:
-            hdf.add_meta_map({'b': rint(1), '__c': rint(2)})
-        assert exc.value.message == 'Reserved attribute name: __c'
+            hdf.add_meta_map({"b": rint(1), "__c": rint(2)})
+        assert exc.value.message == "Reserved attribute name: __c"
         assert hdf.get_meta_map() == m1
 
         with pytest.raises(omero.ValidationException) as exc:
-            hdf.add_meta_map({'d': rint(None)})
-        assert exc.value.serverStackTrace.startswith('Unsupported type:')
+            hdf.add_meta_map({"d": rint(None)})
+        assert exc.value.serverStackTrace.startswith("Unsupported type:")
         assert hdf.get_meta_map() == m1
 
         hdf.add_meta_map({}, replace=True)
         m2 = hdf.get_meta_map()
         assert len(m2) == 2
         assert m2 == {
-            '__initialized': m1['__initialized'], '__version': rstring('2')}
+            "__initialized": m1["__initialized"],
+            "__version": rstring("2"),
+        }
 
-        hdf.add_meta_map({'__test': 1}, replace=True, init=True)
+        hdf.add_meta_map({"__test": 1}, replace=True, init=True)
         m3 = hdf.get_meta_map()
-        assert m3 == {'__test': rint(1)}
+        assert m3 == {"__test": rint(1)}
 
         hdf.cleanup()
 
@@ -243,17 +241,23 @@ class TestHdfStorage(TestCase):
         # Tables size is in bytes, len("მიკროსკოპის პონი".encode()) == 46
         bytesize = 46
         hdf = HdfStorage(self.hdfpath(), self.lock)
-        cols = [omero.columns.StringColumnI(
-            "name", "description", bytesize, None)]
+        cols = [
+            omero.columns.StringColumnI("name", "description", bytesize, None)
+        ]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
         cols[0].values = ["foo", "მიკროსკოპის პონი"]
         hdf.append(cols)
-        rows = hdf.getWhereList(time.time(), '(name=="foo")', None, 'b', None,
-                                None, None)
+        rows = hdf.getWhereList(
+            time.time(), '(name=="foo")', None, "b", None, None, None
+        )
         assert rows == [0]
-        assert bytesize == hdf.readCoordinates(
-            time.time(), [0], self.current).columns[0].size
+        assert (
+            bytesize
+            == hdf.readCoordinates(time.time(), [0], self.current)
+            .columns[0]
+            .size
+        )
         # Unicode conditions don't work on Python 3
         # Fetching should still work though
         r1 = hdf.readCoordinates(time.time(), [1], self.current)
@@ -268,8 +272,9 @@ class TestHdfStorage(TestCase):
         # len("მიკროსკოპის პონი".encode()) == 46
         bytesize = 45
         hdf = HdfStorage(self.hdfpath(), self.lock)
-        cols = [omero.columns.StringColumnI(
-            "name", "description", bytesize, None)]
+        cols = [
+            omero.columns.StringColumnI("name", "description", bytesize, None)
+        ]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
         cols[0].values = ["მიკროსკოპის პონი"]
@@ -277,30 +282,46 @@ class TestHdfStorage(TestCase):
         with pytest.raises(omero.ValidationException) as exc_info:
             hdf.append(cols)
         assert exc_info.value.message == (
-            'Maximum string (byte) length in column name is 45')
+            "Maximum string (byte) length in column name is 45"
+        )
 
         # Doesn't work yet.
         hdf.cleanup()
 
-    @pytest.mark.xfail(reason=(
-        "Unicode conditions broken on Python 3. "
-        "See explanation in omero.columns.StringColumnI"))
+    @pytest.mark.xfail(
+        reason=(
+            "Unicode conditions broken on Python 3. "
+            "See explanation in omero.columns.StringColumnI"
+        )
+    )
     @pytest.mark.broken(reason="Unicode conditions broken on Python 3")
     def testStringColWhereUnicode(self):
         # Tables size is in bytes, len("მიკროსკოპის პონი".encode()) == 46
         bytesize = 46
         hdf = HdfStorage(self.hdfpath(), self.lock)
-        cols = [omero.columns.StringColumnI(
-            "name", "description", bytesize, None)]
+        cols = [
+            omero.columns.StringColumnI("name", "description", bytesize, None)
+        ]
         hdf.initialize(cols)
         cols[0].settable(hdf._HdfStorage__mea)  # Needed for size
         cols[0].values = ["foo", "მიკროსკოპის პონი"]
         hdf.append(cols)
-        rows = hdf.getWhereList(time.time(), '(name=="მიკროსკოპის პონი")',
-                                None, 'b', None, None, None)
+        rows = hdf.getWhereList(
+            time.time(),
+            '(name=="მიკროსკოპის პონი")',
+            None,
+            "b",
+            None,
+            None,
+            None,
+        )
         assert rows == [1]
-        assert bytesize == hdf.readCoordinates(
-            time.time(), [0], self.current).columns[0].size
+        assert (
+            bytesize
+            == hdf.readCoordinates(time.time(), [0], self.current)
+            .columns[0]
+            .size
+        )
         # Doesn't work yet.
         hdf.cleanup()
 
@@ -310,7 +331,7 @@ class TestHdfStorage(TestCase):
     @pytest.mark.broken
     def testMaskColumn(self):
         hdf = HdfStorage(self.hdfpath(), self.lock)
-        mask = omero.columns.MaskColumnI('mask', 'desc', None)
+        mask = omero.columns.MaskColumnI("mask", "desc", None)
         hdf.initialize([mask], None)
         mask.imageId = [1, 2]
         mask.theZ = [2, 2]
@@ -344,7 +365,6 @@ class TestHdfStorage(TestCase):
 
 
 class TestHdfList(TestCase):
-
     def setup_method(self, method):
         TestCase.setup_method(self, method)
         self.mox = mox.Mox()
@@ -354,7 +374,7 @@ class TestHdfList(TestCase):
         return old_div(path(tmpdir), "test.h5")
 
     @pytest.mark.xfail
-    @pytest.mark.broken(reason = "TODO after python3 migration")
+    @pytest.mark.broken(reason="TODO after python3 migration")
     def testLocking(self, monkeypatch):
         lock1 = threading.RLock()
         hdflist2 = HdfList()
@@ -367,35 +387,44 @@ class TestHdfList(TestCase):
         # There are multiple guards against opening the same HDF5 file
 
         # PyTables includes a check
-        monkeypatch.setattr(storage_module, 'HDFLIST', hdflist2)
+        monkeypatch.setattr(storage_module, "HDFLIST", hdflist2)
         with pytest.raises(ValueError) as exc_info:
             HdfStorage(tmp, lock2)
 
         assert exc_info.value.message.startswith(
-            "The file '%s' is already opened. " % tmp)
+            "The file '%s' is already opened. " % tmp
+        )
         monkeypatch.undo()
 
         # HdfList uses portalocker, test by mocking tables.open_file
         if hasattr(tables, "open_file"):
-            self.mox.StubOutWithMock(tables, 'open_file')
-            tables.file._FILE_OPEN_POLICY = 'default'
-            tables.open_file(tmp, mode='w',
-                             title='OMERO HDF Measurement Storage',
-                             rootUEP='/').AndReturn(open(tmp))
+            self.mox.StubOutWithMock(tables, "open_file")
+            tables.file._FILE_OPEN_POLICY = "default"
+            tables.open_file(
+                tmp,
+                mode="w",
+                title="OMERO HDF Measurement Storage",
+                rootUEP="/",
+            ).AndReturn(open(tmp))
 
             self.mox.ReplayAll()
         else:
-            self.mox.StubOutWithMock(tables, 'openFile')
-            tables.openFile(tmp, mode='w',
-                            title='OMERO HDF Measurement Storage',
-                            rootUEP='/').AndReturn(open(tmp))
+            self.mox.StubOutWithMock(tables, "openFile")
+            tables.openFile(
+                tmp,
+                mode="w",
+                title="OMERO HDF Measurement Storage",
+                rootUEP="/",
+            ).AndReturn(open(tmp))
 
-        monkeypatch.setattr(storage_module, 'HDFLIST', hdflist2)
+        monkeypatch.setattr(storage_module, "HDFLIST", hdflist2)
         with pytest.raises(omero.LockTimeout) as exc_info:
             HdfStorage(tmp, lock2)
         print(exc_info.value)
-        assert (exc_info.value.message ==
-                'Cannot acquire exclusive lock on: %s' % tmp)
+        assert (
+            exc_info.value.message
+            == "Cannot acquire exclusive lock on: %s" % tmp
+        )
 
         monkeypatch.undo()
 

--- a/test/unit/tablestest/test_servants.py
+++ b/test/unit/tablestest/test_servants.py
@@ -194,7 +194,6 @@ class mock_storage(object):
 
 
 class TestTables(TestCase):
-
     def setup_method(self, method):
         TestCase.setup_method(self, method)
 
@@ -208,8 +207,9 @@ class TestTables(TestCase):
         self.communicator = mock_communicator()
         self.communicator_provider = communicator_provider(self.communicator)
         self.stop_event = omero.util.concurrency.get_event()
-        self.ctx = omero.util.ServerContext(serverid, self.communicator,
-                                            self.stop_event)
+        self.ctx = omero.util.ServerContext(
+            serverid, self.communicator, self.stop_event
+        )
 
         self.current = mock_current(self.communicator)
         self.__tables = []
@@ -240,8 +240,9 @@ class TestTables(TestCase):
 
     def repodir(self, make=True):
         self.tmp = path(self.tmpdir())
-        self.communicator.getProperties().setProperty("omero.repo.dir",
-                                                      native_str(self.tmp))
+        self.communicator.getProperties().setProperty(
+            "omero.repo.dir", native_str(self.tmp)
+        )
         repo = self.tmp / ".omero" / "repository"
         if make:
             repo.makedirs()
@@ -269,8 +270,9 @@ class TestTables(TestCase):
 
     def testTablesIGetDirGetsRepoThenNoSF(self):
         self.repodir()
-        omero.util.internal_service_factory = \
-            mocked_internal_service_factory(None)
+        omero.util.internal_service_factory = mocked_internal_service_factory(
+            None
+        )
         pytest.raises(Exception, omero.tables.TablesI, self.ctx)
 
     def testTablesIGetDirGetsRepoGetsSFCantFindRepoFile(self):
@@ -280,7 +282,8 @@ class TestTables(TestCase):
     def testTablesIGetDirGetsRepoGetsSFCantFindRepoObject(self):
         self.repofile(self.sf.db_uuid)
         self.sf.return_values.append(
-            omero.ApiUsageException(None, None, "Can't Find"))
+            omero.ApiUsageException(None, None, "Can't Find")
+        )
         pytest.raises(omero.ApiUsageException, omero.tables.TablesI, self.ctx)
 
     def testTablesIGetDirGetsRepoGetsSFGetsRepo(self):
@@ -347,8 +350,9 @@ class TestTables(TestCase):
         storage = table.storage
         assert storage
 
-        table.initialize([LongColumnI("a", None, []),
-                          DoubleColumnI("b", None, [])])
+        table.initialize(
+            [LongColumnI("a", None, []), DoubleColumnI("b", None, [])]
+        )
         template = table.getHeaders(self.current)
         template[0].values = [1] * 5
         template[1].values = [2.0] * 5
@@ -359,7 +363,7 @@ class TestTables(TestCase):
 
     def testTableSearch(self):
         table = self.testTableAddData(True, False)
-        rv = list(table.getWhereList('(a==1)', None, None, None, None, None))
+        rv = list(table.getWhereList("(a==1)", None, None, None, None, None))
         assert list(range(5)) == rv
         data = table.readCoordinates(rv, self.current)
         assert 2 == len(data.columns)
@@ -379,8 +383,13 @@ class TestTables(TestCase):
         f.close()
 
         tables = self.tablesI(internal_repo)
-        pytest.raises(omero.ValidationException, tables.getTable, of, self.sf,
-                      self.current)
+        pytest.raises(
+            omero.ValidationException,
+            tables.getTable,
+            of,
+            self.sf,
+            self.current,
+        )
 
     def testErrorInGet(self):
         self.repofile(self.sf.db_uuid)
@@ -390,8 +399,8 @@ class TestTables(TestCase):
 
         tables = self.tablesI()
         table = tables.getTable(f, self.sf, self.current).table  # From mock
-        cols = [omero.columns.LongColumnI('name', 'desc', None)]
+        cols = [omero.columns.LongColumnI("name", "desc", None)]
         table.initialize(cols)
         cols[0].values = [1, 2, 3, 4]
         table.addData(cols)
-        table.getWhereList('(name==1)', None, 0, 0, 0, self.current)
+        table.getWhereList("(name==1)", None, 0, 0, 0, self.current)

--- a/test/unit/test_clients.py
+++ b/test/unit/test_clients.py
@@ -27,7 +27,6 @@ import omero.clients as base
 
 
 class MockCommunicator(object):
-
     def __init__(self):
         self.props = Ice.createProperties()
         self._impl = object()
@@ -46,13 +45,11 @@ class MockCommunicator(object):
 
 
 class MockRouter(object):
-
     def destroySession(self):
         pass
 
 
 class MockClient(base.BaseClient):
-
     def __init__(self):
         """
         Replicating a good deal of the __init__ setup, since the method
@@ -154,28 +151,48 @@ class TestHostUrlParsing(object):
 
     def _get_hosturl(self, values):
         return {
-            'protocol': values[0],
-            'server': values[1],
-            'port': values[2],
-            'path': values[3],
+            "protocol": values[0],
+            "server": values[1],
+            "port": values[2],
+            "path": values[3],
         }
 
-    @pytest.mark.parametrize('host,port,pmap,expected', [
-        ('test-host', None, {}, None),
-        ('test-host:12345', None, {}, None),
-        ('wss://test', None, {}, ('wss', 'test', 443, None)),
-        ('wss://test:12345', None, {}, ('wss', 'test', 12345, None)),
-        ('wss://test/sub/path', None, {}, ('wss', 'test', 443, '/sub/path')),
-        ('ws://test', None, {}, ('ws', 'test', 80, None)),
-        ('tcp://test', None, {}, ('tcp', 'test', 4063, None)),
-        ('ssl://test', None, {}, ('ssl', 'test', 4064, None)),
-        (None, None, {'omero.host': 'wss://test'},
-            ('wss', 'test', 443, None)),
-        (None, None, {'omero.host': 'wss://test:12345'},
-            ('wss', 'test', 12345, None)),
-        (None, None, {'omero.host': 'wss://test', 'omero.port': '12345'},
-            ('wss', 'test', 12345, None)),
-    ])
+    @pytest.mark.parametrize(
+        "host,port,pmap,expected",
+        [
+            ("test-host", None, {}, None),
+            ("test-host:12345", None, {}, None),
+            ("wss://test", None, {}, ("wss", "test", 443, None)),
+            ("wss://test:12345", None, {}, ("wss", "test", 12345, None)),
+            (
+                "wss://test/sub/path",
+                None,
+                {},
+                ("wss", "test", 443, "/sub/path"),
+            ),
+            ("ws://test", None, {}, ("ws", "test", 80, None)),
+            ("tcp://test", None, {}, ("tcp", "test", 4063, None)),
+            ("ssl://test", None, {}, ("ssl", "test", 4064, None)),
+            (
+                None,
+                None,
+                {"omero.host": "wss://test"},
+                ("wss", "test", 443, None),
+            ),
+            (
+                None,
+                None,
+                {"omero.host": "wss://test:12345"},
+                ("wss", "test", 12345, None),
+            ),
+            (
+                None,
+                None,
+                {"omero.host": "wss://test", "omero.port": "12345"},
+                ("wss", "test", 12345, None),
+            ),
+        ],
+    )
     def test_check_for_hosturl(self, host, port, pmap, expected):
         hosturl = self.mc._check_for_hosturl(host, port, pmap)
         if expected:
@@ -184,57 +201,72 @@ class TestHostUrlParsing(object):
             expected_hosturl = {}
         assert expected_hosturl == hosturl
 
-    @pytest.mark.parametrize('values,expected', [
-        (('ssl', 'test', 12345, ''),
-         '--Ice.Default.Router=OMERO.Glacier2/router:ssl -p 12345 -h test'),
-        (('wss', 'test', 12345, '/sub/path'),
-         '--Ice.Default.Router=OMERO.Glacier2/router:wss -p 12345 -h test '
-         '-r /sub/path'),
-    ])
+    @pytest.mark.parametrize(
+        "values,expected",
+        [
+            (
+                ("ssl", "test", 12345, ""),
+                "--Ice.Default.Router=OMERO.Glacier2/router:ssl -p 12345 -h test",
+            ),
+            (
+                ("wss", "test", 12345, "/sub/path"),
+                "--Ice.Default.Router=OMERO.Glacier2/router:wss -p 12345 -h test "
+                "-r /sub/path",
+            ),
+        ],
+    )
     def test_get_endpoint_from_hosturl(self, values, expected):
         hosturl = self._get_hosturl(values)
         assert expected == self.mc._get_endpoint_from_hosturl(hosturl)
 
 
 class MockClientInit(base.BaseClient):
-
     def _initData(self, id):
         self.test_id = id
 
 
 class TestClientInit(object):
-
     def setup_method(self, method):
         self.mc = None
 
     def teardown_method(self, method):
         self.mc.__del__()
 
-    @pytest.mark.parametrize('args,expected', [
-        (('omero.example.org',), {
-            'omero.host': 'omero.example.org',
-            'omero.port': '4064',
-        }),
-        (('ssl://omero.example.org',), {
-            'omero.host': '',
-            'omero.url.host': 'omero.example.org',
-            'omero.port': '4064',
-            'Ice.Default.Router': 'OMERO.Glacier2/router:ssl -p 4064 '
-            '-h omero.example.org',
-        }),
-        (('wss://omero.example.org/omero-ws',), {
-            'omero.host': '',
-            'omero.url.host': 'omero.example.org',
-            'omero.port': '443',
-            'Ice.Default.Router': 'OMERO.Glacier2/router:wss -p 443 '
-            '-h omero.example.org -r /omero-ws',
-        }),
-    ])
+    @pytest.mark.parametrize(
+        "args,expected",
+        [
+            (
+                ("omero.example.org",),
+                {"omero.host": "omero.example.org", "omero.port": "4064",},
+            ),
+            (
+                ("ssl://omero.example.org",),
+                {
+                    "omero.host": "",
+                    "omero.url.host": "omero.example.org",
+                    "omero.port": "4064",
+                    "Ice.Default.Router": "OMERO.Glacier2/router:ssl -p 4064 "
+                    "-h omero.example.org",
+                },
+            ),
+            (
+                ("wss://omero.example.org/omero-ws",),
+                {
+                    "omero.host": "",
+                    "omero.url.host": "omero.example.org",
+                    "omero.port": "443",
+                    "Ice.Default.Router": "OMERO.Glacier2/router:wss -p 443 "
+                    "-h omero.example.org -r /omero-ws",
+                },
+            ),
+        ],
+    )
     def test_client_init(self, args, expected):
         self.mc = MockClientInit(*args)
         props = self.mc.test_id.properties
         for k, v in expected.items():
-            if k == 'omero.host':
+            if k == "omero.host":
                 # When this is run on Travis ice.config overrides this property
                 assert (props.getProperty(k) == v) or (
-                    props.getProperty(k) == 'localhost')
+                    props.getProperty(k) == "localhost"
+                )

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -70,7 +70,10 @@ def cf(elemA, elemB):
 
     === v ===
 
-    %s""" % (totext(elemA), totext(elemB))
+    %s""" % (
+        totext(elemA),
+        totext(elemB),
+    )
 
 
 def initial(default="default"):
@@ -79,13 +82,14 @@ def initial(default="default"):
     """
     icegrid = Element("icegrid")
     properties = SubElement(icegrid, "properties", id=ConfigXml.INTERNAL)
-    SubElement(properties, "property", name=ConfigXml.DEFAULT,
-               value=default)
-    SubElement(properties, "property", name=ConfigXml.KEY,
-               value=ConfigXml.VERSION)
+    SubElement(properties, "property", name=ConfigXml.DEFAULT, value=default)
+    SubElement(
+        properties, "property", name=ConfigXml.KEY, value=ConfigXml.VERSION
+    )
     properties = SubElement(icegrid, "properties", id=default)
-    SubElement(properties, "property", name=ConfigXml.KEY,
-               value=ConfigXml.VERSION)
+    SubElement(
+        properties, "property", name=ConfigXml.KEY, value=ConfigXml.VERSION
+    )
     return icegrid
 
 
@@ -94,12 +98,11 @@ def totext(elem):
     Use minidom to generate a string representation
     of an XML element.
     """
-    string = tostring(elem, 'utf-8')
+    string = tostring(elem, "utf-8")
     return xml.dom.minidom.parseString(string).toxml()
 
 
 class TestConfig(object):
-
     def testBasic(self):
         p = create_path()
         config = ConfigXml(filename=str(p))
@@ -118,6 +121,7 @@ class TestConfig(object):
         setting, then without, the __ACTIVE__ block should reflect
         "default" and not the intermediate "env" setting.
         """
+
         def get_profile_name(p):
             """
             Takes a path object to the config xml
@@ -179,8 +183,7 @@ class TestConfig(object):
         config["omero.data.dir"] = "HOME"
         config.close()
         i = initial("DICT")
-        _ = SubElement(i[0][0], "property", name="omero.data.dir",
-                       value="HOME")
+        _ = SubElement(i[0][0], "property", name="omero.data.dir", value="HOME")
         _ = SubElement(i, "properties", id="DICT")
         _ = SubElement(_, "property", name="omero.data.dir", value="HOME")
         assertXml(i, XML(p.text()))
@@ -233,15 +236,24 @@ class TestConfig(object):
         default = SubElement(XML, "properties", id="default")
         for properties in (active, default):
             SubElement(
-                properties, "property", name="omero.config.version",
-                value="4.2.0")
+                properties,
+                "property",
+                name="omero.config.version",
+                value="4.2.0",
+            )
             SubElement(
-                properties, "property", name="omero.ldap.new_user_group",
-                value="member=${dn}")
+                properties,
+                "property",
+                name="omero.ldap.new_user_group",
+                value="member=${dn}",
+            )
             SubElement(
-                properties, "property", name="omero.ldap.new_user_group_2",
-                value="member=$${omero.dollar}{dn}")
-        string = tostring(XML, 'utf-8')
+                properties,
+                "property",
+                name="omero.ldap.new_user_group_2",
+                value="member=$${omero.dollar}{dn}",
+            )
+        string = tostring(XML, "utf-8")
         txt = xml.dom.minidom.parseString(string).toprettyxml("  ", "\n", None)
         p.write_text(txt)
 
@@ -261,14 +273,16 @@ class TestConfig(object):
         """
 
         beforeUpdate = '[["Figure", "figure_index"]]'
-        afterUpdate = '[["Data", "webindex", ' \
-            '{"title": "Browse Data via Projects, Tags etc"}], ' \
-            '["History", "history", ' \
-            '{"title": "History"}], ' \
-            '["Help", "https://help.openmicroscopy.org/", ' \
-            '{"target": "new", "title": ' \
-            '"Open OMERO user guide in a new tab"}], ' \
+        afterUpdate = (
+            '[["Data", "webindex", '
+            '{"title": "Browse Data via Projects, Tags etc"}], '
+            '["History", "history", '
+            '{"title": "History"}], '
+            '["Help", "https://help.openmicroscopy.org/", '
+            '{"target": "new", "title": '
+            '"Open OMERO user guide in a new tab"}], '
             '["Figure", "figure_index"]]'
+        )
         p = create_path()
 
         XML = Element("icegrid")
@@ -277,12 +291,18 @@ class TestConfig(object):
         for properties in (active, default):
             # Include a property to indicate version is post-4.2.0
             SubElement(
-                properties, "property", name="omero.config.version",
-                value="4.2.1")
+                properties,
+                "property",
+                name="omero.config.version",
+                value="4.2.1",
+            )
             SubElement(
-                properties, "property", name="omero.web.ui.top_links",
-                value=beforeUpdate)
-        string = tostring(XML, 'utf-8')
+                properties,
+                "property",
+                name="omero.web.ui.top_links",
+                value=beforeUpdate,
+            )
+        string = tostring(XML, "utf-8")
         txt = xml.dom.minidom.parseString(string).toprettyxml("  ", "\n", None)
         p.write_text(txt)
 
@@ -316,15 +336,14 @@ class TestConfig(object):
     def testReadOnlyConfigPassesOnExplicitReadOnly(self):
         p = create_path()
         p.chmod(0o444)  # r--r--r--
-        ConfigXml(filename=str(p),
-                  env_config="default",
-                  read_only=True).close()
+        ConfigXml(filename=str(p), env_config="default", read_only=True).close()
 
     def testReadOnlyConfigFailsOnEnv1(self):
         p = create_path()
         p.chmod(0o444)  # r--r--r--
-        pytest.raises(Exception, ConfigXml, filename=str(p),
-                      env_config="default")
+        pytest.raises(
+            Exception, ConfigXml, filename=str(p), env_config="default"
+        )
 
     def testReadOnlyConfigFailsOnEnv2(self):
         old = os.environ.get("OMERO_CONFIG")
@@ -339,8 +358,9 @@ class TestConfig(object):
             else:
                 os.environ["OMERO_CONFIG"] = old
 
-    @pytest.mark.skipif(sys.platform.startswith("win"),
-                        reason="chmod requires posix")
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="chmod requires posix"
+    )
     def testCannotCreate(self):
         d = create_path(folder=True)
         d.chmod(0o555)
@@ -360,8 +380,9 @@ class TestConfig(object):
             ConfigXml(filename).close()
         assert excinfo.value.errno == errno.EACCES
 
-    @pytest.mark.skipif(sys.platform.startswith("win"),
-                        reason="chmod requires posix")
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="chmod requires posix"
+    )
     def testCannotRead(self):
         p = create_path()
         p.chmod(0)

--- a/test/unit/test_conversions.py
+++ b/test/unit/test_conversions.py
@@ -35,7 +35,6 @@ from omero.conversions import Sym
 
 
 class TestConversions(object):
-
     def assertEquals(self, a, b, places=6):
         assertAlmostEqual(a, b, places=places)
 

--- a/test/unit/test_gateway.py
+++ b/test/unit/test_gateway.py
@@ -29,19 +29,39 @@ import Ice
 import pytest
 import sys
 
-from omero.gateway import BlitzGateway, ImageWrapper, \
-    WellWrapper, LogicalChannelWrapper, OriginalFileWrapper
-from omero.model import ImageI, PixelsI, ExperimenterI, EventI, \
-    ProjectI, TagAnnotationI, FileAnnotationI, OriginalFileI, \
-    MapAnnotationI, NamedValue, PlateI, WellI, \
-    LogicalChannelI, LengthI, IlluminationI, BinningI, \
-    DetectorSettingsI, DichroicI, LightPathI
+from omero.gateway import (
+    BlitzGateway,
+    ImageWrapper,
+    WellWrapper,
+    LogicalChannelWrapper,
+    OriginalFileWrapper,
+)
+from omero.model import (
+    ImageI,
+    PixelsI,
+    ExperimenterI,
+    EventI,
+    ProjectI,
+    TagAnnotationI,
+    FileAnnotationI,
+    OriginalFileI,
+    MapAnnotationI,
+    NamedValue,
+    PlateI,
+    WellI,
+    LogicalChannelI,
+    LengthI,
+    IlluminationI,
+    BinningI,
+    DetectorSettingsI,
+    DichroicI,
+    LightPathI,
+)
 from omero.model.enums import UnitsLength
 from omero.rtypes import rstring, rtime, rlong, rint, rdouble
 
 
 class MockQueryService(object):
-
     def __init__(self, obj_to_be_returned):
         self.obj = obj_to_be_returned
 
@@ -50,7 +70,6 @@ class MockQueryService(object):
 
 
 class MockConnection(BlitzGateway):
-
     def __init__(self, obj_to_be_returned):
         self.obj = obj_to_be_returned
         self.SERVICE_OPTS = dict()
@@ -62,15 +81,15 @@ class MockConnection(BlitzGateway):
         return (64, 64)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def wrapped_image():
     experimenter = ExperimenterI()
-    experimenter.firstName = rstring('first_name')
-    experimenter.lastName = rstring('last_name')
+    experimenter.firstName = rstring("first_name")
+    experimenter.lastName = rstring("last_name")
     image = ImageI()
     image.id = rlong(1)
-    image.description = rstring('description')
-    image.name = rstring('name')
+    image.description = rstring("description")
+    image.name = rstring("name")
     image.acquisitionDate = rtime(1000)  # In milliseconds
     image.details.owner = ExperimenterI(1, False)
     creation_event = EventI()
@@ -88,7 +107,7 @@ class TestObjectsUnicode(object):
         if sys.version_info >= (3, 0, 0):
             return s
         else:
-            return s.encode('utf8')
+            return s.encode("utf8")
 
     def test_experimenter(self):
         """
@@ -96,8 +115,8 @@ class TestObjectsUnicode(object):
 
         These will return unicode strings
         """
-        first_name = u'fîrst_nąmę'
-        last_name = u'làst_NÅMÉ'
+        first_name = "fîrst_nąmę"
+        last_name = "làst_NÅMÉ"
         experimenter = ExperimenterI()
         experimenter.firstName = rstring(first_name)
         experimenter.lastName = rstring(last_name)
@@ -109,8 +128,8 @@ class TestObjectsUnicode(object):
 
     def test_project(self):
         """Tests BlitzObjectWrapper.getName() returns string"""
-        name = u'Pròjëct ©ψ'
-        desc = u"Desc Φωλ"
+        name = "Pròjëct ©ψ"
+        desc = "Desc Φωλ"
         project = ProjectI()
         project.name = rstring(name)
         project.description = rstring(desc)
@@ -124,8 +143,8 @@ class TestObjectsUnicode(object):
 
     def test_tag_annotation(self):
         """Tests AnnotationWrapper methods return strings"""
-        ns = u'πλζ.test.ζ'
-        text_value = u'Tαg - ℗'
+        ns = "πλζ.test.ζ"
+        text_value = "Tαg - ℗"
         obj = TagAnnotationI()
         obj.textValue = rstring(text_value)
         obj.ns = rstring(ns)
@@ -138,7 +157,7 @@ class TestObjectsUnicode(object):
 
     def test_file_annotation(self):
         """Tests AnnotationWrapper methods return strings"""
-        file_name = u'₩€_file_$$'
+        file_name = "₩€_file_$$"
         f = OriginalFileI()
         f.name = rstring(file_name)
         obj = FileAnnotationI()
@@ -149,7 +168,7 @@ class TestObjectsUnicode(object):
 
     def test_map_annotation(self):
         """Tests MapAnnotationWrapper.getValue() returns unicode"""
-        values = [(u'one', u'₹₹'), (u'two', u'¥¥')]
+        values = [("one", "₹₹"), ("two", "¥¥")]
         obj = MapAnnotationI()
         data = [NamedValue(d[0], d[1]) for d in values]
         obj.setMapValue(data)
@@ -159,7 +178,7 @@ class TestObjectsUnicode(object):
 
     def test_plate(self):
         """Tests label methods for Plate and Well."""
-        name = u'plate_∞'
+        name = "plate_∞"
         cols = 4
         rows = 3
         obj = PlateI()
@@ -167,9 +186,9 @@ class TestObjectsUnicode(object):
 
         plate = MockConnection(obj).getObject("Plate", 1)
         assert plate.getName() == self._encode(name)
-        plate._gridSize = {'rows': rows, 'columns': cols}
+        plate._gridSize = {"rows": rows, "columns": cols}
         assert plate.getColumnLabels() == [c for c in range(1, cols + 1)]
-        assert plate.getRowLabels() == ['A', 'B', 'C']
+        assert plate.getRowLabels() == ["A", "B", "C"]
 
         well_obj = WellI()
         well_obj.column = rint(1)
@@ -192,13 +211,13 @@ class TestBlitzObjectGetAttr(object):
         if sys.version_info >= (3, 0, 0):
             return s
         else:
-            return s.encode('utf8')
+            return s.encode("utf8")
 
     def test_logical_channel(self):
-        name = u'₩€_name_$$'
-        ill_val = u'πλζ.test.ζ'
-        fluor = u'GFP-₹₹'
-        binning_value = u'Φωλ'
+        name = "₩€_name_$$"
+        ill_val = "πλζ.test.ζ"
+        fluor = "GFP-₹₹"
+        binning_value = "Φωλ"
         ph_size = 1.11
         ph_units = UnitsLength.MICROMETER
         ex_wave = 3.34
@@ -206,7 +225,7 @@ class TestBlitzObjectGetAttr(object):
         version = 123
         zoom = 100
         gain = 1010.23
-        di_model = u'Model_ 123_àÅÉ'
+        di_model = "Model_ 123_àÅÉ"
 
         obj = LogicalChannelI()
         obj.name = rstring(name)
@@ -242,12 +261,12 @@ class TestBlitzObjectGetAttr(object):
         assert channel.name == name
         assert channel.getPinHoleSize().getValue() == ph_size
         assert channel.getPinHoleSize().getUnit() == ph_units
-        assert channel.getPinHoleSize().getSymbol() == 'µm'
+        assert channel.getPinHoleSize().getSymbol() == "µm"
         # Illumination is an enumeration
         assert channel.getIllumination().getValue() == self._encode(ill_val)
         assert channel.getExcitationWave().getValue() == ex_wave
         assert channel.getExcitationWave().getUnit() == ex_units
-        assert channel.getExcitationWave().getSymbol() == 'Å'
+        assert channel.getExcitationWave().getSymbol() == "Å"
         assert channel.getFluor() == fluor
         assert channel.fluor == fluor
 
@@ -263,7 +282,6 @@ class TestBlitzObjectGetAttr(object):
 
 
 class TestFileObject(object):
-
     def test_original_file_wrapper(self):
 
         file_text = """String to return in chunks from
@@ -297,7 +315,6 @@ class TestFileObject(object):
                 pass
 
         class MockOriginalFile(OriginalFileWrapper):
-
             def asFileObj(self, buf=2621440):
                 return MockFile(file_text)
 
@@ -318,16 +335,17 @@ class TestBlitzGatewayUnicode(object):
     def test_unicode_username(self):
         with pytest.raises(Ice.ConnectionRefusedException):
             gateway = BlitzGateway(
-                username=u'ążźćółę', passwd='secret',
-                host='localhost', port=65535
+                username="ążźćółę",
+                passwd="secret",
+                host="localhost",
+                port=65535,
             )
             gateway.connect()
 
     def test_unicode_password(self):
         with pytest.raises(Ice.ConnectionRefusedException):
             gateway = BlitzGateway(
-                username='user', passwd=u'ążźćółę',
-                host='localhost', port=65535
+                username="user", passwd="ążźćółę", host="localhost", port=65535
             )
             gateway.connect()
 
@@ -336,12 +354,12 @@ class TestBlitzGatewayImageWrapper(object):
     """Tests for various methods associated with the `ImageWrapper`."""
 
     def assert_data(self, data):
-        assert data['description'] == 'description'
-        assert data['author'] == 'first_name last_name'
-        assert data['date'] == 1.0  # In seconds
-        assert data['type'] == 'Image'
-        assert data['id'] == 1
-        assert data['name'] == 'name'
+        assert data["description"] == "description"
+        assert data["author"] == "first_name last_name"
+        assert data["date"] == 1.0  # In seconds
+        assert data["type"] == "Image"
+        assert data["id"] == 1
+        assert data["name"] == "name"
 
     def test_simple_marshal(self, wrapped_image):
         self.assert_data(wrapped_image.simpleMarshal())
@@ -352,11 +370,11 @@ class TestBlitzGatewayImageWrapper(object):
         pixels.sizeX = rint(65)
         pixels.sizeY = rint(65)
         image.addPixels(pixels)
-        data = wrapped_image.simpleMarshal(xtra={'tiled': True})
+        data = wrapped_image.simpleMarshal(xtra={"tiled": True})
         self.assert_data(data)
-        assert data['tiled'] is True
+        assert data["tiled"] is True
 
     def test_simple_marshal_not_tiled(self, wrapped_image):
-        data = wrapped_image.simpleMarshal(xtra={'tiled': True})
+        data = wrapped_image.simpleMarshal(xtra={"tiled": True})
         self.assert_data(data)
-        assert data['tiled'] is False
+        assert data["tiled"] is False

--- a/test/unit/test_metadata_mapannotations.py
+++ b/test/unit/test_metadata_mapannotations.py
@@ -32,8 +32,10 @@ import pytest
 from omero.model import MapAnnotationI, NamedValue
 from omero.rtypes import rstring
 from omero.util.metadata_mapannotations import (
-    CanonicalMapAnnotation, MapAnnotationPrimaryKeyException,
-    MapAnnotationManager)
+    CanonicalMapAnnotation,
+    MapAnnotationPrimaryKeyException,
+    MapAnnotationManager,
+)
 
 
 def assert_equal_name_value(a, b):
@@ -47,7 +49,7 @@ class TestCanonicalMapAnnotation(object):
 
     # test_init_* methods test process_keypairs
 
-    @pytest.mark.parametrize('ns', [None, '', 'NS'])
+    @pytest.mark.parametrize("ns", [None, "", "NS"])
     def test_init_defaults_empty(self, ns):
         ma = MapAnnotationI(1)
         if ns is not None:
@@ -55,48 +57,48 @@ class TestCanonicalMapAnnotation(object):
 
         cma = CanonicalMapAnnotation(ma)
         assert cma.ma is ma
-        expectedns = ns if ns else ''
+        expectedns = ns if ns else ""
         assert cma.ns == expectedns
         assert cma.kvpairs == []
         assert cma.primary is None
         assert cma.parents == set()
 
-    @pytest.mark.parametrize('ns', [None, '', 'NS'])
+    @pytest.mark.parametrize("ns", [None, "", "NS"])
     def test_init_defaults_kvpairs(self, ns):
         ma = MapAnnotationI(1)
-        ma.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        ma.setMapValue([NamedValue("b", "2"), NamedValue("a", "1")])
         if ns is not None:
             ma.setNs(rstring(ns))
 
         cma = CanonicalMapAnnotation(ma)
         assert cma.ma is ma
-        expectedns = ns if ns else ''
+        expectedns = ns if ns else ""
         assert cma.ns == expectedns
-        assert cma.kvpairs == [('b', '2'), ('a', '1')]
+        assert cma.kvpairs == [("b", "2"), ("a", "1")]
         assert cma.primary is None
         assert cma.parents == set()
 
     def test_init_defaults_duplicates(self):
         ma = MapAnnotationI(1)
-        ma.setMapValue([NamedValue('a', '1'), NamedValue('a', '1')])
+        ma.setMapValue([NamedValue("a", "1"), NamedValue("a", "1")])
 
         with pytest.raises(ValueError) as excinfo:
             CanonicalMapAnnotation(ma)
-        assert str(excinfo.value).startswith('Duplicate ')
+        assert str(excinfo.value).startswith("Duplicate ")
 
-    @pytest.mark.parametrize('ns', [None, '', 'NS'])
-    @pytest.mark.parametrize('primary_keys', [[], ['a'], ['a', 'b']])
+    @pytest.mark.parametrize("ns", [None, "", "NS"])
+    @pytest.mark.parametrize("primary_keys", [[], ["a"], ["a", "b"]])
     def test_init_primary_keys(self, ns, primary_keys):
         ma = MapAnnotationI(1)
         ma.setNs(rstring(ns))
-        ma.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        ma.setMapValue([NamedValue("b", "2"), NamedValue("a", "1")])
 
         cma = CanonicalMapAnnotation(ma, primary_keys=primary_keys)
         assert cma.ma is ma
-        expectedns = ns if ns else ''
+        expectedns = ns if ns else ""
         assert cma.ns == expectedns
-        assert cma.kvpairs == [('b', '2'), ('a', '1')]
-        expectedpks = [('a', '1'), ('b', '2')][:len(primary_keys)]
+        assert cma.kvpairs == [("b", "2"), ("a", "1")]
+        expectedpks = [("a", "1"), ("b", "2")][: len(primary_keys)]
         if primary_keys:
             expectedpri = (expectedns, frozenset(expectedpks))
         else:
@@ -106,86 +108,91 @@ class TestCanonicalMapAnnotation(object):
 
     def test_init_missing_primary_key(self):
         ma = MapAnnotationI(1)
-        ma.setMapValue([NamedValue('b', '2')])
+        ma.setMapValue([NamedValue("b", "2")])
 
         with pytest.raises(MapAnnotationPrimaryKeyException) as excinfo:
-            CanonicalMapAnnotation(ma, primary_keys=['a', 'b'])
-        assert str(excinfo.value).startswith('Missing ')
+            CanonicalMapAnnotation(ma, primary_keys=["a", "b"])
+        assert str(excinfo.value).startswith("Missing ")
 
-    @pytest.mark.parametrize('reverse', [True, False])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_merge(self, reverse):
         ma1 = MapAnnotationI(1)
-        ma1.setMapValue([NamedValue('a', '1')])
-        cma1 = CanonicalMapAnnotation(ma1, primary_keys=['a'])
-        cma1.add_parent('Parent', 1)
+        ma1.setMapValue([NamedValue("a", "1")])
+        cma1 = CanonicalMapAnnotation(ma1, primary_keys=["a"])
+        cma1.add_parent("Parent", 1)
         ma2 = MapAnnotationI(2)
-        ma2.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
-        cma2 = CanonicalMapAnnotation(ma2, primary_keys=['b'])
-        cma2.add_parent('Parent', 1)
-        cma2.add_parent('Parent', 2)
+        ma2.setMapValue([NamedValue("b", "2"), NamedValue("a", "1")])
+        cma2 = CanonicalMapAnnotation(ma2, primary_keys=["b"])
+        cma2.add_parent("Parent", 1)
+        cma2.add_parent("Parent", 2)
 
         if reverse:
             cma2.merge(cma1)
-            assert cma2.kvpairs == [('b', '2'), ('a', '1')]
-            assert cma2.parents == set([('Parent', 1), ('Parent', 2)])
-            assert cma2.primary == ('', frozenset([('b', '2')]))
+            assert cma2.kvpairs == [("b", "2"), ("a", "1")]
+            assert cma2.parents == set([("Parent", 1), ("Parent", 2)])
+            assert cma2.primary == ("", frozenset([("b", "2")]))
         else:
             cma1.merge(cma2)
-            assert cma1.kvpairs == [('a', '1'), ('b', '2')]
-            assert cma1.parents == set([('Parent', 1), ('Parent', 2)])
-            assert cma1.primary == ('', frozenset([('a', '1')]))
+            assert cma1.kvpairs == [("a", "1"), ("b", "2")]
+            assert cma1.parents == set([("Parent", 1), ("Parent", 2)])
+            assert cma1.primary == ("", frozenset([("a", "1")]))
 
     def test_add_parent(self):
         ma = MapAnnotationI(1)
         cma = CanonicalMapAnnotation(ma)
         assert cma.parents == set()
-        cma.add_parent('A', 1)
-        assert cma.parents == set([('A', 1)])
-        cma.add_parent('B', 2)
-        assert cma.parents == set([('A', 1), ('B', 2)])
+        cma.add_parent("A", 1)
+        assert cma.parents == set([("A", 1)])
+        cma.add_parent("B", 2)
+        assert cma.parents == set([("A", 1), ("B", 2)])
 
         with pytest.raises(ValueError) as excinfo:
-            cma.add_parent('C', '3')
-        assert str(excinfo.value).startswith('Expected parent')
+            cma.add_parent("C", "3")
+        assert str(excinfo.value).startswith("Expected parent")
 
     def test_get_mapann(self):
         ma = MapAnnotationI(1)
-        ma.setMapValue([NamedValue('a', '1')])
-        cma = CanonicalMapAnnotation(ma, primary_keys=['a'])
-        cma.add_parent('Parent', 1)
-        cma.kvpairs.append(('b', '2'))
+        ma.setMapValue([NamedValue("a", "1")])
+        cma = CanonicalMapAnnotation(ma, primary_keys=["a"])
+        cma.add_parent("Parent", 1)
+        cma.kvpairs.append(("b", "2"))
         newma = cma.get_mapann()
 
         assert newma is ma
         mv = newma.getMapValue()
         assert len(mv) == 2
-        assert_equal_name_value(mv[0], NamedValue('a', '1'))
-        assert_equal_name_value(mv[1], NamedValue('b', '2'))
+        assert_equal_name_value(mv[0], NamedValue("a", "1"))
+        assert_equal_name_value(mv[1], NamedValue("b", "2"))
 
 
 class TestMapAnnotationManager(object):
-
     def create_cmas(self, pk2):
         ma1 = MapAnnotationI(1)
-        ma1.setMapValue([NamedValue('a', '1')])
-        cma1 = CanonicalMapAnnotation(ma1, primary_keys=['a'])
-        cma1.add_parent('Parent', 1)
+        ma1.setMapValue([NamedValue("a", "1")])
+        cma1 = CanonicalMapAnnotation(ma1, primary_keys=["a"])
+        cma1.add_parent("Parent", 1)
 
         ma2 = MapAnnotationI(2)
-        ma2.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        ma2.setMapValue([NamedValue("b", "2"), NamedValue("a", "1")])
         cma2 = CanonicalMapAnnotation(ma2, primary_keys=[pk2])
-        cma2.add_parent('Parent', 1)
-        cma2.add_parent('Parent', 2)
+        cma2.add_parent("Parent", 1)
+        cma2.add_parent("Parent", 2)
 
         return cma1, cma2
 
-    @pytest.mark.parametrize('combine', [
-        None, MapAnnotationManager.MA_APPEND, MapAnnotationManager.MA_OLD,
-        MapAnnotationManager.MA_NEW])
+    @pytest.mark.parametrize(
+        "combine",
+        [
+            None,
+            MapAnnotationManager.MA_APPEND,
+            MapAnnotationManager.MA_OLD,
+            MapAnnotationManager.MA_NEW,
+        ],
+    )
     def test_add_samepk(self, combine):
-        cma1, cma2 = self.create_cmas('a')
-        pk1 = ('', frozenset([('a', '1')]))
-        parents12 = set([('Parent', 1), ('Parent', 2)])
+        cma1, cma2 = self.create_cmas("a")
+        pk1 = ("", frozenset([("a", "1")]))
+        parents12 = set([("Parent", 1), ("Parent", 2)])
 
         if combine:
             mgr = MapAnnotationManager(combine)
@@ -209,27 +216,32 @@ class TestMapAnnotationManager(object):
         r = mgr.add(cma2)
         if combine == MapAnnotationManager.MA_OLD:
             assert mgr.mapanns == {pk1: cma1}
-            assert cma1.kvpairs == [('a', '1')]
+            assert cma1.kvpairs == [("a", "1")]
             assert cma1.parents == parents12
             assert r is cma2
         elif combine == MapAnnotationManager.MA_NEW:
             assert mgr.mapanns == {pk1: cma2}
-            assert cma2.kvpairs == [('b', '2'), ('a', '1')]
+            assert cma2.kvpairs == [("b", "2"), ("a", "1")]
             assert cma2.parents == parents12
             assert r is cma1
         else:  # None or MA_APPEND
             assert mgr.mapanns == {pk1: cma1}
-            assert cma1.kvpairs == [('a', '1'), ('b', '2')]
+            assert cma1.kvpairs == [("a", "1"), ("b", "2")]
             assert cma1.parents == parents12
             assert r is cma2
 
-    @pytest.mark.parametrize('combine', [
-        MapAnnotationManager.MA_APPEND, MapAnnotationManager.MA_OLD,
-        MapAnnotationManager.MA_NEW])
+    @pytest.mark.parametrize(
+        "combine",
+        [
+            MapAnnotationManager.MA_APPEND,
+            MapAnnotationManager.MA_OLD,
+            MapAnnotationManager.MA_NEW,
+        ],
+    )
     def test_add_diffpk(self, combine):
-        cma1, cma2 = self.create_cmas('b')
-        pk1 = ('', frozenset([('a', '1')]))
-        pk2 = ('', frozenset([('b', '2')]))
+        cma1, cma2 = self.create_cmas("b")
+        pk1 = ("", frozenset([("a", "1")]))
+        pk2 = ("", frozenset([("b", "2")]))
 
         mgr = MapAnnotationManager(combine)
         r = mgr.add(cma1)
@@ -237,8 +249,8 @@ class TestMapAnnotationManager(object):
 
         r = mgr.add(cma2)
         assert mgr.mapanns == {pk1: cma1, pk2: cma2}
-        assert cma1.kvpairs == [('a', '1')]
-        assert cma1.parents == set([('Parent', 1)])
-        assert cma2.kvpairs == [('b', '2'), ('a', '1')]
-        assert cma2.parents == set([('Parent', 1), ('Parent', 2)])
+        assert cma1.kvpairs == [("a", "1")]
+        assert cma1.parents == set([("Parent", 1)])
+        assert cma2.kvpairs == [("b", "2"), ("a", "1")]
+        assert cma2.parents == set([("Parent", 1), ("Parent", 2)])
         assert r is None

--- a/test/unit/test_metadata_utils.py
+++ b/test/unit/test_metadata_utils.py
@@ -30,11 +30,16 @@ from builtins import object
 import pytest
 
 from omero.util.metadata_utils import (
-    BulkAnnotationConfiguration, GroupConfig, KeyValueListPassThrough,
-    KeyValueGroupList, KeyValueListTransformer)
+    BulkAnnotationConfiguration,
+    GroupConfig,
+    KeyValueListPassThrough,
+    KeyValueGroupList,
+    KeyValueListTransformer,
+)
 
 try:
     import jinja2  # noqa
+
     JINJA2_MISSING = None
 except ImportError as j2exc:
     JINJA2_MISSING = j2exc
@@ -71,40 +76,51 @@ class TestBulkAnnotationConfiguration(object):
 
     def test_init_def(self):
         c = BulkAnnotationConfiguration(
-            {"visible": False, "omitempty": True}, [])
+            {"visible": False, "omitempty": True}, []
+        )
         assert c.default_cfg == expected(visible=False, omitempty=True)
         assert c.column_cfgs == []
 
     def test_init_col(self):
-        c = BulkAnnotationConfiguration(None, [
-            {"name": "a1", "visible": False, "position": 2},
-            {"name": "b2", "position": 4}])
+        c = BulkAnnotationConfiguration(
+            None,
+            [
+                {"name": "a1", "visible": False, "position": 2},
+                {"name": "b2", "position": 4},
+            ],
+        )
         assert c.default_cfg == expected()
         assert len(c.column_cfgs) == 2
         assert c.column_cfgs[0] == expected(
-            name="a1", visible=False, position=2)
-        assert c.column_cfgs[1] == expected(
-            name="b2", position=4)
+            name="a1", visible=False, position=2
+        )
+        assert c.column_cfgs[1] == expected(name="b2", position=4)
 
     def test_init_def_col(self):
-        c = BulkAnnotationConfiguration({"omitempty": True}, [
-            {"name": "a1"}, {"name": "b2", "omitempty": False}])
+        c = BulkAnnotationConfiguration(
+            {"omitempty": True},
+            [{"name": "a1"}, {"name": "b2", "omitempty": False}],
+        )
         assert c.default_cfg == expected(omitempty=True)
         assert len(c.column_cfgs) == 2
         assert c.column_cfgs[0] == expected(name="a1", omitempty=True)
         assert c.column_cfgs[1] == expected(name="b2")
 
     def test_init_group(self):
-        c = BulkAnnotationConfiguration({"omitempty": True}, [
-            {"name": "a1"},
-            {"group": {"namespace": "group2", "columns": [{"name": "b2"}]}}
-        ])
+        c = BulkAnnotationConfiguration(
+            {"omitempty": True},
+            [
+                {"name": "a1"},
+                {"group": {"namespace": "group2", "columns": [{"name": "b2"}]}},
+            ],
+        )
         assert c.default_cfg == expected(omitempty=True)
         assert len(c.column_cfgs) == 1
         assert c.column_cfgs[0] == expected(name="a1", omitempty=True)
         assert len(c.group_cfgs) == 1
         assert c.group_cfgs[0] == GroupConfig(
-            "group2", [expected(name="b2", omitempty=True)])
+            "group2", [expected(name="b2", omitempty=True)]
+        )
 
     def test_validate_column_config(self):
         with pytest.raises(Exception):
@@ -114,54 +130,65 @@ class TestBulkAnnotationConfiguration(object):
             BulkAnnotationConfiguration.validate_column_config({"name": ""})
 
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_column_config({
-                "non-existent": 1})
+            BulkAnnotationConfiguration.validate_column_config(
+                {"non-existent": 1}
+            )
 
         with pytest.raises(Exception):
             BulkAnnotationConfiguration.validate_column_config({})
 
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_column_config({
-                "include": False})
+            BulkAnnotationConfiguration.validate_column_config(
+                {"include": False}
+            )
 
         # Shouldn't throw
         BulkAnnotationConfiguration.validate_column_config({"name": "a"})
-        BulkAnnotationConfiguration.validate_column_config({
-            "name": "a", "includeclient": False, "include": False})
+        BulkAnnotationConfiguration.validate_column_config(
+            {"name": "a", "includeclient": False, "include": False}
+        )
 
     def test_validate_filled_column_config(self):
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_filled_column_config({
-                "name": "a"})
+            BulkAnnotationConfiguration.validate_filled_column_config(
+                {"name": "a"}
+            )
 
         # Shouldn't throw
         BulkAnnotationConfiguration.validate_column_config(expected(name="a"))
 
     def test_validate_group_config(self):
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_group_config({
-                "namespace": "ga"})
+            BulkAnnotationConfiguration.validate_group_config(
+                {"namespace": "ga"}
+            )
 
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_group_config({
-                "columns": [{"name": "a"}]})
+            BulkAnnotationConfiguration.validate_group_config(
+                {"columns": [{"name": "a"}]}
+            )
 
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_group_config({
-                "namespace": "", "columns": [{"name": "a"}]})
+            BulkAnnotationConfiguration.validate_group_config(
+                {"namespace": "", "columns": [{"name": "a"}]}
+            )
 
         with pytest.raises(Exception):
-            BulkAnnotationConfiguration.validate_group_config({
-                "namespace": "ga", "columns": [{"name": "a"}],
-                "nonexistent": "na"})
+            BulkAnnotationConfiguration.validate_group_config(
+                {
+                    "namespace": "ga",
+                    "columns": [{"name": "a"}],
+                    "nonexistent": "na",
+                }
+            )
 
         # Shouldn't throw
-        BulkAnnotationConfiguration.validate_group_config({
-            "namespace": "ga", "columns": [{"name": "a"}]})
+        BulkAnnotationConfiguration.validate_group_config(
+            {"namespace": "ga", "columns": [{"name": "a"}]}
+        )
 
 
 class TestKeyValueListPassThrough(object):
-
     def test_transform(self):
         headers = ["a1", "b2"]
         tr = KeyValueListPassThrough(headers)
@@ -175,9 +202,10 @@ class TestKeyValueGroupList(object):
     def test_init_col(self):
         headers = ["a1"]
         kvgl = KeyValueGroupList(
-            headers, None, [{"name": "a1", "visible": False}])
+            headers, None, [{"name": "a1", "visible": False}]
+        )
         assert kvgl.default_cfg == expected()
-        assert kvgl.headerindexmap == {'a1': 0}
+        assert kvgl.headerindexmap == {"a1": 0}
 
         assert len(kvgl.output_configs) == 1
         assert kvgl.output_configs[0].namespace == ""
@@ -203,9 +231,11 @@ class TestKeyValueGroupList(object):
 
     def test_init_col_ordered_unordered(self):
         headers = ["a2", "a1"]
-        kvgl = KeyValueGroupList(headers, None, [
-            {"name": "a2", "visible": False},
-            {"name": "a1", "position": 1}])
+        kvgl = KeyValueGroupList(
+            headers,
+            None,
+            [{"name": "a2", "visible": False}, {"name": "a1", "position": 1}],
+        )
         assert kvgl.default_cfg == expected()
 
         assert len(kvgl.output_configs) == 1
@@ -217,17 +247,21 @@ class TestKeyValueGroupList(object):
 
     def test_init_col_unincluded(self):
         headers = ["a2", "a1"]
-        kvgl = KeyValueGroupList(headers, {
-            "include": False, "includeclient": False},
-            [{"name": "a2", "include": True}])
+        kvgl = KeyValueGroupList(
+            headers,
+            {"include": False, "includeclient": False},
+            [{"name": "a2", "include": True}],
+        )
         assert kvgl.default_cfg == expected(include=False, includeclient=False)
 
         assert len(kvgl.output_configs) == 1
         assert kvgl.output_configs[0].namespace == ""
         configs = kvgl.output_configs[0].columns
         assert len(configs) == 1
-        assert configs[0] == (expected(
-            name="a2", include=True, includeclient=False), 0)
+        assert configs[0] == (
+            expected(name="a2", include=True, includeclient=False),
+            0,
+        )
 
     def test_init_col_complicated_order(self):
         headers, column_cfgs = self.get_complicated_headers()
@@ -241,8 +275,10 @@ class TestKeyValueGroupList(object):
         assert configs[0] == (expected(name="a1", position=1, split="|"), 3)
         assert configs[1] == (expected(name="a2", visible=False), 1)
         assert configs[2] == (expected(name="a3"), 0)
-        assert configs[3] == (expected(
-            name="a4", position=4, clientvalue="*-{{ value }}-*"), 2)
+        assert configs[3] == (
+            expected(name="a4", position=4, clientvalue="*-{{ value }}-*"),
+            2,
+        )
         assert configs[4] == (expected(name="a5"), 5)
         assert configs[5] == (expected(name="a6"), 6)
 
@@ -254,7 +290,7 @@ class TestKeyValueGroupList(object):
         ]
         kvgl = KeyValueGroupList(headers, None, desc)
         assert kvgl.default_cfg == expected()
-        assert kvgl.headerindexmap == {'a1': 0, 'a2': 1}
+        assert kvgl.headerindexmap == {"a1": 0, "a2": 1}
 
         assert len(kvgl.output_configs) == 2
 
@@ -271,14 +307,22 @@ class TestKeyValueGroupList(object):
             {"name": "a1"},
             {"group": {"namespace": "g2", "columns": [{"name": "a2"}]}},
             {"name": "a3"},
-            {"group": {
-                "namespace": "g4", "columns": [{"name": "a4"}, {"name": "a5"}]
-            }},
+            {
+                "group": {
+                    "namespace": "g4",
+                    "columns": [{"name": "a4"}, {"name": "a5"}],
+                }
+            },
         ]
         kvgl = KeyValueGroupList(headers, None, desc)
         assert kvgl.default_cfg == expected()
         assert kvgl.headerindexmap == {
-            'a1': 0, 'a2': 1, 'a3': 2, 'a4': 3, 'a5': 4}
+            "a1": 0,
+            "a2": 1,
+            "a3": 2,
+            "a4": 3,
+            "a5": 4,
+        }
 
         assert len(kvgl.output_configs) == 3
 
@@ -287,38 +331,55 @@ class TestKeyValueGroupList(object):
 
         assert kvgl.output_configs[1].namespace == "g4"
         assert kvgl.output_configs[1].columns == [
-            (expected(name="a4"), 3), (expected(name="a5"), 4)]
+            (expected(name="a4"), 3),
+            (expected(name="a5"), 4),
+        ]
 
         # Default group always comes last
         assert kvgl.output_configs[2].namespace == ""
         assert kvgl.output_configs[2].columns == [
-            (expected(name="a1"), 0), (expected(name="a3"), 2)]
+            (expected(name="a1"), 0),
+            (expected(name="a3"), 2),
+        ]
 
 
 @pytest.mark.skipif(JINJA2_MISSING, reason="Requires Jinja2")
 class TestKeyValueListTransformer(object):
-
     def test_transform1_default(self):
         cfg = expected(name="a1")
         assert KeyValueListTransformer.transform1("ab, c", cfg) == (
-            "a1", ["ab, c"])
+            "a1",
+            ["ab, c"],
+        )
 
     def test_transform1_clientname(self):
         cfg = expected(name="a1", clientname="a / 1")
         assert KeyValueListTransformer.transform1("ab, c", cfg) == (
-            "a / 1", ["ab, c"])
+            "a / 1",
+            ["ab, c"],
+        )
 
-    @pytest.mark.parametrize('inout', [
-        ("ab, c", {}, ("a1", ["ab, c"])),
-        ("ab, c", {"clientname": "a / 1"}, ("a / 1", ["ab, c"])),
-        ("ab, c", {"visible": False}, ("__a1", ["ab, c"])),
-        ("ab, c", {"split": ","}, ("a1", ["ab", "c"])),
-        (" ", {"omitempty": True}, ("a1", [])),
-        (" , ", {"split": ",", "omitempty": True}, ("a1", [])),
-        ("ab, c", {"clientvalue": "*-{{ value }}-*"}, ("a1", ["*-ab, c-*"])),
-        (" ", {"clientvalue": "*-{{ value }}-*", "omitempty": True},
-            ("a1", [])),
-    ])
+    @pytest.mark.parametrize(
+        "inout",
+        [
+            ("ab, c", {}, ("a1", ["ab, c"])),
+            ("ab, c", {"clientname": "a / 1"}, ("a / 1", ["ab, c"])),
+            ("ab, c", {"visible": False}, ("__a1", ["ab, c"])),
+            ("ab, c", {"split": ","}, ("a1", ["ab", "c"])),
+            (" ", {"omitempty": True}, ("a1", [])),
+            (" , ", {"split": ",", "omitempty": True}, ("a1", [])),
+            (
+                "ab, c",
+                {"clientvalue": "*-{{ value }}-*"},
+                ("a1", ["*-ab, c-*"]),
+            ),
+            (
+                " ",
+                {"clientvalue": "*-{{ value }}-*", "omitempty": True},
+                ("a1", []),
+            ),
+        ],
+    )
     def test_transform1(self, inout):
         cfg = expected(name="a1", **inout[1])
         assert KeyValueListTransformer.transform1(inout[0], cfg) == inout[2]
@@ -327,7 +388,9 @@ class TestKeyValueListTransformer(object):
     def test_transformj2(self):
         cfg = expected(name="a1", clientvalue="http://{{ value | urlencode }}")
         assert KeyValueListTransformer.transform1("a b", cfg) == (
-            "a1", ["http://a%20b"])
+            "a1",
+            ["http://a%20b"],
+        )
 
     def test_transform(self):
         headers = ["a2", "a4", "a3", "a1"]

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -44,25 +44,27 @@ from omero.rtypes import rtime
 
 
 class TestProxyString(object):
-
-    @pytest.mark.parametrize("data", (
-        ("", None, None, None),
-        ("1", None, None, None),
-        ("Image", None, None, None),
-        ("ImageI", None, None, None),
-        ("Image:1", None, ImageI, 1),
-        ("ImageI:1", None, ImageI, 1),
-        ("ImageI:1", "ImageI", ImageI, 1),
-        ("Image:1", "ImageI", ImageI, 1),
-        ("1", "ImageI", ImageI, 1),
-        ("1", "Image", ImageI, 1),
-    ))
+    @pytest.mark.parametrize(
+        "data",
+        (
+            ("", None, None, None),
+            ("1", None, None, None),
+            ("Image", None, None, None),
+            ("ImageI", None, None, None),
+            ("Image:1", None, ImageI, 1),
+            ("ImageI:1", None, ImageI, 1),
+            ("ImageI:1", "ImageI", ImageI, 1),
+            ("Image:1", "ImageI", ImageI, 1),
+            ("1", "ImageI", ImageI, 1),
+            ("1", "Image", ImageI, 1),
+        ),
+    )
     def testAll(self, data):
         source = data[0]
         default = data[1]
         type = data[2]
         id = data[3]
-        err = (type is None and id is None)
+        err = type is None and id is None
         try:
             obj = omero.proxy_to_instance(source, default)
             assert isinstance(obj, type)
@@ -76,7 +78,6 @@ class TestProxyString(object):
 
 
 class TestModel(object):
-
     def testVirtual(self):
         img = ImageI()
         imgI = ImageI()
@@ -278,17 +279,20 @@ class TestModel(object):
 
         def assign_loaded():
             i.loaded = False
+
         pytest.raises(AttributeError, assign_loaded)
         pytest.raises(AttributeError, lambda: i.foo)
 
         def assign_foo():
             i.foo = 1
+
         pytest.raises(AttributeError, assign_foo)
         pytest.raises(AttributeError, lambda: i.annotationLinks)
         pytest.raises(AttributeError, lambda: i.getAnnotationLinks())
 
         def assign_links():
             i.annotationLinks = []
+
         pytest.raises(AttributeError, assign_links)
 
     def testGetAttrSetAttrDetails(self):
@@ -370,25 +374,25 @@ class TestModel(object):
         assert "µm" == sym
 
     CONV_DATA = (
-        (ElectricPotentialI, 1, 'VOLT', 100, 'CENTIVOLT'),
-        (FrequencyI, 1, 'HERTZ', 1000, 'MILLIHERTZ'),
-        (FrequencyI, 1, 'HERTZ', 1000, 'MILLIHERTZ'),
-        (LengthI, 10, 'METER', 393.701, 'INCH'),
-        (LengthI, 12, 'INCH', 1, 'FOOT'),
-        (LengthI, 3, 'FOOT', 1, 'YARD'),
-        (LengthI, 1, 'NANOMETER', 10, 'ANGSTROM'),
-        (PowerI, 1, 'WATT', 10, 'DECIWATT'),
-        (PowerI, 1, 'WATT', .1, 'DECAWATT'),
-        (PressureI, 1, 'BAR', 100, 'KILOPASCAL'),
-        (PressureI, 1, 'TORR', 133.32236842, 'PASCAL'),
-        (TemperatureI, 0, 'CELSIUS', 32, 'FAHRENHEIT'),
-        (TemperatureI, -40, 'CELSIUS', -40, 'FAHRENHEIT'),
-        (TemperatureI, 100, 'CELSIUS', 212, 'FAHRENHEIT'),
-        (TemperatureI, 10, 'KELVIN', 18, 'RANKINE'),
-        (TemperatureI, 200, 'RANKINE', 111.11111111, 'KELVIN'),
-        (TimeI, 1, 'DAY', 24, 'HOUR'),
-        (TimeI, 1, 'HOUR', 3600, 'SECOND'),
-        (TimeI, 1, 'SECOND', 10**6, 'MICROSECOND'),
+        (ElectricPotentialI, 1, "VOLT", 100, "CENTIVOLT"),
+        (FrequencyI, 1, "HERTZ", 1000, "MILLIHERTZ"),
+        (FrequencyI, 1, "HERTZ", 1000, "MILLIHERTZ"),
+        (LengthI, 10, "METER", 393.701, "INCH"),
+        (LengthI, 12, "INCH", 1, "FOOT"),
+        (LengthI, 3, "FOOT", 1, "YARD"),
+        (LengthI, 1, "NANOMETER", 10, "ANGSTROM"),
+        (PowerI, 1, "WATT", 10, "DECIWATT"),
+        (PowerI, 1, "WATT", 0.1, "DECAWATT"),
+        (PressureI, 1, "BAR", 100, "KILOPASCAL"),
+        (PressureI, 1, "TORR", 133.32236842, "PASCAL"),
+        (TemperatureI, 0, "CELSIUS", 32, "FAHRENHEIT"),
+        (TemperatureI, -40, "CELSIUS", -40, "FAHRENHEIT"),
+        (TemperatureI, 100, "CELSIUS", 212, "FAHRENHEIT"),
+        (TemperatureI, 10, "KELVIN", 18, "RANKINE"),
+        (TemperatureI, 200, "RANKINE", 111.11111111, "KELVIN"),
+        (TimeI, 1, "DAY", 24, "HOUR"),
+        (TimeI, 1, "HOUR", 3600, "SECOND"),
+        (TimeI, 1, "SECOND", 10 ** 6, "MICROSECOND"),
     )
 
     CONV_IDS = ["%s_%s_%s_%s" % tuple(x[1:]) for x in CONV_DATA]

--- a/test/unit/test_parameters.py
+++ b/test/unit/test_parameters.py
@@ -16,7 +16,6 @@ from omero_sys_ParametersI import ParametersI
 
 
 class TestParameters(object):
-
     def assertNull(self, arg):
         assert None == arg
 
@@ -161,7 +160,7 @@ class TestParameters(object):
         assert p1.map is not p2.map
 
     def testSameMap(self):
-        m = {'key': 0}
+        m = {"key": 0}
         p1 = ParametersI(parammap=m)
         p2 = ParametersI(parammap=m)
         assert p1.map is p2.map

--- a/test/unit/test_path.py
+++ b/test/unit/test_path.py
@@ -15,11 +15,10 @@ import omero_ext.path as path
 
 
 class TestPath(object):
-
     def test_parpath(self):
-        root = path.path('/')
-        a1, a2 = [old_div(root, _) for _ in ('a1', 'a2')]
-        b = old_div(a1, 'b')
+        root = path.path("/")
+        a1, a2 = [old_div(root, _) for _ in ("a1", "a2")]
+        b = old_div(a1, "b")
         for x, y in (root, a1), (root, a2), (a1, b):
             assert len(y.parpath(x)) == 1
             assert len(x.parpath(y)) == 0

--- a/test/unit/test_permissions.py
+++ b/test/unit/test_permissions.py
@@ -15,7 +15,6 @@ import omero.model
 
 
 class TestPermissions(object):
-
     def setup_method(self, method):
         self.p = omero.model.PermissionsI()
 
@@ -69,32 +68,32 @@ class TestPermissions(object):
 
     def testPermissionsSetters(self):
         # start with everythin false
-        p = omero.model.PermissionsI('------')
+        p = omero.model.PermissionsI("------")
 
         # read flags are easy, straight binary
         # user flags
         p.setUserRead(True)
         assert p.isUserRead()
-        assert 'r' == str(p)[0]
+        assert "r" == str(p)[0]
         p.setUserRead(False)
         assert not p.isUserRead()
-        assert '-' == str(p)[0]
+        assert "-" == str(p)[0]
 
         # group flags
         p.setGroupRead(True)
         assert p.isGroupRead()
-        assert 'r' == str(p)[2]
+        assert "r" == str(p)[2]
         p.setGroupRead(False)
         assert not p.isGroupRead()
-        assert '-' == str(p)[2]
+        assert "-" == str(p)[2]
 
         # world flags
         p.setWorldRead(True)
         assert p.isWorldRead()
-        assert 'r' == str(p)[4]
+        assert "r" == str(p)[4]
         p.setWorldRead(False)
         assert not p.isWorldRead()
-        assert '-' == str(p)[4]
+        assert "-" == str(p)[4]
 
         # write flags are trickier as the string
         # representation is ternary
@@ -102,55 +101,55 @@ class TestPermissions(object):
         p.setUserAnnotate(True)
         assert p.isUserAnnotate()
         assert not p.isUserWrite()
-        assert 'a' == str(p)[1]
+        assert "a" == str(p)[1]
         p.setUserWrite(True)
         assert p.isUserAnnotate()
         assert p.isUserWrite()
-        assert 'w' == str(p)[1]
+        assert "w" == str(p)[1]
         p.setUserWrite(False)
         assert p.isUserAnnotate()
         assert not p.isUserWrite()
-        assert 'a' == str(p)[1]
+        assert "a" == str(p)[1]
         p.setUserAnnotate(False)
         assert not p.isUserAnnotate()
         assert not p.isUserWrite()
-        assert '-' == str(p)[1]
+        assert "-" == str(p)[1]
 
         # group flags
         p.setGroupAnnotate(True)
         assert p.isGroupAnnotate()
         assert not p.isGroupWrite()
-        assert 'a' == str(p)[3]
+        assert "a" == str(p)[3]
         p.setGroupWrite(True)
         assert p.isGroupAnnotate()
         assert p.isGroupWrite()
-        assert 'w' == str(p)[3]
+        assert "w" == str(p)[3]
         p.setGroupWrite(False)
         assert p.isGroupAnnotate()
         assert not p.isGroupWrite()
-        assert 'a' == str(p)[3]
+        assert "a" == str(p)[3]
         p.setGroupAnnotate(False)
         assert not p.isGroupAnnotate()
         assert not p.isGroupWrite()
-        assert '-' == str(p)[3]
+        assert "-" == str(p)[3]
 
         # world flags
         p.setWorldAnnotate(True)
         assert p.isWorldAnnotate()
         assert not p.isWorldWrite()
-        assert 'a' == str(p)[5]
+        assert "a" == str(p)[5]
         p.setWorldWrite(True)
         assert p.isWorldAnnotate()
         assert p.isWorldWrite()
-        assert 'w' == str(p)[5]
+        assert "w" == str(p)[5]
         p.setWorldWrite(False)
         assert p.isWorldAnnotate()
         assert not p.isWorldWrite()
-        assert 'a' == str(p)[5]
+        assert "a" == str(p)[5]
         p.setWorldAnnotate(False)
         assert not p.isWorldAnnotate()
         assert not p.isWorldWrite()
-        assert '-' == str(p)[5]
+        assert "-" == str(p)[5]
 
     def test8564(self):
 
@@ -191,8 +190,16 @@ class TestPermissions(object):
 Permissions: %s Role: %s
 Expected READ: %s \t Found: %s
 Expected ANNO: %s \t Found: %s
-Expected EDIT: %s \t Found: %s""" % \
-            (p, role, read, isRead, annotate, isAnno, edit, isEdit)
+Expected EDIT: %s \t Found: %s""" % (
+            p,
+            role,
+            read,
+            isRead,
+            annotate,
+            isAnno,
+            edit,
+            isEdit,
+        )
 
         assert read == isRead, msg
         assert annotate == isAnno, msg

--- a/test/unit/test_python_only.py
+++ b/test/unit/test_python_only.py
@@ -26,12 +26,11 @@ class test_client(BaseClient):
 
 
 class TestPythonOnly(object):
-
     def testRepairArguments(self):
         t = test_client()
         ar = ["a", "b"]
         id = Ice.InitializationData()
-        pm = {'A': 1}
+        pm = {"A": 1}
         ho = "host"
         po = 4064
         no = None

--- a/test/unit/test_rois.py
+++ b/test/unit/test_rois.py
@@ -29,34 +29,23 @@ from omero.util.roi_handling_utils import points_string_to_xy_list
 
 
 class TestRoiUtils(object):
-
     def test_old_format(self):
-        xy_list = pointsStringToXYlist((
-            "points[1,2, 3,4, 5,6] "
-        ))
+        xy_list = pointsStringToXYlist(("points[1,2, 3,4, 5,6] "))
         assert xy_list == [(1, 2), (3, 4), (5, 6)]
 
     def test_new_format(self):
-        xy_list = pointsStringToXYlist((
-            "1,2 3,4 5,6"
-        ))
+        xy_list = pointsStringToXYlist(("1,2 3,4 5,6"))
         assert xy_list == [(1, 2), (3, 4), (5, 6)]
 
     def test_bbox(self):
-        xy_list = points_string_to_xy_list((
-            "points[1,2, 3,4, 5,6] "
-        ))
+        xy_list = points_string_to_xy_list(("points[1,2, 3,4, 5,6] "))
         bbox = xyListToBbox(xy_list)
         assert bbox == (1, 2, 4, 4)
 
     def test_old_format_new_method(self):
-        xy_list = points_string_to_xy_list((
-            "points[1,2, 3,4, 5,6] "
-        ))
+        xy_list = points_string_to_xy_list(("points[1,2, 3,4, 5,6] "))
         assert xy_list == [(1, 2), (3, 4), (5, 6)]
 
     def test_new_format_new_method(self):
-        xy_list = points_string_to_xy_list((
-            "1,2 3,4 5,6"
-        ))
+        xy_list = points_string_to_xy_list(("1,2 3,4 5,6"))
         assert xy_list == [(1, 2), (3, 4), (5, 6)]

--- a/test/unit/test_rtypes.py
+++ b/test/unit/test_rtypes.py
@@ -25,7 +25,6 @@ ids = [rlong(1)]
 
 
 class TestModel(object):
-
     def testConversionMethod(self):
         assert None == rtype(None)
         assert rlong(1) == rtype(rlong(1))  # Returns self
@@ -456,28 +455,30 @@ class TestModel(object):
 
     nu = native_str("u")
     bu = str("u")
-    cn = '中國'
-    cnu = u'中國'
+    cn = "中國"
+    cnu = "中國"
 
     class UStr(object):
-
         def __init__(self, rv):
             self.rv = rv
 
         def __str__(self):
             return self.rv
 
-    @pytest.mark.parametrize("data", (
-        (1, rstring, 1, "1"),
-        (2, rstring, nu, "u"),
-        (3, rstring, bu, "u"),
-        (4, rstring, nu.encode("utf-8"), b"u"),
-        (5, rstring, bu.encode("utf-8"), b"u"),
-        (6, rstring, UStr(nu), "u"),
-        (7, rstring, UStr(bu), "u"),
-        (8, rstring, cn, cn),
-        (9, rstring, cnu, cn),
-    ))
+    @pytest.mark.parametrize(
+        "data",
+        (
+            (1, rstring, 1, "1"),
+            (2, rstring, nu, "u"),
+            (3, rstring, bu, "u"),
+            (4, rstring, nu.encode("utf-8"), b"u"),
+            (5, rstring, bu.encode("utf-8"), b"u"),
+            (6, rstring, UStr(nu), "u"),
+            (7, rstring, UStr(bu), "u"),
+            (8, rstring, cn, cn),
+            (9, rstring, cnu, cn),
+        ),
+    )
     def testMoreConversions(self, data):
         # Some useful conversions were not supported in 5.1.2 and
         # earlier. This tests each of those which should no longer

--- a/test/unit/test_tempfiles.py
+++ b/test/unit/test_tempfiles.py
@@ -14,13 +14,13 @@ from builtins import str
 from builtins import object
 from past.utils import old_div
 import logging
+
 logging.basicConfig(level=0)
 
 import omero.util.temp_files as t_f
 
 
 class TestTemps(object):
-
     def testBasicUsage(self):
         p = t_f.create_path("foo", ".bar")
         assert p.exists()

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -42,6 +42,7 @@ from omero.util.temp_files import manager
 from omero.util import get_user_dir
 from omero_version import omero_version
 import omero.util.image_utils as image_utils
+
 try:
     from PIL import Image
 except ImportError:
@@ -50,9 +51,9 @@ import numpy
 
 
 class MockTable(object):
-
-    def __init__(self, names, data, csvheaders, csvrows, sqlheaders, sqlrows,
-                 jsondicts):
+    def __init__(
+        self, names, data, csvheaders, csvrows, sqlheaders, sqlrows, jsondicts
+    ):
         self.names = names
         self.data = data
         self.length = len(data)
@@ -78,49 +79,68 @@ class MockTable(object):
 
 
 tables = (
-    MockTable(("c1", "c2"), (("a", "b"),),
-              ['c1,c2'], ['a,b'],
-              ' c1 | c2 \n----+----\n', [' a  | b  '],
-              [{"c1": "a", "c2": "b"}],
-              ),
-    MockTable(("c1", "c2"), (("a,b", "c"),),
-              ['c1,c2'], ['"a,b",c'],
-              ' c1  | c2 \n-----+----\n', [' a,b | c  '],
-              [{"c1": "a,b", "c2": "c"}],
-              ),
-    MockTable(("c1", "c2"), (("'a b'", "c"),),
-              ['c1,c2'], ["'a b',c"],
-              ' c1    | c2 \n-------+----\n', [" 'a b' | c  "],
-              [{"c1": "'a b'", "c2": "c"}],
-              ),
-    MockTable(("c1", "c2"), (("a", "b"), ("c", "d")),
-              ['c1,c2'], ['a,b', 'c,d'],
-              ' c1 | c2 \n----+----\n', [' a  | b  ', ' c  | d  '],
-              [{"c1": "a", "c2": "b"}, {"c1": "c", "c2": "d"}],
-              ),
-    MockTable(("c1", "c2"), (("£ö", "b"),),
-              ['c1,c2'], ['£ö,b'],
-              ' c1 | c2 \n----+----\n', [' £ö | b  '],
-              [{"c1": "£ö", "c2": "b"}],
-              ),
-    )
+    MockTable(
+        ("c1", "c2"),
+        (("a", "b"),),
+        ["c1,c2"],
+        ["a,b"],
+        " c1 | c2 \n----+----\n",
+        [" a  | b  "],
+        [{"c1": "a", "c2": "b"}],
+    ),
+    MockTable(
+        ("c1", "c2"),
+        (("a,b", "c"),),
+        ["c1,c2"],
+        ['"a,b",c'],
+        " c1  | c2 \n-----+----\n",
+        [" a,b | c  "],
+        [{"c1": "a,b", "c2": "c"}],
+    ),
+    MockTable(
+        ("c1", "c2"),
+        (("'a b'", "c"),),
+        ["c1,c2"],
+        ["'a b',c"],
+        " c1    | c2 \n-------+----\n",
+        [" 'a b' | c  "],
+        [{"c1": "'a b'", "c2": "c"}],
+    ),
+    MockTable(
+        ("c1", "c2"),
+        (("a", "b"), ("c", "d")),
+        ["c1,c2"],
+        ["a,b", "c,d"],
+        " c1 | c2 \n----+----\n",
+        [" a  | b  ", " c  | d  "],
+        [{"c1": "a", "c2": "b"}, {"c1": "c", "c2": "d"}],
+    ),
+    MockTable(
+        ("c1", "c2"),
+        (("£ö", "b"),),
+        ["c1,c2"],
+        ["£ö,b"],
+        " c1 | c2 \n----+----\n",
+        [" £ö | b  "],
+        [{"c1": "£ö", "c2": "b"}],
+    ),
+)
 
 
 class TestCSVSTyle(object):
-
-    @pytest.mark.parametrize('mock_table', tables)
+    @pytest.mark.parametrize("mock_table", tables)
     def testGetRow(self, mock_table):
         assert mock_table.get_row(None) == mock_table.names
         for i in range(mock_table.length):
             assert mock_table.get_row(i) == mock_table.data[i]
 
-    @pytest.mark.parametrize('mock_table', tables)
+    @pytest.mark.parametrize("mock_table", tables)
     def testCSVModuleParsing(self, mock_table):
         style = CSVStyle()
         output = list(style.get_rows(mock_table))
         assert output == mock_table.csvheaders + mock_table.csvrows
 
-    @pytest.mark.parametrize('mock_table', tables)
+    @pytest.mark.parametrize("mock_table", tables)
     def testPlainModuleParsing(self, mock_table):
         style = PlainStyle()
         output = list(style.get_rows(mock_table))
@@ -128,17 +148,15 @@ class TestCSVSTyle(object):
 
 
 class TestJSONSTyle(object):
-
-    @pytest.mark.parametrize('mock_table', tables)
+    @pytest.mark.parametrize("mock_table", tables)
     def testPlainModuleParsing(self, mock_table):
         style = JSONStyle()
-        output = ''.join(style.get_rows(mock_table))
+        output = "".join(style.get_rows(mock_table))
         assert json.loads(output) == mock_table.jsondicts
 
 
 class TestTableBuilder(object):
-
-    @pytest.mark.parametrize('mock_table', tables)
+    @pytest.mark.parametrize("mock_table", tables)
     def testStr(self, mock_table):
         tb = TableBuilder(*mock_table.names)
         for row in mock_table.data:
@@ -147,7 +165,6 @@ class TestTableBuilder(object):
 
 
 class TestUpgradeCheck(object):
-
     def testNoActionOnNull(self):
         uc = UpgradeCheck("test", url=None)
         uc.run()
@@ -160,23 +177,27 @@ class TestUpgradeCheck(object):
         assert uc.isUpgradeNeeded() is False
         assert uc.isExceptionThrown() is False
 
-    @pytest.mark.parametrize('port', [8000, 9998])
+    @pytest.mark.parametrize("port", [8000, 9998])
     def testSlowResponse(self, port):
         uc = UpgradeCheck("test", url="http://127.0.0.1:%s" % port)
         uc.run()
         assert uc.isUpgradeNeeded() is False
         assert uc.isExceptionThrown() is True
 
-    @pytest.mark.parametrize('prefix', ['', 'XYZ'])
+    @pytest.mark.parametrize("prefix", ["", "XYZ"])
     def testBadIp(self, prefix):
-        uc = UpgradeCheck("test", url="200.200.200.200",
-                          version="%s%s" % (prefix, omero_version))
+        uc = UpgradeCheck(
+            "test",
+            url="200.200.200.200",
+            version="%s%s" % (prefix, omero_version),
+        )
         uc.run()
         assert uc.isUpgradeNeeded() is False
         assert uc.isExceptionThrown() is True
 
     @pytest.mark.parametrize(
-        'url', ("http://foo", "file://dev/null", "abcp", "abc://bar"))
+        "url", ("http://foo", "file://dev/null", "abcp", "abc://bar")
+    )
     def testBadUrl(self, url):
         uc = UpgradeCheck("test", url=url, version="XYZ" + omero_version)
         uc.run()
@@ -185,52 +206,72 @@ class TestUpgradeCheck(object):
 
 
 class TestTempFileManager(object):
-
-    @pytest.mark.parametrize('environment', (
-        {'OMERO_USERDIR': None,
-         'OMERO_TEMPDIR': None,
-         'OMERO_TMPDIR': None},
-        {'OMERO_USERDIR': None,
-         'OMERO_TEMPDIR': 'tempdir',
-         'OMERO_TMPDIR': None},
-        {'OMERO_USERDIR': None,
-         'OMERO_TEMPDIR': None,
-         'OMERO_TMPDIR': 'tmpdir'},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_TEMPDIR': None,
-         'OMERO_TMPDIR': None},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_TEMPDIR': 'tempdir',
-         'OMERO_TMPDIR': None},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_TEMPDIR': None,
-         'OMERO_TMPDIR': 'tmpdir'},
-        {'OMERO_USERDIR': None,
-         'OMERO_TEMPDIR': 'tempdir',
-         'OMERO_TMPDIR': 'tmpdir'},
-        {'OMERO_USERDIR': 'userdir',
-         'OMERO_TEMPDIR': 'tempdir',
-         'OMERO_TMPDIR': 'tmpdir'}))
+    @pytest.mark.parametrize(
+        "environment",
+        (
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_TEMPDIR": None,
+                "OMERO_TMPDIR": None,
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_TEMPDIR": "tempdir",
+                "OMERO_TMPDIR": None,
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_TEMPDIR": None,
+                "OMERO_TMPDIR": "tmpdir",
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_TEMPDIR": None,
+                "OMERO_TMPDIR": None,
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_TEMPDIR": "tempdir",
+                "OMERO_TMPDIR": None,
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_TEMPDIR": None,
+                "OMERO_TMPDIR": "tmpdir",
+            },
+            {
+                "OMERO_USERDIR": None,
+                "OMERO_TEMPDIR": "tempdir",
+                "OMERO_TMPDIR": "tmpdir",
+            },
+            {
+                "OMERO_USERDIR": "userdir",
+                "OMERO_TEMPDIR": "tempdir",
+                "OMERO_TMPDIR": "tmpdir",
+            },
+        ),
+    )
     def testTmpdirEnvironment(self, monkeypatch, tmpdir, environment):
         for var in list(environment.keys()):
             if environment[var]:
                 monkeypatch.setenv(
                     native_str(var),
-                    native_str(old_div(tmpdir, environment.get(var))))
+                    native_str(old_div(tmpdir, environment.get(var))),
+                )
             else:
                 monkeypatch.delenv(native_str(var), raising=False)
 
-        if environment.get('OMERO_TEMPDIR'):
+        if environment.get("OMERO_TEMPDIR"):
             value = pytest.deprecated_call(manager.tmpdir)
         else:
             value = manager.tmpdir()
 
-        if environment.get('OMERO_TMPDIR'):
-            tdir = old_div(tmpdir, environment.get('OMERO_TMPDIR'))
-        elif environment.get('OMERO_TEMPDIR'):
-            tdir = tmpdir / environment.get('OMERO_TEMPDIR') / "omero" / "tmp"
-        elif environment.get('OMERO_USERDIR'):
-            tdir = tmpdir / environment.get('OMERO_USERDIR') / "tmp"
+        if environment.get("OMERO_TMPDIR"):
+            tdir = old_div(tmpdir, environment.get("OMERO_TMPDIR"))
+        elif environment.get("OMERO_TEMPDIR"):
+            tdir = tmpdir / environment.get("OMERO_TEMPDIR") / "omero" / "tmp"
+        elif environment.get("OMERO_USERDIR"):
+            tdir = tmpdir / environment.get("OMERO_USERDIR") / "tmp"
         else:
             tdir = path(get_user_dir()) / "omero" / "tmp"
 
@@ -238,67 +279,67 @@ class TestTempFileManager(object):
 
     def testTmpdir2805_1(self, monkeypatch, tmpdir):
 
-        monkeypatch.setenv(native_str('OMERO_TEMPDIR'), native_str(tmpdir))
-        monkeypatch.delenv(native_str('OMERO_USERDIR'), raising=False)
-        tmpfile = old_div(tmpdir, 'omero')
-        tmpfile.write('')
+        monkeypatch.setenv(native_str("OMERO_TEMPDIR"), native_str(tmpdir))
+        monkeypatch.delenv(native_str("OMERO_USERDIR"), raising=False)
+        tmpfile = old_div(tmpdir, "omero")
+        tmpfile.write("")
 
         value = pytest.deprecated_call(manager.tmpdir)
         assert value == path(get_user_dir()) / "omero" / "tmp"
 
     def testTmpdir2805_2(self, monkeypatch, tmpdir):
 
-        monkeypatch.setenv(native_str('OMERO_TEMPDIR'), native_str(tmpdir))
-        monkeypatch.delenv(native_str('OMERO_USERDIR'), raising=False)
-        tempdir = old_div(tmpdir, 'omero')
+        monkeypatch.setenv(native_str("OMERO_TEMPDIR"), native_str(tmpdir))
+        monkeypatch.delenv(native_str("OMERO_USERDIR"), raising=False)
+        tempdir = old_div(tmpdir, "omero")
         tempdir.mkdir()
-        tmpfile = old_div(tempdir, 'tmp')
-        tmpfile.write('')
+        tmpfile = old_div(tempdir, "tmp")
+        tmpfile.write("")
 
         value = pytest.deprecated_call(manager.tmpdir)
         assert value == path(get_user_dir()) / "omero" / "tmp"
 
 
 class TestImageUtils(object):
-
-    @pytest.mark.parametrize(
-        'size', [4, 6, 8, 10, 12, 14, 16, 18, 20])
+    @pytest.mark.parametrize("size", [4, 6, 8, 10, 12, 14, 16, 18, 20])
     def test_get_front(self, size):
         font = image_utils.get_font(size)
         assert font is not None
 
-    @pytest.mark.parametrize("color", [
-        (255, 0, 0, 255, -16776961),     # Red
-        (0, 255, 0, 255, 16711935),      # Green
-        (0, 0, 255, 255, 65535),         # Blue
-        (0, 255, 255, 255, 16777215),    # Cyan
-        (255, 0, 255, 255, -16711681),   # Magenta
-        (255, 255, 0, 255, -65281),      # Yellow
-        (0, 0, 0, 255, 255),             # Black
-        (255, 255, 255, 255, -1),        # White
-        (0, 0, 0, 127, 127),             # Transparent black
-        (127, 127, 127, 127, 2139062143)])  # Grey
+    @pytest.mark.parametrize(
+        "color",
+        [
+            (255, 0, 0, 255, -16776961),  # Red
+            (0, 255, 0, 255, 16711935),  # Green
+            (0, 0, 255, 255, 65535),  # Blue
+            (0, 255, 255, 255, 16777215),  # Cyan
+            (255, 0, 255, 255, -16711681),  # Magenta
+            (255, 255, 0, 255, -65281),  # Yellow
+            (0, 0, 0, 255, 255),  # Black
+            (255, 255, 255, 255, -1),  # White
+            (0, 0, 0, 127, 127),  # Transparent black
+            (127, 127, 127, 127, 2139062143),
+        ],
+    )  # Grey
     def test_int_to_rgba(self, color):
         v = image_utils.int_to_rgba(color[4])
         for x in range(0, 3):
             assert color[x] == v[x]
 
-    @pytest.mark.parametrize("size", [
-        (100, 100, 50, 20, 5),
-        (100, 100, 20, 50, 5)])
+    @pytest.mark.parametrize(
+        "size", [(100, 100, 50, 20, 5), (100, 100, 20, 50, 5)]
+    )
     def test_get_zoom_factor(self, size):
         image_size = (size[0], size[1])
         r = image_utils.get_zoom_factor(image_size, size[2], size[3])
         assert r == size[4]
 
-    @pytest.mark.parametrize("size", [
-        (512, 512),
-        (256, 256)])
+    @pytest.mark.parametrize("size", [(512, 512), (256, 256)])
     def test_resize_image(self, size):
         w, h = 512, 512
         data = numpy.zeros((h, w, 3), dtype=numpy.uint8)
         data[256, 256] = [255, 0, 0]
-        img = Image.fromarray(data, 'RGB')
+        img = Image.fromarray(data, "RGB")
         result = image_utils.resize_image(img, size[0], size[1])
         assert result is not None
         width, height = result.size
@@ -308,9 +349,9 @@ class TestImageUtils(object):
     def test_paste_image(self):
         data = numpy.zeros((512, 512, 3), dtype=numpy.uint8)
         data[256, 256] = [255, 0, 0]
-        img = Image.fromarray(data, 'RGB')
+        img = Image.fromarray(data, "RGB")
 
         data_canvas = numpy.zeros((512, 512, 3), dtype=numpy.uint8)
         data_canvas[256, 256] = [255, 255, 0]
-        canvas = Image.fromarray(data_canvas, 'RGB')
+        canvas = Image.fromarray(data_canvas, "RGB")
         image_utils.paste_image(img, canvas, 0, 0)


### PR DESCRIPTION
Closes https://github.com/ome/omero-py/issues/2

Opening for discussion.
- First commit configures pre-commit to run the [`black` autoformatter](https://black.readthedocs.io/en/stable/)
- Second commit is the result of `pre-commit run --all-files`

In future code can be formatted by running `pre-commit run --all-files` locally.

--exclude
Since this will otherwise conflict with everything!