### PR TITLE
Windows: require pywin32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ setup(
         'numpy',
         'Pillow',
         'zeroc-ice>=3.6.4,<3.7',
+        'pywin32; platform_system=="Windows"',
     ],
     tests_require=[
         'pytest',

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     restructuredtext-lint
     py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
     py37: zeroc-ice
-    py37-win: pypiwin32
+    py37-win: pywin32
     mox3
     jinja2
 setenv =


### PR DESCRIPTION
Closes #201 

Tested by running `pip install https://github.com/manics/omero-py/archive/pywin32.zip` on Windows with the zeroc-ice36-python testing package.