### PR TITLE
Replace ~/omero with standard OS-dependent paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
     },
     python_requires='>=3',
     install_requires=[
+        'appdirs',
         'future',
         'numpy',
         'Pillow',

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -572,8 +572,7 @@ class ImportControl(BaseControl):
         omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
         self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
-        if not jars_dir.exists():
-            jars_dir.mkdir()
+        jars_dir.makedirs_p()
         with urlopen(omero_java_zip) as resp:
             with ZipFile(BytesIO(resp.read())) as zipfile:
                 topdirs = set(f.filename.split(

--- a/test/unit/clitest/test_export.py
+++ b/test/unit/clitest/test_export.py
@@ -65,7 +65,7 @@ class TestExport(object):
         self.cli.invoke(string, strict=True)
 
     def testSimpleExport(self):
-        self.invoke("x -f %s Image:3" % self.p)
+        self.invoke(["x", "-f", self.p, "Image:3"])
 
     def testStdOutExport(self):
         """

--- a/test/unit/clitest/test_prefs.py
+++ b/test/unit/clitest/test_prefs.py
@@ -188,23 +188,23 @@ class TestPrefs(object):
     def testLoad(self, capsys):
         to_load = create_path()
         to_load.write_text("A=B")
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.assertStdoutStderr(capsys)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=B")
 
         # Same property/value pairs should pass
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
 
         to_load.write_text("A=C")
         with pytest.raises(NonZeroReturnCode):
             # Different property/value pair should fail
-            self.invoke("load %s" % to_load)
+            self.invoke(["load", to_load])
         self.assertStdoutStderr(
             capsys, err="Duplicate property: A ('B' => 'C')")
 
         # Quiet load
-        self.invoke("load -q %s" % to_load)
+        self.invoke(["load", "-q", to_load])
         self.assertStdoutStderr(capsys)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=C")
@@ -217,7 +217,7 @@ class TestPrefs(object):
     def testLoadMultiLine(self, capsys):
         to_load = create_path()
         to_load.write_text("A=B\\\nC")
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=BC")
 
@@ -228,7 +228,7 @@ class TestPrefs(object):
         valid_key, valid_value = validkeyvalue
         to_load = create_path()
         to_load.write_text("%s=%s\n" % (valid_key, valid_value))
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.invoke("get %s" % valid_key)
         self.assertStdoutStderr(capsys, out=valid_value)
 
@@ -244,7 +244,7 @@ class TestPrefs(object):
         to_load = create_path()
         to_load.write_text("C=D\n%s\nH=I\n" % invalidline)
         with pytest.raises(NonZeroReturnCode):
-            self.invoke("load %s" % to_load)
+            self.invoke(["load", to_load])
         self.assertStdoutStderr(
             capsys, err="Illegal property name: %s" % invalidkey)
         self.invoke("get")
@@ -269,7 +269,7 @@ class TestPrefs(object):
     def testSetFromFile(self, capsys):
         to_load = create_path()
         to_load.write_text("Test")
-        self.invoke("set -f %s A" % to_load)
+        self.invoke(["set", "-f", to_load, "A"])
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=Test")
 

--- a/test/unit/clitest/test_sessions.py
+++ b/test/unit/clitest/test_sessions.py
@@ -53,7 +53,7 @@ class TestSessions(object):
 
         # Default store sessions dir is under user dir
         store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(get_user_dir()) / 'omero' / 'sessions'
+        assert store.dir == path(get_user_dir()) / 'sessions'
 
     @pytest.mark.parametrize('environment', (
         {'OMERO_USERDIR': None,
@@ -115,5 +115,5 @@ class TestSessions(object):
         elif environment.get('OMERO_USERDIR'):
             sdir = path(tmpdir) / environment.get('OMERO_USERDIR') / 'sessions'
         else:
-            sdir = path(get_user_dir()) / 'omero' / 'sessions'
+            sdir = path(get_user_dir()) / 'sessions'
         assert store.dir == str(sdir)

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -232,7 +232,7 @@ class TestTempFileManager(object):
         elif environment.get('OMERO_USERDIR'):
             tdir = tmpdir / environment.get('OMERO_USERDIR') / "tmp"
         else:
-            tdir = path(get_user_dir()) / "omero" / "tmp"
+            tdir = path(get_user_dir()) / "tmp"
 
         assert value == str(tdir)
 
@@ -244,7 +244,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "omero" / "tmp"
+        assert value == path(get_user_dir()) / "tmp"
 
     def testTmpdir2805_2(self, monkeypatch, tmpdir):
 
@@ -256,7 +256,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "omero" / "tmp"
+        assert value == path(get_user_dir()) / "tmp"
 
 
 class TestImageUtils(object):


### PR DESCRIPTION
Replaces `~/omero` with "standard" paths according to each operating system: https://pypi.org/project/appdirs/

Closes https://github.com/ome/omero-py/issues/210