### PR TITLE
Import logprefix

### DIFF
--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -281,6 +281,7 @@ class CommandArguments(object):
             return None
         if prefix:
             file = os.path.sep.join([prefix, file])
+        file = os.path.abspath(file)
         dir = os.path.dirname(file)
         if not os.path.exists(dir):
             os.makedirs(dir)

--- a/test/unit/clitest/test_import.py
+++ b/test/unit/clitest/test_import.py
@@ -343,6 +343,27 @@ class TestImport(object):
             "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
+    def testLogs(self, tmpdir, capfd, monkeypatch):
+        fakefile = tmpdir.join("test.fake")
+        fakefile.write('')
+        monkeypatch.chdir(tmpdir)
+
+        self.add_client_dir()
+        self.args += ["-f", "--file=out", "--errs=errs"]
+        self.args += [str(fakefile)]
+        self.cli.invoke(self.args, strict=True)
+
+        o, e = capfd.readouterr()
+        assert o == ""
+        assert (e == "" or e.startswith('Using OMERO.java-'))
+
+        outlines = tmpdir.join("out").read().split("\n")
+        reader = 'loci.formats.in.FakeReader'
+        assert outlines[-2] == str(fakefile)
+        assert outlines[-3] == \
+            "# Group: %s SPW: false Reader: %s" % (str(fakefile), reader)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails on Windows")
     def testYamlOutput(self, tmpdir, capfd):
 
         import yaml


### PR DESCRIPTION
Fixes #212

Currently `omero import` will fail if `--log/--err` are specified as files relative to the current directory without `--logprefix`. The workaround is either to set `--logprefix` or pass absolute paths to the log options.  f1b85cc introduces a new unit test which should fail with the current version of `omero-py` (see https://travis-ci.org/github/sbesson/omero-py/jobs/712819681).   384ecf5 fixes the issue by systematically computing the absolute path of the target log files.

