### PR TITLE
Use get_error for 'fs usage' failures (fix #187)

### DIFF
--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -926,7 +926,7 @@ Examples:
         """
         err = self.get_error(rsp)
         if err:
-            self.ctx.err("Error: " + rsp.parameters['message'])
+            self.ctx.err(err)
         else:
             size = sum(rsp.totalBytesUsed.values())
             if args.size_only:


### PR DESCRIPTION
New error statement:

```
$ omero fs usage Project:-1
failed: 'graph-fail'
failed: cannot read ome.model.containers.Project[-1]
```