### PR TITLE
download provider uses NamedTemporaryFile

### DIFF
--- a/src/omero/util/populate_roi.py
+++ b/src/omero/util/populate_roi.py
@@ -165,7 +165,8 @@ class DownloadingOriginalFileProvider(object):
         """
         log.info("Downloading original file: %d" % original_file.id.val)
         self.raw_file_store.setFileId(original_file.id.val)
-        temporary_file = tempfile.TemporaryFile(mode='rt+', dir=str(self.dir))
+        temporary_file = tempfile.NamedTemporaryFile(mode='rt+',
+                                                     dir=str(self.dir))
         size = original_file.size.val
         for i in range((old_div(size, self.BUFFER_SIZE)) + 1):
             index = i * self.BUFFER_SIZE


### PR DESCRIPTION
See https://github.com/ome/omero-scripts/pull/180

The Populate_Metadata script that uses `DownloadingOriginalFileProvider` needs to read the temp file with a specific encoder. By returning a `NamedTemporaryFile`, consumers can open the temp file themselves. 