### PR TITLE
admin.py: optionally check for system manager environment variable

### DIFF
--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1160,7 +1160,7 @@ class ServiceManagerMixin:
             if not service_envvalue:
                 self.ctx.die(112, (
                     "ERROR: OMERO is configured to run under a service "
-                    "manager but {} is not set".format(service_env)))
+                    "manager which should also set {}".format(service_env)))
 
 
 class CLI(cmd.Cmd, Context):

--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1131,6 +1131,38 @@ OMERO Diagnostics (%s) %s
                 self.ctx.out("%-12s %s" % (self._sz_str(p.size), msg))
 
 
+class ServiceManagerMixin:
+    """
+    A mixin that adds a requires_service_manager method.
+
+    This method can be called to check for the presence of an environment
+    variable that indicates the plugin is being controlled by an external
+    service manager.
+
+    The class must define a property SERVICE_MANAGER_KEY that is used to
+    construct the name of the OMERO property
+    `omero.{SERVICE_MANAGER_KEY}.servicemanager.checkenv` defining the name of
+    the environment variable.
+    """
+
+    def requires_service_manager(self, config):
+        """
+        Checks whether OMERO is being managed by a service manager by
+        checking that a specified environment variable is non-empty.
+
+        config: An OMERO ConfigXml object
+        """
+        service_env = config.as_map().get(
+            "omero.{}.servicemanager.checkenv".format(
+                self.SERVICE_MANAGER_KEY))
+        if service_env:
+            service_envvalue = os.getenv(service_env)
+            if not service_envvalue:
+                self.ctx.die(112, (
+                    "ERROR: OMERO is configured to run under a service "
+                    "manager but {} is not set".format(service_env)))
+
+
 class CLI(cmd.Cmd, Context):
     """
     Command line interface class. Supports various styles of executing the

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -721,6 +721,20 @@ present, the user will enter a console""")
                          % os.path.sep.join(["etc", "grid", __d__]))
         return descript
 
+    def _requires_service_manager(self, config):
+        """
+        Checks whether OMERO is being managed by a service manager by
+        checking that a specified environment variable is non-empty
+        """
+        service_env = config.as_map().get(
+            "omero.admin.servicemanager.checkenv")
+        if service_env:
+            service_envvalue = os.getenv(service_env)
+            if not service_envvalue:
+                self.ctx.die(112, (
+                    "ERROR: OMERO is configured to run under a service "
+                    "manager but {} is not set".format(service_env)))
+
     def checkwindows(self, args):
         r"""
         Checks that the templates file as defined in etc\Windows.cfg
@@ -760,6 +774,7 @@ present, the user will enter a console""")
         First checks for a valid installation, then checks the grid,
         then registers the action: "node HOST start"
         """
+        self._requires_service_manager(config)
         self.check_access(mask=os.R_OK, config=config)
         self.checkice()
         self.check_node(args)
@@ -974,6 +989,7 @@ present, the user will enter a console""")
         """
         Returns true if the server was already stopped
         """
+        self._requires_service_manager(config)
         self.check_node(args)
         if args.force_rewrite:
             self.rewrite(args, config, force=True)

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -42,6 +42,7 @@ from omero.cli import (
     DiagnosticsControl,
     DirectoryType,
     NonZeroReturnCode,
+    ServiceManagerMixin,
     UserGroupControl,
 )
 
@@ -93,7 +94,11 @@ if platform.system() == 'Windows':
 
 class AdminControl(DiagnosticsControl,
                    WriteableConfigControl,
-                   UserGroupControl):
+                   UserGroupControl,
+                   ServiceManagerMixin):
+
+    # Require by omero.cli.ServiceManagerMixin
+    SERVICE_MANAGER_KEY = 'server'
 
     def _complete(self, text, line, begidx, endidx):
         """
@@ -723,20 +728,6 @@ present, the user will enter a console""")
                          % os.path.sep.join(["etc", "grid", __d__]))
         return descript
 
-    def _requires_service_manager(self, config):
-        """
-        Checks whether OMERO is being managed by a service manager by
-        checking that a specified environment variable is non-empty
-        """
-        service_env = config.as_map().get(
-            "omero.admin.servicemanager.checkenv")
-        if service_env:
-            service_envvalue = os.getenv(service_env)
-            if not service_envvalue:
-                self.ctx.die(112, (
-                    "ERROR: OMERO is configured to run under a service "
-                    "manager but {} is not set".format(service_env)))
-
     def checkwindows(self, args):
         r"""
         Checks that the templates file as defined in etc\Windows.cfg
@@ -776,7 +767,7 @@ present, the user will enter a console""")
         First checks for a valid installation, then checks the grid,
         then registers the action: "node HOST start"
         """
-        self._requires_service_manager(config)
+        self.requires_service_manager(config)
         self.check_access(mask=os.R_OK, config=config)
         self.checkice()
         self.check_node(args)
@@ -991,7 +982,7 @@ present, the user will enter a console""")
         """
         Returns true if the server was already stopped
         """
