### PR TITLE
Use OS specific application directories instead of ~/omero

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ setup(
     },
     python_requires='>=3',
     install_requires=[
+        'appdirs',
         'future',
         'numpy',
         'Pillow',

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -579,8 +579,7 @@ class ImportControl(BaseControl):
         omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
         self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
-        if not jars_dir.exists():
-            jars_dir.mkdir()
+        jars_dir.makedirs_p()
         with requests.get(omero_java_zip) as resp:
             with ZipFile(BytesIO(resp.content)) as zipfile:
                 topdirs = set(f.filename.split(

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -46,7 +46,7 @@ orig_stdout = sys.stdout
 orig_stderr = sys.stderr
 
 # Application name, Author (Windows only), Major version
-APPDIR_DEFAULTS = ('OMERO.cli', 'OME', omero_version.split('.')[0])
+APPDIR_DEFAULTS = ('OMERO.py', 'OME', omero_version.split('.')[0])
 
 
 def make_logname(self):

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -845,6 +845,8 @@ def get_omero_userdir():
     In 6.0.0 the default will change to use appdirs.user_data_dir.
     You can enable this behaviour now by setting OMERO_USERDIR="" (empty
     string) instead of unset.
+
+    Note that files in the old user directory will not be migrated.
     """
     omero_userdir = os.environ.get('OMERO_USERDIR', None)
     if omero_userdir:

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -45,7 +45,7 @@ LOGMODE = "a"
 orig_stdout = sys.stdout
 orig_stderr = sys.stderr
 
-# Application name, Owner (Windows only), Major version
+# Application name, Author (Windows only), Major version
 APPDIR_DEFAULTS = ('OMERO.cli', 'OME', omero_version.split('.')[0])
 
 

--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -859,7 +859,7 @@ def get_omero_user_cache_dir():
     """Returns the OMERO user cache directory"""
     omero_userdir = os.environ.get('OMERO_USERDIR', None)
     if omero_userdir:
-        return path.path(omero_userdir)
+        return path.path(omero_userdir) / "cache"
     else:
         return path.path(user_cache_dir(*APPDIR_DEFAULTS))
 

--- a/test/unit/clitest/test_export.py
+++ b/test/unit/clitest/test_export.py
@@ -65,7 +65,7 @@ class TestExport(object):
         self.cli.invoke(string, strict=True)
 
     def testSimpleExport(self):
-        self.invoke("x -f %s Image:3" % self.p)
+        self.invoke(["x", "-f", self.p, "Image:3"])
 
     def testStdOutExport(self):
         """

--- a/test/unit/clitest/test_prefs.py
+++ b/test/unit/clitest/test_prefs.py
@@ -188,23 +188,23 @@ class TestPrefs(object):
     def testLoad(self, capsys):
         to_load = create_path()
         to_load.write_text("A=B")
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.assertStdoutStderr(capsys)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=B")
 
         # Same property/value pairs should pass
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
 
         to_load.write_text("A=C")
         with pytest.raises(NonZeroReturnCode):
             # Different property/value pair should fail
-            self.invoke("load %s" % to_load)
+            self.invoke(["load", to_load])
         self.assertStdoutStderr(
             capsys, err="Duplicate property: A ('B' => 'C')")
 
         # Quiet load
-        self.invoke("load -q %s" % to_load)
+        self.invoke(["load", "-q", to_load])
         self.assertStdoutStderr(capsys)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=C")
@@ -217,7 +217,7 @@ class TestPrefs(object):
     def testLoadMultiLine(self, capsys):
         to_load = create_path()
         to_load.write_text("A=B\\\nC")
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=BC")
 
@@ -228,7 +228,7 @@ class TestPrefs(object):
         valid_key, valid_value = validkeyvalue
         to_load = create_path()
         to_load.write_text("%s=%s\n" % (valid_key, valid_value))
-        self.invoke("load %s" % to_load)
+        self.invoke(["load", to_load])
         self.invoke("get %s" % valid_key)
         self.assertStdoutStderr(capsys, out=valid_value)
 
@@ -244,7 +244,7 @@ class TestPrefs(object):
         to_load = create_path()
         to_load.write_text("C=D\n%s\nH=I\n" % invalidline)
         with pytest.raises(NonZeroReturnCode):
-            self.invoke("load %s" % to_load)
+            self.invoke(["load", to_load])
         self.assertStdoutStderr(
             capsys, err="Illegal property name: %s" % invalidkey)
         self.invoke("get")
@@ -269,7 +269,7 @@ class TestPrefs(object):
     def testSetFromFile(self, capsys):
         to_load = create_path()
         to_load.write_text("Test")
-        self.invoke("set -f %s A" % to_load)
+        self.invoke(["set", "-f", to_load, "A"])
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=Test")
 

--- a/test/unit/clitest/test_sessions.py
+++ b/test/unit/clitest/test_sessions.py
@@ -53,7 +53,7 @@ class TestSessions(object):
 
         # Default store sessions dir is under user dir
         store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(get_user_dir()) / 'omero' / 'sessions'
+        assert store.dir == path(get_user_dir()) / 'sessions'
 
     @pytest.mark.parametrize('environment', (
         {'OMERO_USERDIR': None,
@@ -115,5 +115,5 @@ class TestSessions(object):
         elif environment.get('OMERO_USERDIR'):
             sdir = path(tmpdir) / environment.get('OMERO_USERDIR') / 'sessions'
         else:
-            sdir = path(get_user_dir()) / 'omero' / 'sessions'
+            sdir = path(get_user_dir()) / 'sessions'
         assert store.dir == str(sdir)

--- a/test/unit/clitest/test_sessions.py
+++ b/test/unit/clitest/test_sessions.py
@@ -53,7 +53,7 @@ class TestSessions(object):
 
         # Default store sessions dir is under user dir
         store = self.cli.controls['sessions'].store(None)
-        assert store.dir == path(get_user_dir()) / 'sessions'
+        assert store.dir == path(get_user_dir()) / 'omero' / 'sessions'
 
     @pytest.mark.parametrize('environment', (
         {'OMERO_USERDIR': None,
@@ -115,5 +115,5 @@ class TestSessions(object):
         elif environment.get('OMERO_USERDIR'):
             sdir = path(tmpdir) / environment.get('OMERO_USERDIR') / 'sessions'
         else:
-            sdir = path(get_user_dir()) / 'sessions'
+            sdir = path(get_user_dir()) / 'omero' / 'sessions'
         assert store.dir == str(sdir)

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -232,7 +232,7 @@ class TestTempFileManager(object):
         elif environment.get('OMERO_USERDIR'):
             tdir = tmpdir / environment.get('OMERO_USERDIR') / "tmp"
         else:
-            tdir = path(get_user_dir()) / "tmp"
+            tdir = path(get_user_dir()) / "omero" / "tmp"
 
         assert value == str(tdir)
 
@@ -244,7 +244,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "tmp"
+        assert value == path(get_user_dir()) / "omero" / "tmp"
 
     def testTmpdir2805_2(self, monkeypatch, tmpdir):
 
@@ -256,7 +256,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "tmp"
+        assert value == path(get_user_dir()) / "omero" / "tmp"
 
 
 class TestImageUtils(object):

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -39,7 +39,8 @@ from os import linesep
 from omero.util.text import CSVStyle, JSONStyle, PlainStyle, TableBuilder
 from omero.util.upgrade_check import UpgradeCheck
 from omero.util.temp_files import manager
-from omero.util import get_omero_userdir, get_user_dir
+from omero.util import (
+    get_omero_userdir, get_omero_user_cache_dir, get_user_dir)
 from omero_version import omero_version
 import omero.util.image_utils as image_utils
 try:
@@ -320,14 +321,27 @@ class TestUserdirs(object):
 
     def testUserdirEnvironmentDefault(self, monkeypatch):
         monkeypatch.delenv('OMERO_USERDIR', raising=False)
+
         assert get_omero_userdir().basename() == 'omero'
+
+        c = get_omero_user_cache_dir()
+        assert c.basename() == omero_version.split('.')[0]
+        assert 'OMERO.cli' in str(c)
 
     def testUserdirEnvironmentAppdir(self, monkeypatch):
         monkeypatch.setenv('OMERO_USERDIR', '')
+
         d = get_omero_userdir()
         assert d.basename() == omero_version.split('.')[0]
         assert 'OMERO.cli' in str(d)
 
+        c = get_omero_user_cache_dir()
+        assert c.basename() == omero_version.split('.')[0]
+        assert 'OMERO.cli' in str(c)
+
     def testUserdirEnvironmentSet(self, monkeypatch, tmpdir):
         monkeypatch.setenv('OMERO_USERDIR', str(tmpdir))
+
         assert get_omero_userdir() == tmpdir
+
+        assert get_omero_user_cache_dir() == tmpdir

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -326,18 +326,18 @@ class TestUserdirs(object):
 
         c = get_omero_user_cache_dir()
         assert c.basename() == omero_version.split('.')[0]
-        assert 'OMERO.cli' in str(c)
+        assert 'OMERO.py' in str(c)
 
     def testUserdirEnvironmentAppdir(self, monkeypatch):
         monkeypatch.setenv('OMERO_USERDIR', '')
 
         d = get_omero_userdir()
         assert d.basename() == omero_version.split('.')[0]
-        assert 'OMERO.cli' in str(d)
+        assert 'OMERO.py' in str(d)
 
         c = get_omero_user_cache_dir()
         assert c.basename() == omero_version.split('.')[0]
-        assert 'OMERO.cli' in str(c)
+        assert 'OMERO.py' in str(c)
 
     def testUserdirEnvironmentSet(self, monkeypatch, tmpdir):
         monkeypatch.setenv('OMERO_USERDIR', str(tmpdir))

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -232,7 +232,7 @@ class TestTempFileManager(object):
         elif environment.get('OMERO_USERDIR'):
             tdir = tmpdir / environment.get('OMERO_USERDIR') / "tmp"
         else:
-            tdir = path(get_user_dir()) / "omero" / "tmp"
+            tdir = path(get_user_dir()) / "tmp"
 
         assert value == str(tdir)
 
@@ -244,7 +244,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "omero" / "tmp"
+        assert value == path(get_user_dir()) / "tmp"
 
     def testTmpdir2805_2(self, monkeypatch, tmpdir):
 
@@ -256,7 +256,7 @@ class TestTempFileManager(object):
         tmpfile.write('')
 
         value = pytest.deprecated_call(manager.tmpdir)
-        assert value == path(get_user_dir()) / "omero" / "tmp"
+        assert value == path(get_user_dir()) / "tmp"
 
 
 class TestImageUtils(object):

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -344,4 +344,4 @@ class TestUserdirs(object):
 
         assert get_omero_userdir() == tmpdir
 
-        assert get_omero_user_cache_dir() == tmpdir
+        assert get_omero_user_cache_dir() == tmpdir / "cache"

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -39,7 +39,7 @@ from os import linesep
 from omero.util.text import CSVStyle, JSONStyle, PlainStyle, TableBuilder
 from omero.util.upgrade_check import UpgradeCheck
 from omero.util.temp_files import manager
-from omero.util import get_user_dir
+from omero.util import get_omero_userdir, get_user_dir
 from omero_version import omero_version
 import omero.util.image_utils as image_utils
 try:
@@ -314,3 +314,20 @@ class TestImageUtils(object):
         data_canvas[256, 256] = [255, 255, 0]
         canvas = Image.fromarray(data_canvas, 'RGB')
         image_utils.paste_image(img, canvas, 0, 0)
+
+
+class TestUserdirs(object):
+
+    def testUserdirEnvironmentDefault(self, monkeypatch):
+        monkeypatch.delenv('OMERO_USERDIR', raising=False)
+        assert get_omero_userdir().basename() == 'omero'
+
+    def testUserdirEnvironmentAppdir(self, monkeypatch):
+        monkeypatch.setenv('OMERO_USERDIR', '')
+        d = get_omero_userdir()
+        assert d.basename() == omero_version.split('.')[0]
+        assert 'OMERO.cli' in str(d)
+
+    def testUserdirEnvironmentSet(self, monkeypatch, tmpdir):
+        monkeypatch.setenv('OMERO_USERDIR', str(tmpdir))
+        assert get_omero_userdir() == tmpdir


### PR DESCRIPTION
This is https://github.com/ome/omero-py/pull/233 rebased and modified to only use the `user_cache_dir` property. `get_omero_userdir()` is unchanged (still returns `~/omero`) but this can be changed to `user_data_dir` in 6.0.0 when breaking changes are allowed.

You can enable the new behaviour for `get_omero_userdir()` by setting `OMERO_USERDIR=""` (empty string, as opposed to not setting it).

Related to https://github.com/ome/omero-py/issues/210 but does not fully resolve it- need to wait until the new behaviour is the default

No migration options are supported since the cache dir has not yet been released. Longer term I'm inclined not to, AFAIK at the moment sessions are the only meaningful state stored under `~/omero`, and since a major release probably implies a major release of the server and therefore a restart there's no point migrating an old session.

Decisions:
- [x] Include the major version (currently `5`, will be `6` in future) in the directory path or not.