### PR TITLE
Remove f-string usage for Python 3.5 compatibility

### DIFF
--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -932,7 +932,7 @@ Examples:
             if args.human_readable:
                 size_str = filesizeformat(size)
             else:
-                size_str = f"{size}"
+                size_str = "%s" % size
 
             if args.size_only:
                 self.ctx.out(size_str)


### PR DESCRIPTION
The usage of f-strings breaks Python 3.5 compatibility which affects the ability to run OMERO on some environments. This is a minor change which restores some compatibility.