-        self._requires_service_manager(config)
+        self.requires_service_manager(config)
         self.check_node(args)
         if args.force_rewrite:
             self.rewrite(args, config, force=True)

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -36,12 +36,14 @@ import omero.config
 
 from omero.grid import RawAccessRequest
 
-from omero.cli import admin_only
-from omero.cli import CLI
-from omero.cli import DirectoryType
-from omero.cli import NonZeroReturnCode
-from omero.cli import DiagnosticsControl
-from omero.cli import UserGroupControl
+from omero.cli import (
+    admin_only,
+    CLI,
+    DiagnosticsControl,
+    DirectoryType,
+    NonZeroReturnCode,
+    UserGroupControl,
+)
 
 from omero.install.config_parser import PropertyParser
 from omero.plugins.prefs import \

--- a/test/unit/clitest/mocks.py
+++ b/test/unit/clitest/mocks.py
@@ -90,6 +90,12 @@ class MockCLI(CLI):
         finally:
             self.__error = []
 
+    def getStdout(self):
+        return self.__output
+
+    def getStderr(self):
+        return self.__error
+
     def addCall(self, rv):
         self.__call.append(rv)
 

--- a/test/unit/clitest/test_admin.py
+++ b/test/unit/clitest/test_admin.py
@@ -242,32 +242,6 @@ class TestAdmin(object):
         assert 0 == self.cli.rv
 
 
-class TestAdminCommandsFailFast(object):
-    # These commands should fail immediately so there's no need for the full
-    # setup
-
-    @pytest.fixture(autouse=True)
-    def setup_method(self, tmpdir, monkeypatch):
-        # Other setup
-        self.cli = MockCLI()
-        monkeypatch.setenv('OMERODIR', str(tmpdir))
-        self.cli.dir = tmpdir
-        self.cli.register("admin", AdminControl, "TEST")
-        self.cli.register("config", PrefsControl, "TEST")
-
-    @pytest.mark.parametrize("command", ["start", "stop", "restart"])
-    def testCheckServiceManagerEnv(self, command):
-        self.cli.invoke([
-            "config", "set",
-            "omero.admin.servicemanager.checkenv",
-            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV"],
-            strict=True)
-        self.cli.invoke(["admin", command, "--force-rewrite"], strict=False)
-        assert self.cli.getStderr()[-1] == (
-            "ERROR: OMERO is configured to run under a service manager but "
-            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV is not set")
-
-
 def check_registry(topdir, prefix='', registry=4061, **kwargs):
     for key in ['master.cfg', 'internal.cfg']:
         s = path(old_div(topdir, "etc" / key)).text()

--- a/test/unit/clitest/test_admin.py
+++ b/test/unit/clitest/test_admin.py
@@ -242,6 +242,32 @@ class TestAdmin(object):
         assert 0 == self.cli.rv
 
 
+class TestAdminCommandsFailFast(object):
+    # These commands should fail immediately so there's no need for the full
+    # setup
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, tmpdir, monkeypatch):
+        # Other setup
+        self.cli = MockCLI()
+        monkeypatch.setenv('OMERODIR', str(tmpdir))
+        self.cli.dir = tmpdir
+        self.cli.register("admin", AdminControl, "TEST")
+        self.cli.register("config", PrefsControl, "TEST")
+
+    @pytest.mark.parametrize("command", ["start", "stop", "restart"])
+    def testCheckServiceManagerEnv(self, command):
+        self.cli.invoke([
+            "config", "set",
+            "omero.admin.servicemanager.checkenv",
+            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV"],
+            strict=True)
+        self.cli.invoke(["admin", command, "--force-rewrite"], strict=False)
+        assert self.cli.getStderr()[-1] == (
+            "ERROR: OMERO is configured to run under a service manager but "
+            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV is not set")
+
+
 def check_registry(topdir, prefix='', registry=4061, **kwargs):
     for key in ['master.cfg', 'internal.cfg']:
         s = path(old_div(topdir, "etc" / key)).text()

--- a/test/unit/clitest/test_admin_noomerodir.py
+++ b/test/unit/clitest/test_admin_noomerodir.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+from omero.plugins.admin import AdminControl
+from omero.plugins.prefs import PrefsControl
+
+from mocks import MockCLI
+
+
+class TestAdminCommandsFailFast(object):
+    # These commands should fail immediately so there's no need for the full
+    # setup
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, tmpdir, monkeypatch):
+        # Other setup
+        self.cli = MockCLI()
+        monkeypatch.setenv('OMERODIR', str(tmpdir))
+        self.cli.dir = tmpdir
+        self.cli.register("admin", AdminControl, "TEST")
+        self.cli.register("config", PrefsControl, "TEST")
+
+    @pytest.mark.parametrize("command", ["start", "stop", "restart"])
+    def testCheckServiceManagerEnv(self, command):
+        self.cli.invoke([
+            "config", "set",
+            "omero.admin.servicemanager.checkenv",
+            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV"],
+            strict=True)
+        self.cli.invoke(["admin", command, "--force-rewrite"], strict=False)
+        assert self.cli.getStderr()[-1] == (
+            "ERROR: OMERO is configured to run under a service manager but "
+            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV is not set")

--- a/test/unit/clitest/test_admin_noomerodir.py
+++ b/test/unit/clitest/test_admin_noomerodir.py
@@ -62,8 +62,8 @@ class TestServiceManagerMixin:
             'TEST_SERVICEMANAGER_MIXIN'}))
         assert cli.ctx._die_args == [(
             112,
-            "ERROR: OMERO is configured to run under a service manager but "
-            "TEST_SERVICEMANAGER_MIXIN is not set")]
+            "ERROR: OMERO is configured to run under a service manager which "
+            "should also set TEST_SERVICEMANAGER_MIXIN")]
 
 
 class TestAdminCommandsFailFast(object):
@@ -88,5 +88,5 @@ class TestAdminCommandsFailFast(object):
             strict=True)
         self.cli.invoke(["admin", command, "--force-rewrite"], strict=False)
         assert self.cli.getStderr()[-1] == (
-            "ERROR: OMERO is configured to run under a service manager but "
-            "TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV is not set")
+            "ERROR: OMERO is configured to run under a service manager which "
+            "should also set TESTOMERO_ADMIN_SERVICEMANAGER_CHECKENV")


### PR DESCRIPTION
Adds a config property that can be set to the name of an environment variable that is only set when running under systemd or some other service manager. `omero admin start|stop` will check this variable and abort if it's not set.

## Example using systemd
If you have systemd v232+ the `INVOCATION_ID` environment variable should be set by systemd so you can check for this https://serverfault.com/a/927481
```
$ cat /opt/omero/server/config/10-systemd.omero
config set omero.server.servicemanager.checkenv INVOCATION_ID
```

If you have an older version of systemd you can define your own non-empty variable in your systemd service file:
```diff
[Service]
User=omero-server
UMask=0002
Type=forking
PIDFile=/opt/omero/server/OMERO.server/var/master/master.pid
Restart=no
RestartSec=10
+Environment=CHECK_FOR_THIS_VARIABLE=something
# Allow up to 5 min for start/stop
TimeoutSec=300
ExecStartPre=/opt/omero/server/OMERO.server/bin/omero load --glob /opt/omero/server/config/*.omero
ExecStart=/opt/omero/server/OMERO.server/bin/omero admin start
ExecStop=/opt/omero/server/OMERO.server/bin/omero admin stop
```

```
$ cat /opt/omero/server/config/10-systemd.omero
config set omero.server.servicemanager.checkenv CHECK_FOR_THIS_VARIABLE
```

If you then attempt to start/stop omero outside systemd:
```
[vagrant@omero ~]$ sudo systemctl start omero-server
[vagrant@omero ~]$ sudo -u omero-server /opt/omero/server/OMERO.server/bin/omero admin stop
ERROR: OMERO is configured to run under a service manager but CHECK_FOR_THIS_VARIABLE is not set
[vagrant@omero ~]$ sudo -u omero-server /opt/omero/server/OMERO.server/bin/omero admin restart
ERROR: OMERO is configured to run under a service manager but CHECK_FOR_THIS_VARIABLE is not set
```

Note since the omero configuration is updated from `/opt/omero/server/config/*.omero` you must've started omero at least once with systemd after updating the configuration.

I'll document this property in https://github.com/ome/openmicroscopy/blob/develop/etc/omero.properties if everyone is happy with this.

Includes a test, though I had to put it in a new file because `test_admin.py` contains a global autouser fixture that requires `OMERODIR`, which means it's not tested on Travis.

A similar property can be added to `omero web`. Since these are decoupled I don't think they should share the same property, instead it would be `omero.web.servicemanager.checkenv`.

@stick 

Note this was updated so the property is now `omero.server.servicemanager.checkenv`, not `omero.admin.servicemanager.checkenv`