### PR TITLE
List preferred conda installation first

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,18 +31,18 @@ You can create one using either ``venv`` or ``conda`` (preferred).
 If you opt for `Conda`_, you will need
 to install it first, see `miniconda`_ for more details.
 
-To install ``omero-py`` using venv::
+To install ``omero-py`` using conda (preferred)::
+
+    conda create -n myenv -c ome python=3.6 zeroc-ice36-python omero-py
+    conda activate myenv
+
+Alternatively install ``omero-py`` using venv::
 
     python3.6 -m venv myenv
     . myenv/bin/activate
     pip install omero-py
 
 You may need to replace ``python3.6`` with ``python`` or ``python3`` depending on your Python distribution.
-
-To install ``omero-py`` using conda (preferred)::
-
-    conda create -n myenv -c ome python=3.6 zeroc-ice36-python omero-py
-    conda activate myenv
 
 Setting of the environment variable ``OMERODIR`` is required
 for some functionality.


### PR DESCRIPTION
If conda is the preferred way to install, it should be mentioned first.

See also https://github.com/ome/ome-documentation/pull/2104