### PR TITLE
processor: set OMERODIR

### DIFF
--- a/src/omero/processor.py
+++ b/src/omero/processor.py
@@ -155,6 +155,7 @@ class ProcessI(omero.grid.Process, omero.util.SimpleServant):
             "LANGUAGE",
             "LD_LIBRARY_PATH",
             "MLABRAW_CMD_STR",
+            "OMERODIR",
             "OMERO_TEMPDIR",
             "OMERO_TMPDIR",
             "PATH",


### PR DESCRIPTION
https://github.com/ome/openmicroscopy/pull/6222 is currently
failing since the script run by the test is not able to find
the importer jars. With OMERODIR set in the processor server
the jars should be detected.