### PR TITLE
roi utils zero division fix

### DIFF
--- a/src/omero/util/roi_handling_utils.py
+++ b/src/omero/util/roi_handling_utils.py
@@ -51,7 +51,7 @@ def get_line_data(pixels, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):
     line_x = x2-x1
     line_y = y2-y1
 
-    rads = math.atan(old_div(float(line_x),line_y))
+    rads = math.atan2(line_x, line_y)
 
     # How much extra Height do we need, top and bottom?
     extra_h = abs(math.sin(rads) * line_w)


### PR DESCRIPTION
This fixes an error I saw on outreach server during today's training (see below).

To test:
 - Draw a horizontal line on an image and save
 - Select the Image and run Analysis Scripts > Plot_Profile
 
Should run without an error and generate a csv file.

```
Traceback (most recent call last):
  File "./script", line 305, in <module>
    run_script()
  File "./script", line 293, in run_script
    file_anns, message = process_images(conn, script_params)
  File "./script", line 224, in process_images
    conn, script_params, image, polylines, line_width, f)
  File "./script", line 65, in process_polylines
    the_z, the_c, the_t)
  File "/opt/omero/server/venv3/lib64/python3.6/site-packages/omero/util/roi_handling_utils.py", line 54, in get_line_data
    rads = math.atan(old_div(float(line_x),line_y))
  File "/opt/omero/server/venv3/lib64/python3.6/site-packages/past/utils/__init__.py", line 95, in old_div
    return a / b
ZeroDivisionError: float division by zero
```
