### PR TITLE
config add web middleware

### DIFF
--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -227,16 +227,29 @@ class ConfigXml(object):
         for k, v in self.properties(None, True):
             version = self.version(k)
             if version == "5.1.0" and v is not None:
-                for x in list(v):
-                    # User has configured their middleware list.
-                    if x.get("name") == "omero.web.middleware":
-                        val = x.get("value", "")
-                        middleware = json.loads(val)
-                        middleware.append({"index": 7, "class": "omeroweb.middleware.CustomHeadersMiddleware"})
-                        val = json.dumps(middleware)
-                        x.set("value", val)
-                    if x.get("name") == self.KEY:
-                        x.set("value", self.VERSION)
+                try:
+                    from omeroweb.middleware import CustomHeadersMiddleware
+                except:
+                    self.logger.info(
+                        "Failed to import"
+                        " omeroweb.middleware.CustomHeadersMiddleware")
+                else:
+                    self.logger.info(
+                        "Adding omeroweb.middleware.CustomHeadersMiddleware"
+                        " to omero.web.middleware")
+                    for x in list(v):
+                        # User has configured their middleware list.
+                        if x.get("name") == "omero.web.middleware":
+                            val = x.get("value", "")
+                            middleware = json.loads(val)
+                            middleware.append({
+                                "index": 7,
+                                "class":
+                                "omeroweb.middleware.CustomHeadersMiddleware"})
+                            val = json.dumps(middleware)
+                            x.set("value", val)
+                        if x.get("name") == self.KEY:
+                            x.set("value", self.VERSION)
 
     def version_fix(self, props, version):
         """

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -238,7 +238,7 @@ class ConfigXml(object):
                 try:
                     from omeroweb.middleware import CustomHeadersMiddleware
                 except:
-                    self.logger.info(
+                    self.logger.error(
                         "Failed to import"
                         " omeroweb.middleware.CustomHeadersMiddleware."
                         " Please upgrade omero-web")

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -244,8 +244,8 @@ class ConfigXml(object):
                         " Please upgrade omero-web")
                 else:
                     self.logger.info(
-                        "Adding omeroweb.middleware.CustomHeadersMiddleware"
-                        " to omero.web.middleware")
+                        "Removing default middleware classes"
+                        " from omero.web.middleware")
                     for x in list(v):
                         # User has configured their middleware list.
                         if x.get("name") == "omero.web.middleware":

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -232,7 +232,8 @@ class ConfigXml(object):
                 except:
                     self.logger.info(
                         "Failed to import"
-                        " omeroweb.middleware.CustomHeadersMiddleware")
+                        " omeroweb.middleware.CustomHeadersMiddleware."
+                        " Please upgrade omero-web")
                 else:
                     self.logger.info(
                         "Adding omeroweb.middleware.CustomHeadersMiddleware"
@@ -240,7 +241,7 @@ class ConfigXml(object):
                     for x in list(v):
                         # User has configured their middleware list.
                         if x.get("name") == "omero.web.middleware":
-                            val = x.get("value", "")
+                            val = x.get("value", "[]")
                             middleware = json.loads(val)
                             middleware.append({
                                 "index": 7,

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -87,7 +87,7 @@ class ConfigXml(object):
     in etc/grid. For a copy of the dict, use "as_map"
     """
     KEY = "omero.config.version"
-    VERSION = "5.1.0"
+    VERSION = "5.2.0"
     INTERNAL = "__ACTIVE__"
     DEFAULT = "omero.config.profile"
     IGNORE = (KEY, DEFAULT)
@@ -124,6 +124,7 @@ class ConfigXml(object):
             try:
                 self.version_check()
                 self.toplinks_check()
+                self.middleware_check()
             except:
                 self.close()
                 raise
@@ -218,6 +219,21 @@ class ConfigXml(object):
                                     "Open OMERO user guide in a new tab"}]]
                         toplinks = defaultlinks + toplinks
                         val = json.dumps(toplinks)
