### PR TITLE
api order by ID

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3423,6 +3423,9 @@ class _BlitzGateway (object):
         # Order by... e.g. 'lower(obj.name)' or 'obj.column, obj.row' for wells
         if order_by is not None:
             query += " order by %s, obj.id" % order_by
+        else:
+            # to ensure consistent pagination etc
+            query += " order by obj.id"
 
         return (query, baseParams, wrapper)
 


### PR DESCRIPTION
```getObjects()``` orders by ID by default

Since we support pagination, we should ensure consistent ordering of objects.
If user doesn't choose any ordering, then we order by ID by default.