### PR TITLE
hql.py: when querying masks, filter `bytes` field

### DIFF
--- a/src/omero/plugins/hql.py
+++ b/src/omero/plugins/hql.py
@@ -25,7 +25,7 @@ If no query is given, then a shell is opened which will run any entered query
 with the current parameters.
 """
 
-BLACKLISTED_KEYS = ["_id", "_loaded"]
+BLACKLISTED_KEYS = ["_id", "_loaded", "_bytes"]
 WHITELISTED_VALUES = [0, False]
 
 


### PR DESCRIPTION
`omero hql "select s from Shape s"` or similar fails with

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udcb0' in position 3797: surrogates not allowed
```

due to the bytes field.