### PR TITLE
Activate test_import unit tests with OMERO_USERDIR

### DIFF
--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -106,7 +106,7 @@ SKIP_CHOICES = ['all', 'checksum', 'minmax', 'thumbnails', 'upgrade']
 NO_ARG = object()
 
 OMERO_JAVA_ZIP = (
-    'https://downloads.openmicroscopy.org/omero/latest/OMERO.java.zip'
+    'https://downloads.openmicroscopy.org/omero/{version}/OMERO.java.zip'
 )
 
 
@@ -326,8 +326,8 @@ class ImportControl(BaseControl):
             help="Path to a logback xml file. "
             " Default: etc/logback-cli.xml")
         add_python_argument(
-            "--fetch-jars", action="store_true",
-            help="Download OMERO.java jars")
+            "--fetch-jars", type=str,
+            help="Download this version of OMERO.java jars")
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
@@ -502,7 +502,7 @@ class ImportControl(BaseControl):
         if args.fetch_jars:
             if args.path:
                 self.ctx.err('WARNING: Ignoring extra arguments')
-            self.download_omero_java()
+            self.download_omero_java(args.fetch_jars)
             return
 
         if args.clientdir:
@@ -555,12 +555,13 @@ class ImportControl(BaseControl):
         else:
             return None, omero_java_txt
 
-    def download_omero_java(self):
-        self.ctx.err("Downloading %s" % OMERO_JAVA_ZIP)
+    def download_omero_java(self, version):
+        omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
+        self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         if not jars_dir.exists():
             jars_dir.mkdir()
-        resp = urlopen(OMERO_JAVA_ZIP)
+        resp = urlopen(omero_java_zip)
         zipfile = ZipFile(BytesIO(resp.read()))
         topdirs = set(f.filename.split(
             os.path.sep)[0] for f in zipfile.filelist if f.is_dir())

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -561,23 +561,23 @@ class ImportControl(BaseControl):
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         if not jars_dir.exists():
             jars_dir.mkdir()
-        resp = urlopen(omero_java_zip)
-        zipfile = ZipFile(BytesIO(resp.read()))
-        topdirs = set(f.filename.split(
-            os.path.sep)[0] for f in zipfile.filelist if f.is_dir())
-        if len(topdirs) != 1:
-            self.ctx.die(
-                108, 'Expected one top directory in OMERO.java.zip: {}'.format(
-                    topdirs))
-        topdir = topdirs.pop()
-        if os.path.isabs(topdir):
-            self.ctx.die(
-                108, 'Unexpected absolute paths in OMERO.java.zip: {}'.format(
-                    topdir))
-        zipfile.extractall(jars_dir)
-        zipfile.close()
-        omero_java_txt.write_text(topdir)
-        resp.close()
+        with urlopen(omero_java_zip) as resp:
+            with ZipFile(BytesIO(resp.read())) as zipfile:
+                topdirs = set(f.filename.split(
+                    os.path.sep)[0] for f in zipfile.filelist if f.is_dir())
+                if len(topdirs) != 1:
+                    self.ctx.die(
+                        108,
+                        'Expected one top directory in OMERO.java.zip: {}'
+                        .format(topdirs))
+                topdir = topdirs.pop()
+                if os.path.isabs(topdir):
+                    self.ctx.die(
+                        108,
+                        'Unexpected absolute paths in OMERO.java.zip: {}'
+                        .format(topdir))
+                zipfile.extractall(jars_dir)
+                omero_java_txt.write_text(topdir)
 
     def do_import(self, command_args, xargs, mode="w"):
         out = err = None

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -112,8 +112,8 @@ SKIP_CHOICES = ['all', 'checksum', 'minmax', 'thumbnails', 'upgrade']
 NO_ARG = object()
 
 OMERO_JAVA_ZIP = (
-    'https://downloads.openmicroscopy.org/omero/5.6.0-m5/artifacts/'
-    'OMERO.java-5.6.0-m5-ice36-b129.zip'
+    'https://downloads.openmicroscopy.org/omero/5.6.1/artifacts/'
+    'OMERO.java-5.6.1-ice36-b225.zip'
 )
 
 

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -73,11 +73,12 @@ class TestImport(object):
         self.args = ["import"]
 
     def add_client_dir(self):
