### PR TITLE
Bug: `obj update` strips newlines

### DIFF
--- a/src/omero/plugins/obj.py
+++ b/src/omero/plugins/obj.py
@@ -43,7 +43,7 @@ class TxField(object):
 
     ARG_RE = re.compile((r"(?P<FIELD>[a-zA-Z][a-zA-Z0-9]*)"
                          "(?P<OPER>[@])?="
-                         "(?P<VALUE>.*)"))
+                         "(?P<VALUE>.*)"), re.MULTILINE|re.DOTALL)
 
     def __init__(self, tx_state, arg):
         self.tx_state = tx_state


### PR DESCRIPTION
The regex used for capturing the string after the
= symbol currently stops at the first newline. This
passes `re` flags to allow capturing the multiline.

More tests are needed.

see: https://forum.image.sc/t/line-breaks-in-descriptions-via-cli/49236/4