### PR TITLE
Error handling when attempting to check log files

### DIFF
--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1115,7 +1115,7 @@ OMERO Diagnostics (%s) %s
                              r'error:?\s')
                 warn = 0
                 err = 0
-                for l in p.lines():
+                for l in p.lines(encoding='UTF-8'):
                     # ensure errors/warnings search is case-insensitive
                     lcl = l.lower()
                     if re.match(warn_regex, lcl):

--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1115,7 +1115,7 @@ OMERO Diagnostics (%s) %s
                              r'error:?\s')
                 warn = 0
                 err = 0
-                for l in p.lines(encoding='UTF-8'):
+                for l in p.lines(errors="surrogateescape"):
                     # ensure errors/warnings search is case-insensitive
                     lcl = l.lower()
                     if re.match(warn_regex, lcl):


### PR DESCRIPTION
I think this is a Python2 --> Python3 hangover. Python2 would have just silently corrupted incorrect encodings whereas Python3 will unicode everything and try to use what's specified. `UnicodeDecodeError`'s can then be thrown during `omero admin diagnostics` if log files contain UTF-8. For example:

```
Log dir:    /opt/omero/OMERO.current/var/log exists
Log files:  Blitz-0.log                    339.8 MB      errors=273  warnings=1024
Log files:  Blitz-0.log.1                  Traceback (most recent call last):
  File "/opt/omero/OMERO.venv36/bin/omero", line 118, in <module>
    rv = omero.cli.argv()
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/cli.py", line 1754, in argv
    cli.invoke(args[1:])
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/cli.py", line 1187, in invoke
    stop = self.onecmd(line, previous_args)
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/cli.py", line 1264, in onecmd
    self.execute(line, previous_args)
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/cli.py", line 1346, in execute
    args.func(args)
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/install/windows_warning.py", line 26, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/plugins/prefs.py", line 79, in open_and_close_config
    return func(*args, **kwargs)
  File "/opt/omero/OMERO.venv36/lib/python3.6/site-packages/omero/plugins/admin.py", line 1417, in diagnostics
    parse_logs()
  File "/opt/omero/OMERO.venv36/lib/python3.6/site-packages/omero/plugins/admin.py", line 1371, in parse_logs
    self._exists(old_div(log_dir, x))
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero/cli.py", line 1117, in _exists
    for l in p.lines():
  File "/opt/omero/OMERO.venv36/lib64/python3.6/site-packages/omero_ext/path.py", line 938, in lines
    return f.readlines()
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1809: ordinal not in range(128)
```

Default encoding of our vendored `path.py` is specified as ascii here:

 * https://github.com/ome/omero-py/blame/master/src/omero_ext/path.py#L917

Since we are using PyPI for nearly everything now might be worth looking into removing our vendored version and adding a dependency on the `path` module.

/cc @emilroz 
