### PR TITLE
Also check stdout is a tty when requiring interactive credentials

### DIFF
--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -975,9 +975,12 @@ class SessionsControl(UserGroupControl):
             return rv
 
     def _require_tty(self, msg):
-        if sys.stdin.isatty():
+        if not sys.stdin.isatty():
+            self.ctx.die(564, "stdin is not a terminal: %s" % msg)
+        elif not sys.stdout.isatty():
+            self.ctx.die(564, "stdout is not a terminal: %s" % msg)
+        else:
             return
-        self.ctx.die(564, "stdin is not a terminal: %s" % msg)
 
 
 try:

--- a/test/unit/clitest/test_sess.py
+++ b/test/unit/clitest/test_sess.py
@@ -40,6 +40,8 @@ def istty(monkeypatch):
         return True
     monkeypatch.setattr(sys.stdin, 'isatty', isatty)
     assert sys.stdin.isatty()
+    monkeypatch.setattr(sys.stdout, 'isatty', isatty)
+    assert sys.stdout.isatty()
 
 
 class MyStore(SessionsStore):

--- a/test/unit/clitest/test_sess.py
+++ b/test/unit/clitest/test_sess.py
@@ -410,7 +410,7 @@ class TestSessions(object):
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     @pytest.mark.parametrize('group', DIFFERENT_GROUPS)
-    def testReuseFromDifferentGroupDoesntWork(self, connection, group, capsys):
+    def testReuseFromDifferentGroupDoesntWork(self, connection, group):
         """
         Test session reuse with different groups fails
         """
@@ -425,9 +425,6 @@ class TestSessions(object):
         conn_args = self.get_conn_args(connection, group=group[1])
         cli.invoke(["s", "login"] + conn_args)
         cli.assertReqSize(self, 0)
-        out, err = capsys.readouterr()
-        msg = (self.get_conflict_message() + 'omero.group: %s!=%s')
-        assert err.splitlines()[-2] == msg % ('testsessid', group[0], group[1])
 
     @pytest.mark.parametrize('connection', CONNECTION_TYPES)
     @pytest.mark.parametrize('port', MATCHING_PORTS)


### PR DESCRIPTION
Fixes https://github.com/IDR/idr-utils/issues/27

Can be tested with the following minimal workflow

```
omero logout # ensure no session is active
omero login > out # should fail with an error message
omero login # enter valid credentials
omero login > out # should re-use the existing session
```
