### PR TITLE
CLI: Fix sort(lambda) under Python 3

### DIFF
--- a/src/omero/plugins/basics.py
+++ b/src/omero/plugins/basics.py
@@ -293,7 +293,7 @@ class ErrorsControl(BaseControl):
                 combined = []
                 if hasattr(control, "get_errors"):
                     combined.extend(list(control.get_errors().items()))
-                    combined.sort(lambda a, b: cmp(a[1].rcode, b[1].rcode))
+                    combined.sort(key=lambda x: x[1].rcode)
                     for key, err in combined:
                         arranged[err.rcode][name][key].append(err)
 

--- a/test/unit/clitest/test_basics.py
+++ b/test/unit/clitest/test_basics.py
@@ -79,3 +79,8 @@ class TestBasics(object):
         captured = capsys.readouterr()
         lines = captured.out.splitlines()
         assert lines == ['a=a', 'b=b', 'c=c']
+
+    def testErrors(object, monkeypatch, tmp_path, capsys):
+        cli.invoke(["errors"], strict=True)
+        captured = capsys.readouterr()
+        assert "52	       hql	 BAD_QUERY" in captured.out


### PR DESCRIPTION
Discovered while testing for https://forum.image.sc/t/omero-cli-exit-status/44110

Without this PR:
```
(z) /opt/omero-py $omero errors
Traceback (most recent call last):
  File "/usr/local/anaconda3/envs/z/bin/omero", line 33, in <module>
    sys.exit(load_entry_point('omero-py', 'console_scripts', 'omero')())
  File "/opt/omero-py/target/omero/main.py", line 125, in main
    rv = omero.cli.argv()
  File "/opt/omero-py/target/omero/cli.py", line 1784, in argv
    cli.invoke(args[1:])
  File "/opt/omero-py/target/omero/cli.py", line 1222, in invoke
    stop = self.onecmd(line, previous_args)
  File "/opt/omero-py/target/omero/cli.py", line 1299, in onecmd
    self.execute(line, previous_args)
  File "/opt/omero-py/target/omero/cli.py", line 1381, in execute
    args.func(args)
  File "/opt/omero-py/target/omero/plugins/basics.py", line 296, in __call__
    combined.sort(lambda a, b: cmp(a[1].rcode, b[1].rcode))
TypeError: sort() takes no positional arguments
```

With this PR:
```
(z) /opt/omero-py $omero errors
   52	       hql	 BAD_QUERY	'Bad query: %s'
   52	    search	 BAD_QUERY	'Bad query: %s'
   53	       hql	 NOT_ADMIN	'SecurityViolation: Current user is not an admin an...'
   53	    search	 NOT_ADMIN	'SecurityViolation: Current user is not an admin an...'
   67	       hql	  NO_QUIET	'Can't ask for query with --quiet option'
   67	    search	  NO_QUIET	'Can't ask for query with --quiet option'
  123	     admin	NOT_WINDOWS	'Not Windows'
  200	     admin	     SETUP	'Error during service user set up:  (%s) %s'
  201	     admin	   RUNNING	'%s is already running. Use stop first'
  202	     admin	NO_SERVICE	'%s service deleted.'
  300	     admin	BAD_CONFIG	'Bad configuration: No IceGrid.Node.Data property'
  400	     admin	WIN_CONFIG	'%s is not in this directory. Abortin...'
  666	     admin	  NO_WIN32	'Could not import win32service and/or win32evtlogut...'
```