### PR TITLE
omero.server.nodedescriptors allows components to be enabled/disabled

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -57,7 +57,7 @@ from omero_ext.which import whichall
 from omero_ext.argparse import FileType
 from omero_version import ice_compatibility
 
-from ..util._process_defaultxml import _process_xml
+from omero.util._process_defaultxml import _process_xml
 
 
 try:

--- a/src/omero/util/_process_defaultxml.py
+++ b/src/omero/util/_process_defaultxml.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+"""
+Convert the nodes and server-instances in default.xml to a multi-node
+configuration
+
+The configuration string should be in the form node1:s1,s2,... node2:s3 ...
+
+Examples
+
+Everything on a single node (default, the same as passing no config):
+master:Blitz-0,Indexer-0,DropBox,MonitorServer,FileServer,Storm,PixelData-0,Processor-0,Tables-0,TestDropBox
+
+Processor on a separate node:
+master:Blitz-0,Indexer-0,DropBox,MonitorServer,FileServer,Storm,PixelData-0,Tables-0,TestDropBox slave:Processor-0
+
+Two Processor and two PixelData on two separate nodes:
+master:Blitz-0,Indexer-0,DropBox,MonitorServer,FileServer,Storm,Tables-0,TestDropBox slave-1:Processor-0,PixelData-0 slave-2:Processor-1,PixelData-1
+"""
+
+
+import re
+import sys
+
+
+def getnodes(nodedescs):
+    nodes = {}
+    for nd in nodedescs:
+        s = ''
+        node, descs = nd.split(':')
+        descs = descs.split(',')
+        for d in descs:
+            try:
+                t, i = d.split('-')
+            except ValueError:
+                t = d
+                i = None
+            s += '      <server-instance template="%sTemplate"' % t
+            if i is not None:
+                s += ' index="%s"' % i
+            if t in ('Blitz',):
+                s += ' config="default"'
+            if t in ('PixelData', 'Processor', 'Tables'):
+                s += ' dir=""'
+            s += '/>\n'
+        nodes[node] = s
+    return nodes
+
+
+with open(sys.argv[1]) as f:
+    xml = f.read()
+
+pattern = r'\<node name="master"\>\s*\<server-instance[^\>]*\>(.*?\</node\>)'
+m = re.search(pattern, xml, re.DOTALL)
+assert m
+
+nodedescs = sys.argv[2:]
+
+master = '\n    </node>\n'
+slaves = ''
+nodes = getnodes(nodedescs)
+for nodename in sorted(nodes.keys()):
+    servers = nodes[nodename]
+    if nodename == 'master':
+        master = '%s%s' % (servers, master)
+    else:
+        slaves += '    <node name="%s">\n%s    </node>\n' % (nodename, servers)
+
+if nodes:
+    xmlout = xml[:m.start(1)] + master + slaves + xml[m.end(1):]
+else:
+    xmlout = xml
+print xmlout


### PR DESCRIPTION
This is a modified copy of https://github.com/ome/omero-grid-docker/blob/fba17b12891a971e3c4bfc90ba59485607e28863/omero-grid/process_defaultxml.py that can be used to define Ice master and worker nodes with custom combinations of enabled services

Adds a new property `omero.server.nodedescriptors`. E.g. setting it to `master:Blitz-0,Tables-0` will disable `Indexer-0`, `DropBox` ,`MonitorServer`, `Processor-0`

To run the new test:
`OMERODIR=/path/to/OMERO.server pytest test/unit/clitest/test_admin.py -k testNodeDescriptors`
Note several of the other `test_admin.py` tests have been broken for a while https://github.com/ome/omero-py/issues/61