-        dist_dir = path(OMERODIR)
-        client_dir = dist_dir / "lib" / "client"
-        logback = dist_dir / "etc" / "logback-cli.xml"
-        self.args += ["--clientdir", client_dir]
-        self.args += ["--logback", logback]
+        if OMERODIR is not False:
+            dist_dir = path(OMERODIR)
+            client_dir = dist_dir / "lib" / "client"
+            logback = dist_dir / "etc" / "logback-cli.xml"
+            self.args += ["--clientdir", client_dir]
+            self.args += ["--logback", logback]
 
     def mkdir(self, parent, name, with_ds_store=False):
         child = old_div(parent, name)
@@ -166,7 +167,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize("data", (("1", False), ("3", True)))
     def testImportDepth(self, tmpdir, capfd, data):
         """Test import using depth argument"""
@@ -195,7 +195,6 @@ class TestImport(object):
             with pytest.raises(NonZeroReturnCode):
                 f()
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testImportFakeImage(self, tmpdir, capfd):
         """Test fake image import"""
 
@@ -214,7 +213,6 @@ class TestImport(object):
         assert outputlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('params', (
         ("-l", "only_fakes.txt", True),
         ("-l", "no_fakes.txt", False),
@@ -247,7 +245,6 @@ class TestImport(object):
             o, e = capfd.readouterr()
             assert "parsed into 0 group" in e
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('with_ds_store', (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
         """Test fake screen import"""
@@ -270,7 +267,6 @@ class TestImport(object):
         for i in range(len(fieldfiles)):
             assert outputlines[-1-len(fieldfiles)+i] == str(fieldfiles[i])
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testImportPattern(self, tmpdir, capfd):
         """Test pattern import"""
 
@@ -318,7 +314,6 @@ class TestImport(object):
         expected_args += ['test.fake']
         assert command_args.java_args() == expected_args
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testLogPrefix(self, tmpdir, capfd):
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')
@@ -340,7 +335,6 @@ class TestImport(object):
         assert outlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testYamlOutput(self, tmpdir, capfd):
 
         import yaml
@@ -368,7 +362,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkSimple(self):
         t = path(__file__).parent / "bulk_import" / "test_simple"
         b = old_div(t, "bulk.yml")
@@ -377,7 +370,6 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkInclude(self):
         t = path(__file__).parent / "bulk_import" / "test_include" / "inner"
         b = old_div(t, "bulk.yml")
@@ -386,7 +378,6 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkName(self):
         # Metadata provided in the yml file will be applied
         # to the args
@@ -402,7 +393,6 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkCols(self):
         # Metadata provided about the individual columns in
         # the tsv will be used.
@@ -430,7 +420,6 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkDry(self, capfd):
         t = path(__file__).parent / "bulk_import" / "test_dryrun"
         b = old_div(t, "bulk.yml")
@@ -441,7 +430,6 @@ class TestImport(object):
         o, e = capfd.readouterr()
         assert o == '"--name=no-op" "1.fake"\n'
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     def testBulkJavaArgs(self):
         """Test Java arguments"""
         t = path(__file__).parent / "bulk_import" / "test_javaargs"
@@ -461,7 +449,6 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
-    @pytest.mark.skipif(OMERODIR is False, reason="Needs client dir")
     @pytest.mark.parametrize('skip', plugin.SKIP_CHOICES)
     def testBulkSkip(self, skip):
         """Test skip arguments"""

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -19,6 +19,7 @@ from builtins import object
 from past.utils import old_div
 import os
 import pytest
+import sys
 from omero_ext.path import path
 import omero.clients
 import uuid
@@ -167,6 +168,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize("data", (("1", False), ("3", True)))
     def testImportDepth(self, tmpdir, capfd, data):
         """Test import using depth argument"""
@@ -195,6 +197,7 @@ class TestImport(object):
             with pytest.raises(NonZeroReturnCode):
                 f()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testImportFakeImage(self, tmpdir, capfd):
         """Test fake image import"""
 
@@ -213,6 +216,7 @@ class TestImport(object):
         assert outputlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('params', (
         ("-l", "only_fakes.txt", True),
         ("-l", "no_fakes.txt", False),
@@ -245,6 +249,7 @@ class TestImport(object):
             o, e = capfd.readouterr()
             assert "parsed into 0 group" in o
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('with_ds_store', (True, False))
     def testImportFakeScreen(self, tmpdir, capfd, with_ds_store):
         """Test fake screen import"""
@@ -267,6 +272,7 @@ class TestImport(object):
         for i in range(len(fieldfiles)):
             assert outputlines[-1-len(fieldfiles)+i] == str(fieldfiles[i])
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testImportPattern(self, tmpdir, capfd):
         """Test pattern import"""
 
@@ -314,6 +320,7 @@ class TestImport(object):
         expected_args += ['test.fake']
         assert command_args.java_args() == expected_args
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testLogPrefix(self, tmpdir, capfd):
         fakefile = tmpdir.join("test.fake")
         fakefile.write('')
@@ -335,6 +342,7 @@ class TestImport(object):
         assert outlines[-3] == \
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testYamlOutput(self, tmpdir, capfd):
 
         import yaml
@@ -364,6 +372,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkSimple(self):
         t = path(__file__).parent / "bulk_import" / "test_simple"
         b = old_div(t, "bulk.yml")
@@ -372,6 +381,7 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkInclude(self):
         t = path(__file__).parent / "bulk_import" / "test_include" / "inner"
         b = old_div(t, "bulk.yml")
@@ -380,6 +390,7 @@ class TestImport(object):
         self.args += ["-f", "---bulk=%s" % b]
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkName(self):
         # Metadata provided in the yml file will be applied
         # to the args
@@ -395,6 +406,7 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkCols(self):
         # Metadata provided about the individual columns in
         # the tsv will be used.
@@ -422,6 +434,7 @@ class TestImport(object):
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkDry(self, capfd):
         t = path(__file__).parent / "bulk_import" / "test_dryrun"
         b = old_div(t, "bulk.yml")
@@ -432,6 +445,7 @@ class TestImport(object):
         o, e = capfd.readouterr()
         assert o == '"--name=no-op" "1.fake"\n'
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testBulkJavaArgs(self):
         """Test Java arguments"""
         t = path(__file__).parent / "bulk_import" / "test_javaargs"
@@ -451,6 +465,7 @@ class TestImport(object):
         self.add_client_dir()
         self.cli.invoke(self.args, strict=True)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     @pytest.mark.parametrize('skip', plugin.SKIP_CHOICES)
     def testBulkSkip(self, skip):
         """Test skip arguments"""

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -41,6 +41,21 @@ OMERODIR = False
 if 'OMERODIR' in os.environ:
     OMERODIR = os.environ.get('OMERODIR')
 
+
+@pytest.fixture(scope="session")
+def omero_userdir_tmpdir(tmpdir_factory):
+    # If OMERO_USERDIR is set assume user wants to use it for tests
+    # Otherwise avoid modifying the default userdir
+    if os.getenv("OMERO_USERDIR"):
+        return os.getenv("OMERO_USERDIR")
+    return str(tmpdir_factory.mktemp('omero_userdir'))
+
+
+@pytest.fixture(scope="function", autouse=True)
+def omero_userdir(monkeypatch, omero_userdir_tmpdir):
+    monkeypatch.setenv("OMERO_USERDIR", omero_userdir_tmpdir)
+
+
 class MockClient(omero.clients.BaseClient):
 
     def setSessionId(self, uuid):

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     pytest-rerunfailures
     pytest-xdist
     restructuredtext-lint
-    py36: https://github.com/ome/zeroc-ice-py-manylinux/releases/download/0.2.0/zeroc_ice-3.6.5-cp36-cp36m-manylinux2010_x86_64.whl
+    py36: https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
     py37: zeroc-ice
     py37-win: pywin32
     mox3

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,7 @@ deps =
     pytest-rerunfailures
     pytest-xdist
     restructuredtext-lint
-    py36: https://github.com/ome/zeroc-ice-ubuntu1804/releases/download/0.3.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
-    py37: zeroc-ice
+    zeroc-ice
     py37-win: pywin32
     mox3
     jinja2


### PR DESCRIPTION
This is a followup to https://github.com/ome/omero-py/pull/162 (the last ~3~ 4 commits in this PR are new).
1. If `OMERO_USERDIR` is not set this uses a temporary directory to ensure the unit test does not modify the user's environment since jars are automatically downloaded.
2. Activates all import tests that were previously disabled when `OMERODIR` wasn't set
3. Fixes broken import tests which apparently were never run in CI
4. Disables the tests activated in step 2 on Windows only since they're failing

Downside of course is that anyone running the full test suite without setting `OMERO_USERDIR` will end up downloading OMERO.java once (the fixture that sets `OMERO_USERDIR` to a tempdir is scoped to the session not the function), but I think this is preferable to modifying the default `OMERO_USERDIR`. Alternatively we could disable the tests by default, but then they'll probably break again.