### PR TITLE
 admin diagnostics: show BF (and optionally other) jar versions

### DIFF
--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1070,6 +1070,7 @@ class DiagnosticsControl(BaseControl):
         diagnostics.add_argument(
             "--no-logs", action="store_true",
             help="Skip log parsing")
+        return diagnostics
 
     def _diagnostics_banner(self, control_name):
 

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -30,6 +30,7 @@ import time
 
 from glob import glob
 from math import ceil
+from zipfile import ZipFile
 
 import omero
 import omero.config
@@ -1486,6 +1487,51 @@ present, the user will enter a console""")
                 sb = " ".join([str(x) for x in v])
                 self._item("JVM settings", " %s" % (k[0].upper() + k[1:]))
                 self.ctx.out("%s" % sb)
+
+        def jar_manifest(jar):
+            manifest = {}
+            error = ''
+            try:
+                with ZipFile(jar) as z:
+                    current = ''
+                    for line in z.read('META-INF/MANIFEST.MF').splitlines():
+                        if line and line[0] == ' ':
+                            current += line[1:]
+                        else:
+                            if current:
+                                manifest.update([current.split(': ', 1)])
+                            current = line
+                    if current:
+                        manifest.update([current.split(': ', 1)])
+            except Exception as e:
+                error = str(e)
+            return manifest, error
+
+        # Bio-Format versions
+        jars = (
+            'lib/client/formats-api.jar',
+            'lib/client/formats-bsd.jar',
+            'lib/client/formats-gpl.jar',
+            'lib/server/formats-api.jar',
+            'lib/server/formats-bsd.jar',
+            'lib/server/formats-gpl.jar',
+        )
+        manifest_keys = (
+            'Implementation-Title',
+            'Implementation-Version',
+            'Implementation-Date',
+        )
+        self.ctx.out("")
+        for jar in jars:
+            manifest, error = jar_manifest(self.ctx.dir / jar)
+            if error:
+                info = [error]
+            else:
+                info = [manifest.get(key, '') for key in manifest_keys]
+            self._item("Jar", jar)
+            self.ctx.out('\t'.join(info))
+
+
 
     def email(self, args):
         client = self.ctx.conn(args)

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1511,20 +1511,17 @@ present, the user will enter a console""")
                 error = str(e)
             return manifest, error
 
-        # Bio-Formats versions
+        # Jar versions
+        jars = sorted(
+            os.path.join(os.path.relpath(root, self.ctx.dir), filename)
+            for root, dirnames, filenames in os.walk(self.ctx.dir)
+            for filename in filenames
+            if filename.endswith('.jar')
+        )
         if args.all_jars:
-            jars = sorted(
-                os.path.join(os.path.relpath(root, self.ctx.dir), filename)
-                for root, dirnames, filenames in os.walk(self.ctx.dir)
-                for filename in filenames
-                if filename.endswith('.jar')
-            )
+            jar_re = r'.*'
         else:
-            jars = (
-                'lib/server/formats-api.jar',
-                'lib/server/formats-bsd.jar',
-                'lib/server/formats-gpl.jar',
-            )
+            jar_re = r'lib/server/(formats|ome|omero)-.*.jar'
         manifest_keys = (
             'Implementation-Title',
             'Implementation-Version',
@@ -1533,6 +1530,8 @@ present, the user will enter a console""")
         )
         self.ctx.out("")
         for jar in jars:
+            if not re.match(jar_re, jar):
+                continue
             manifest, error = jar_manifest(self.ctx.dir / jar)
             if error:
                 info = [error]

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1520,9 +1520,6 @@ present, the user will enter a console""")
             )
         else:
             jars = (
-                'lib/client/formats-api.jar',
-                'lib/client/formats-bsd.jar',
-                'lib/client/formats-gpl.jar',
                 'lib/server/formats-api.jar',
                 'lib/server/formats-bsd.jar',
                 'lib/server/formats-gpl.jar',

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1528,6 +1528,7 @@ present, the user will enter a console""")
             'Implementation-Title',
             'Implementation-Version',
             'Implementation-Date',
+            'Implementation-Build',
         )
         self.ctx.out("")
         for jar in jars:

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -110,7 +110,10 @@ class AdminControl(DiagnosticsControl,
 
     def _configure(self, parser):
         sub = parser.sub()
-        self._add_diagnostics(parser, sub)
+        parser = self._add_diagnostics(parser, sub)
+        parser.add_argument(
+            "--all-jars", action="store_true",
+            help="Show information for all jars")
         self.add_error(
             "NOT_WINDOWS", 123,
             "Not Windows")
@@ -1508,14 +1511,22 @@ present, the user will enter a console""")
             return manifest, error
 
         # Bio-Format versions
-        jars = (
-            'lib/client/formats-api.jar',
-            'lib/client/formats-bsd.jar',
-            'lib/client/formats-gpl.jar',
-            'lib/server/formats-api.jar',
-            'lib/server/formats-bsd.jar',
-            'lib/server/formats-gpl.jar',
-        )
+        if args.all_jars:
+            jars = sorted(
+                os.path.join(os.path.relpath(root, self.ctx.dir), filename)
+                for root, dirnames, filenames in os.walk(self.ctx.dir)
+                for filename in filenames
+                if filename.endswith('.jar')
+            )
+        else:
+            jars = (
+                'lib/client/formats-api.jar',
+                'lib/client/formats-bsd.jar',
+                'lib/client/formats-gpl.jar',
+                'lib/server/formats-api.jar',
+                'lib/server/formats-bsd.jar',
+                'lib/server/formats-gpl.jar',
+            )
         manifest_keys = (
             'Implementation-Title',
             'Implementation-Version',

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1498,6 +1498,7 @@ present, the user will enter a console""")
                 with ZipFile(jar) as z:
                     current = ''
                     for line in z.read('META-INF/MANIFEST.MF').splitlines():
+                        line = line.decode()
                         if line and line[0] == ' ':
                             current += line[1:]
                         else:

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1511,7 +1511,7 @@ present, the user will enter a console""")
                 error = str(e)
             return manifest, error
 
-        # Bio-Format versions
+        # Bio-Formats versions
         if args.all_jars:
             jars = sorted(
                 os.path.join(os.path.relpath(root, self.ctx.dir), filename)


### PR DESCRIPTION
# What this PR does

Displays some jar manifest information for the Bio-Formats jars.

https://github.com/IDR/deployment/pull/168 replaces the bundled BF jars with a custom version. Since development versions may be used it'd be useful to check the versions if problems occur.

# Testing this PR

```
$ bin/omero admin diagnostics

...

Jar:        lib/server/formats-api.jar     Bio-Formats API      6.3.1   13 December 2019        e355a853c5768721711cb9b29c3a27561539c4e4
Jar:        lib/server/formats-bsd.jar     BSD Bio-Formats readers and writers 6.3.1    13 December 2019        e355a853c5768721711cb9b29c3a27561539c4e4
Jar:        lib/server/formats-gpl.jar     Bio-Formats library  6.3.1   13 December 2019        e355a853c5768721711cb9b29c3a27561539c4e4
```

```
$ bin/omero admin diagnostics --all-jars
```
Recursively find and show info for all `*.jar`

Ported from https://github.com/ome/openmicroscopy/pull/6093
