### PR TITLE
Update README release commands to sign release tags

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,7 @@
 current_version = 5.7.1.dev0
 commit = True
 tag = True
+sign_tags = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{release}{build}

--- a/README.rst
+++ b/README.rst
@@ -117,10 +117,9 @@ Release process
 This repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.
 To tag a release run::
 
-    $ bumpversion release --sign-tags
+    $ bumpversion release
 
-This will remove the ``.dev0`` suffix from the current version, commit, and
-create a signed tag for the release.
+This will remove the ``.dev0`` suffix from the current version, commit, and tag the release.
 
 To switch back to a development version run::
 

--- a/README.rst
+++ b/README.rst
@@ -117,9 +117,10 @@ Release process
 This repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.
 To tag a release run::
 
-    $ bumpversion release
+    $ bumpversion release --sign-tags
 
-This will remove the ``.dev0`` suffix from the current version, commit, and tag the release.
+This will remove the ``.dev0`` suffix from the current version, commit, and
+create a signed tag for the release.
 
 To switch back to a development version run::
 


### PR DESCRIPTION
Minor improvements from my experience releasing omero-py 5.7.0.

A second minor is that if the previous dev version does not match the expected release version (in my case `5.6.3.dev0` was released as `5.7.0`), the default command will obviously create an undesired tag/commit. Options are either:
- to review the current version and have a preliminary bump of `bumpversion --no-tag [major|minor|patch]`
- to override the content of `.bumpversion.cfg` using  `bumpversion release --current-version/--new-version
No strong preference either way but if people have a inclination towards either of these options, I can certainly add a sentence to the README as part of this PR