### PR TITLE
config: Escape quotes in `Default:` section

### DIFF
--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -421,6 +421,7 @@ class PropertyParser(object):
                 if not p.val:
                     v = "[empty]"
 
+                v = v.replace('"', '\\\\"')
                 if ',' in v and ', ' not in v:
                     properties += "Default: `%s`\n\n" % (
                         ",\n".join(v.split(',')))


### PR DESCRIPTION
At some point, sphinx started converting quotes to smartquotes
by default. This attempts to escape them only as necessary where
users will copy and paste values. It may be necessary, however,
to disable them globally.

see:
 - https://forum.image.sc/t/omero-web-installation-error-on-version-5-6-0/34150/3
 - http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes