### PR TITLE
Add support for mutliple Ice TLS protocols

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -243,7 +243,8 @@ class BaseClient(object):
 
         self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
-        self._optSetProp(id, "IceSSL.Protocols", "tls1")
+        self._optSetProp(id, "IceSSL.ProtocolVersionMax", "tls1_2")
+        self._optSetProp(id, "IceSSL.Protocols", "tls1_0,tls1_1,tls1_2")
 
         # Setting block size
         self._optSetProp(

--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -243,7 +243,6 @@ class BaseClient(object):
 
         self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
-        self._optSetProp(id, "IceSSL.ProtocolVersionMax", "tls1_2")
         self._optSetProp(id, "IceSSL.Protocols", "tls1_0,tls1_1,tls1_2")
 
         # Setting block size


### PR DESCRIPTION
The issue was noticed when trying to connect running server on Ubuntu20.04 or CentOS 8
It was possible to connect for example from a mac to Ubuntu20.04 server but not possible to connect to Ubuntu20.04 to Ubuntu20.04 server. See https://travis-ci.org/github/ome/omero-install/jobs/725545346
This PR adds support for multiple protocols

see https://github.com/ome/omero-py/issues/250

 