+                        x.set("value", val)
+                    if x.get("name") == self.KEY:
+                        x.set("value", self.VERSION)
+
+    def middleware_check(self):
+        for k, v in self.properties(None, True):
+            version = self.version(k)
+            if version == "5.1.0" and v is not None:
+                for x in list(v):
+                    # User has configured their middleware list.
+                    if x.get("name") == "omero.web.middleware":
+                        val = x.get("value", "")
+                        middleware = json.loads(val)
+                        middleware.append({"index": 7, "class": "omeroweb.middleware.CustomHeadersMiddleware"})
+                        val = json.dumps(middleware)
                         x.set("value", val)
                     if x.get("name") == self.KEY:
                         x.set("value", self.VERSION)

--- a/src/omero/config.py
+++ b/src/omero/config.py
@@ -224,6 +224,14 @@ class ConfigXml(object):
                         x.set("value", self.VERSION)
 
     def middleware_check(self):
+        mw_classes = [
+            "django.middleware.common.BrokenLinkEmailsMiddleware",
+            "django.middleware.common.CommonMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.middleware.csrf.CsrfViewMiddleware",
+            "django.contrib.messages.middleware.MessageMiddleware",
+            "django.middleware.clickjacking.XFrameOptionsMiddleware"
+        ]
         for k, v in self.properties(None, True):
             version = self.version(k)
             if version == "5.1.0" and v is not None:
@@ -243,11 +251,9 @@ class ConfigXml(object):
                         if x.get("name") == "omero.web.middleware":
                             val = x.get("value", "[]")
                             middleware = json.loads(val)
-                            middleware.append({
-                                "index": 7,
-                                "class":
-                                "omeroweb.middleware.CustomHeadersMiddleware"})
-                            val = json.dumps(middleware)
+                            custom = [mw for mw in middleware
+                                if mw['class'] not in mw_classes]
+                            val = json.dumps(custom)
                             x.set("value", val)
                         if x.get("name") == self.KEY:
                             x.set("value", self.VERSION)

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -203,7 +203,7 @@ class TestConfig(object):
         config = ConfigXml(filename=str(p))
         m = config.as_map()
         for k, v in list(m.items()):
-            assert "5.1.0" == v
+            assert ConfigXml.VERSION == v
 
     def testOldVersionDetected(self):
         p = create_path()
@@ -297,11 +297,11 @@ class TestConfig(object):
         finally:
             config.close()
 
-        # After config.close() calls config.save() new version should be 5.1.0
+        # After config.close() calls config.save() new version should be updated
         config = ConfigXml(filename=str(p), env_config="default")
         try:
             # Check version has been updated
-            assert config.version() == "5.1.0"
+            assert config.version() == config.VERSION
             # And that top_links has not been modified further
             compare_json_maps(config, afterUpdate)
         finally:


### PR DESCRIPTION
See https://github.com/ome/omero-web/pull/260

With an update to the default `omero.web.middleware` as in the PR above,
if the user has previously updated their config then the values will be stored in the `etc/grid/config.xml` and
the new default will be ignored.
This PR aims to update the `omero.web.middleware` config in the same way as the above PR.
This will only happen if the above PR is included in `omero-web` (the new middleware is importable)

NB: last commit of the PR above changes the default `omero.web.middleware` setting so that it is simpler
for this PR to update in the same way (simply append a single class, instead of update multiple classes in the list).
This allows us to simplify the update and reduce the amount of settings that are hard-coded in `config.py`.

I'm assuming no-one is upgrading from "4.2.1" (6 years ago).

To test:

 - with current web (without https://github.com/ome/omero-web/pull/260) do typical CORs config to update middleware:
 ```
$ omero config append omero.web.middleware '{"index": 0.5, "class": "corsheaders.middleware.CorsMiddleware"}'
$ omero config append omero.web.middleware '{"index": 10, "class": "corsheaders.middleware.CorsPostCsrfMiddleware"}'
```
 - Update `omero-py` to include this PR
 - The config should not be changed yet (this won't show `CustomHeadersMiddleware`
```
$ omero config get omero.web.middleware
```
- Update omero-web to include https://github.com/ome/omero-web/pull/260
- The config *should* now show `CustomHeadersMiddleware`
```
$ omero config get omero.web.middleware
```

NB: If you *ONLY* stop web, upgrade web and start web (without any `$ omero config... ` command), the change will not take effect.