### PR TITLE
Add PyYAML as a dependency of omero-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,6 +211,7 @@ setup(
         'future',
         'numpy',
         'Pillow',
+        'PyYAML',
         'zeroc-ice>=3.6.4,<3.7',
         'pywin32; platform_system=="Windows"',
     ],

--- a/src/omero/util/pydict_text_io.py
+++ b/src/omero/util/pydict_text_io.py
@@ -28,21 +28,14 @@ import json
 import re
 from omero.rtypes import unwrap
 from future.utils import bytes_to_native_str
-
-try:
-    import yaml
-    YAML_ENABLED = True
-except ImportError:
-    YAML_ENABLED = False
+import yaml
 
 
 def get_supported_formats():
     """
     Return the supported formats
     """
-    if YAML_ENABLED:
-        return ('json', 'yaml')
-    return ('json',)
+    return ('json', 'yaml')
 
 
 def load(fileobj, filetype=None, single=True, session=None):
@@ -77,9 +70,7 @@ def load(fileobj, filetype=None, single=True, session=None):
         rawdata, filetype = get_format_filename(fileobj, filetype)
 
     if filetype == 'yaml':
-        if not YAML_ENABLED:
-            raise ImportError("yaml (PyYAML) module required")
-        data = list(yaml.load_all(rawdata))
+        data = list(yaml.safe_load_all(rawdata))
         if single:
             if len(data) != 1:
                 raise Exception(
@@ -108,8 +99,6 @@ def dump(data, formattype):
     """
 
     if formattype == 'yaml':
-        if not YAML_ENABLED:
-            raise ImportError("yaml (PyYAML) module required")
         return yaml.dump(data)
 
     if formattype == 'json':

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -338,7 +338,7 @@ class TestImport(object):
         self.cli.invoke(self.args, strict=True)
 
         o, e = capfd.readouterr()
-        result = yaml.load(StringIO(o))
+        result = yaml.safe_load(StringIO(o))
         result = result[0]
         assert "fake" in result["group"]
         assert 1 == len(result["files"])


### PR DESCRIPTION
In the current construction of omero-py, there are two public APIs which require PyYAML at runtime: the CLI `import --bulk` functionalitity as well as the `omero.util.pydict_text_io` utility consumed by a few CLI plugins (render, metadata) for loading YAML files.


497f1bd makes `PyYAML` a mandatory dependency of `omero-py`
dcde6b2 also removes the optional `import yaml` handling and replaces usage of the deprecated `yaml.load` and `yaml.load_all` by `yaml.safe_load` and `yaml.safe_load_all`