### PR TITLE
cli: don't unset ICE_CONFIG (fix #191)

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1683,6 +1683,7 @@ present, the user will enter a console""")
         # See ticket #10051
         popen = self.ctx.popen(["icegridnode", "--version"])
         env = self.ctx._env()
+        # Unclear how this could have been set with the call to unsetenv
         ice_config = env.get("ICE_CONFIG")
         if ice_config is not None and not os.path.exists(ice_config):
             popen = self.ctx.popen(["icegridnode", "--version"],


### PR DESCRIPTION
The unsetting of ICE_CONFIG fails on Windows and may
no longer be needed. It was added in 445940543a0469fe0476d0a1d6b5f4846e7349b8
while working on `omero shell`.

see: https://github.com/ome/omero-py/issues/191