### PR TITLE
fs usage: don't overwrite size (Fix #243)

### DIFF
--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -929,18 +929,21 @@ Examples:
             self.ctx.err(err)
         else:
             size = sum(rsp.totalBytesUsed.values())
+            if args.human_readable:
+                size_str = filesizeformat(size)
+            else:
+                size_str = f"{size}"
+
             if args.size_only:
-                self.ctx.out(size)
+                self.ctx.out(size_str)
             else:
                 files = sum(rsp.totalFileCount.values())
                 if args.units:
-                    size = ("%s %siB"
+                    size_str = ("%s %siB"
                             % (self._to_units(size, args.units), args.units))
-                elif args.human_readable:
-                    size = filesizeformat(size)
                 self.ctx.out(
                     "Total disk usage: %s bytes in %d files"
-                    % (size, files))
+                    % (size_str, files))
 
             if args.report and not args.size_only and size > 0:
                 self._detailed_usage_report(req, rsp, status, args)


### PR DESCRIPTION
see  https://github.com/ome/omero-py/issues/243

```
  File "/tmp/omero/lib/python3.7/site-packages/omero/plugins/fs.py", line 945, in _usage_report
    if args.report and not args.size_only and size > 0:
TypeError: '>' not supported between instances of 'str' and 'int'
```