### PR TITLE
Warn if omero.db.poolsize is not set.

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -773,6 +773,15 @@ present, the user will enter a console""")
             self.checkwindows(args)
         self.check_lock(config)
 
+        try:
+            config['omero.db.poolsize']
+        except KeyError:
+            self.ctx.out(
+                "WARNING: Your server has not been configured for production "
+                "use. See https://docs.openmicroscopy.org/omero/latest/"
+                "sysadmins/server-performance.html?highlight=poolsize "
+                "for more information.")
+
         self._initDir()
         # Do a check to see if we've started before.
         self._regdata()

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -778,8 +778,8 @@ present, the user will enter a console""")
         except KeyError:
             self.ctx.out(
                 "WARNING: Your server has not been configured for production "
-                "use. See https://docs.openmicroscopy.org/omero/latest/"
-                "sysadmins/server-performance.html?highlight=poolsize "
+                "use.\nSee https://docs.openmicroscopy.org/omero/latest/"
+                "sysadmins/server-performance.html?highlight=poolsize\n"
                 "for more information.")
 
         self._initDir()


### PR DESCRIPTION
Fixes https://github.com/ome/omero-server/issues/84 by printing the suggested message during `omero admin start` if `omero.db.poolsize` has not been configured.