### PR TITLE
Use requests for HTTP/HTTPS calls in library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
         'PyYAML',
         'zeroc-ice>=3.6.4,<3.7',
         'pywin32; platform_system=="Windows"',
+        'requests'
     ],
     tests_require=[
         'pytest',

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -35,7 +35,7 @@ import os
 import csv
 import sys
 import shlex
-from urllib.request import urlopen
+import requests
 from zipfile import ZipFile
 
 
@@ -575,8 +575,8 @@ class ImportControl(BaseControl):
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         if not jars_dir.exists():
             jars_dir.mkdir()
-        with urlopen(omero_java_zip) as resp:
-            with ZipFile(BytesIO(resp.read())) as zipfile:
+        with requests.get(omero_java_zip) as resp:
+            with ZipFile(BytesIO(resp.content)) as zipfile:
                 topdirs = set(f.filename.split(
                     os.path.sep)[0] for f in zipfile.filelist if f.is_dir())
                 if len(topdirs) != 1:

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -312,8 +312,14 @@ class ImportControl(BaseControl):
         for name, help in (
             ("bulk", "Bulk YAML file for driving multiple imports"),
             ("logprefix", "Directory or file prefix for --file and --errs"),
-            ("file", "File for storing the standard output from the Java process"),
-            ("errs", "File for storing the standard error from the Java process")
+            (
+                "file",
+                "File for storing the standard output from the Java process"
+            ),
+            (
+                "errs",
+                "File for storing the standard error from the Java process"
+            )
         ):
             add_python_argument("--%s" % name, nargs="?", help=help)
             add_python_argument("---%s" % name, nargs="?", help=SUPPRESS)
@@ -766,6 +772,7 @@ class ImportControl(BaseControl):
 
 class TestEngine(ImportControl):
     COMMAND = [TEST_CLASS]
+
 
 try:
     register("import", ImportControl, HELP, epilog=EXAMPLES)

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -45,8 +45,8 @@ class UpgradeCheck(object):
     """
 
     #
-    # Default timeout is 3 seconds.
-    # * http://docs.python.org/2/library/socket.html#socket.setdefaulttimeout
+    # requests timeout, default is no timeout
+    # * https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
     #
     DEFAULT_TIMEOUT = 6.0
 

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -45,7 +45,7 @@ class UpgradeCheck(object):
     """
 
     #
-    # requests timeout, default is no timeout
+    # our default timeout to use for requests; package default is no timeout
     # * https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
     #
     DEFAULT_TIMEOUT = 6.0

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -6,7 +6,6 @@
 """
 
 from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import object
 from omero_version import omero_version
@@ -14,6 +13,7 @@ from omero_version import omero_version
 import platform
 import logging
 import requests
+standard_library.install_aliases()
 
 
 class UpgradeCheck(object):
@@ -100,7 +100,7 @@ class UpgradeCheck(object):
                                      platform.mac_ver()[0])
             else:
                 version = platform.platform()
-        except:
+        except Exception:
             version = platform.platform()
         return version
 

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -13,9 +13,7 @@ from omero_version import omero_version
 
 import platform
 import logging
-import urllib.request, urllib.error, urllib.parse
-import urllib.request, urllib.parse, urllib.error
-import socket
+import requests
 
 
 class UpgradeCheck(object):
@@ -129,20 +127,13 @@ class UpgradeCheck(object):
             params["python.version"] = platform.python_version()
             params["python.compiler"] = platform.python_compiler()
             params["python.build"] = platform.python_build()
-            params = urllib.parse.urlencode(params)
 
-            old_timeout = socket.getdefaulttimeout()
-            try:
-                socket.setdefaulttimeout(self.timeout)
-                full_url = "%s?%s" % (self.url, params)
-                request = urllib.request.Request(full_url)
-                request.add_header('User-Agent', self.agent)
-                self.log.debug("Attempting to connect to %s" % full_url)
-                response = urllib.request.urlopen(request)
-                result = response.read()
-            finally:
-                socket.setdefaulttimeout(old_timeout)
-
+            headers = {'User-Agent': self.agent}
+            request = requests.get(
+                self.url, headers=headers, params=params,
+                timeout=self.DEFAULT_TIMEOUT
+            )
+            result = request.text
         except Exception as e:
             self.log.error(str(e), exc_info=0)
             self._set(None, e)

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -143,5 +143,5 @@ class UpgradeCheck(object):
             self.log.info("no update needed")
             self._set(None, None)
         else:
-            self.log.warn("UPGRADE AVAILABLE:" + result.decode('utf-8'))
-            self._set(result.decode('utf-8'), None)
+            self.log.warn("UPGRADE AVAILABLE:" + result)
+            self._set(result, None)


### PR DESCRIPTION
CentOS 7 ships with version 1.0.2k of OpenSSL.  These versions of OpenSSL had various forms of global state that the Ice developers decided, likely for a very good reason, to cleanup when the Ice OpenSSL engine is destroyed:

 * https://github.com/zeroc-ice/ice/blob/3.6/cpp/src/IceSSL/OpenSSLEngine.cpp#L350

Unfortunately, calling `EVP_Cleanup()` like this causes the global algorithms table to end up missing and/or corrupt:

 * https://stackoverflow.com/questions/31549652/ssl-ctx-newunable-to-load-ssl2-md5-routines
 * google/keyczar#135

This will break other uses of OpenSSL in the same process. The most obvious condition where this can occur is making an HTTPS request after an OMERO session has been closed. For example (Ubuntu 16.04, OpenSSL 1.0.2g):

```
$ omero shell --login
Created session for chris.allan@localhost:4064. Idle timeout: 10 min. Current group: chris.allan
Python 3.5.2 (default, Oct  8 2019, 13:06:37)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: client.closeSession()

In [2]: import urllib

In [3]: urllib.request.urlopen('http://www.glencoesoftware.com/').read()
---------------------------------------------------------------------------
SSLError                                  Traceback (most recent call last)
<ipython-input-3-474f67ef9573> in <module>
----> 1 urllib.request.urlopen('http://www.glencoesoftware.com/').read()

/usr/lib/python3.5/urllib/request.py in urlopen(url, data, timeout, cafile, capath, cadefault, context)
    161     else:
    162         opener = _opener
--> 163     return opener.open(url, data, timeout)
    164
    165 def install_opener(opener):

/usr/lib/python3.5/urllib/request.py in open(self, fullurl, data, timeout)
    470         for processor in self.process_response.get(protocol, []):
    471             meth = getattr(processor, meth_name)
--> 472             response = meth(req, response)
    473
    474         return response

/usr/lib/python3.5/urllib/request.py in error(self, proto, *args)
    502             http_err = 0
    503         args = (dict, proto, meth_name) + args
--> 504         result = self._call_chain(*args)
    505         if result:
    506             return result

/usr/lib/python3.5/urllib/request.py in _call_chain(self, chain, kind, meth_name, *args)
    442         for handler in handlers:
    443             func = getattr(handler, meth_name)
--> 444             result = func(*args)
    445             if result is not None:
    446                 return result

/usr/lib/python3.5/urllib/request.py in http_error_302(self, req, fp, code, msg, headers)
    694         fp.close()
    695
--> 696         return self.parent.open(new, timeout=req.timeout)
    697
    698     http_error_301 = http_error_303 = http_error_307 = http_error_302

/usr/lib/python3.5/urllib/request.py in open(self, fullurl, data, timeout)
    464             req = meth(req)
    465
--> 466         response = self._open(req, data)
    467
    468         # post-process response

/usr/lib/python3.5/urllib/request.py in _open(self, req, data)
    482         protocol = req.type
    483         result = self._call_chain(self.handle_open, protocol, protocol +
--> 484                                   '_open', req)
    485         if result:
    486             return result

/usr/lib/python3.5/urllib/request.py in _call_chain(self, chain, kind, meth_name, *args)
    442         for handler in handlers:
    443             func = getattr(handler, meth_name)
--> 444             result = func(*args)
    445             if result is not None:
    446                 return result

/usr/lib/python3.5/urllib/request.py in https_open(self, req)
   1295         def https_open(self, req):
   1296             return self.do_open(http.client.HTTPSConnection, req,
-> 1297                 context=self._context, check_hostname=self._check_hostname)
   1298
   1299         https_request = AbstractHTTPHandler.do_request_

/usr/lib/python3.5/urllib/request.py in do_open(self, http_class, req, **http_conn_args)
   1221
   1222         # will parse host:port
-> 1223         h = http_class(host, timeout=req.timeout, **http_conn_args)
   1224         h.set_debuglevel(self._debuglevel)
   1225

/usr/lib/python3.5/http/client.py in __init__(self, host, port, key_file, cert_file, timeout, source_address, context, check_hostname)
   1251             self.cert_file = cert_file
   1252             if context is None:
-> 1253                 context = ssl._create_default_https_context()
   1254             will_verify = context.verify_mode != ssl.CERT_NONE
   1255             if check_hostname is None:

/usr/lib/python3.5/ssl.py in create_default_context(purpose, cafile, capath, cadata)
    439         raise TypeError(purpose)
    440
--> 441     context = SSLContext(PROTOCOL_SSLv23)
    442
    443     # SSLv2 considered harmful.

/usr/lib/python3.5/ssl.py in __new__(cls, protocol, *args, **kwargs)
    359
    360     def __new__(cls, protocol, *args, **kwargs):
--> 361         self = _SSLContext.__new__(cls, protocol)
    362         if protocol != _SSLv2_IF_EXISTS:
    363             self.set_ciphers(_DEFAULT_CIPHERS)

SSLError: ('failed to allocate SSL context',)
```

The easiest way to work around this is to bring `pyopenssl`, which is linked against a version of OpenSSL we control, into the equation.  In order to have both OpenSSL versions functional in the process we need to use a Python package that is mindful of these conditions and will optionally use `pyopenssl` if it is available.  `requests` is such a package.  Using `requests` with `pyopenssl` installed this should be your output:

```
$ omero shell --login
Using session for chris.allan@localhost:4064. Idle timeout: 10 min. Current group: chris.allan
Python 3.5.2 (default, Oct  8 2019, 13:06:37)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.9.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: client.closeSession()

In [2]: import requests

In [3]: r = requests.get('https://www.glencoesoftware.com/')

In [4]: r.status_code
Out[4]: 200

In [5]:
```

This PR makes changes to the usage of `urllib` in the library to use `requests` instead.