### PR TITLE
login: add --retry=seconds option to login

### DIFF
--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -201,9 +201,6 @@ class SessionsControl(UserGroupControl):
         logout = parser.add(
             sub, self.logout, "Logout and remove current session key")
         self._configure_login(login)
-        login.add_argument(
-            "--retry", nargs="?", type=int, default=0,
-            help="Number of seconds to retry login (default: no retry)")
 
         group = parser.add(
             sub, self.group,
@@ -277,6 +274,9 @@ class SessionsControl(UserGroupControl):
             "-t", "--timeout", type=int,
             help="Timeout for session. After this many inactive seconds, the"
             " session will be closed")
+        login.add_argument(
+            "--retry", nargs="?", type=int, default=0,
+            help="Number of seconds to retry login (default: no retry)")
         login.add_argument(
             "connection", nargs="?",
             help="Connection string. See extended help for examples")

--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -28,6 +28,7 @@ from __future__ import division
 
 from builtins import str
 from past.utils import old_div
+import datetime
 import os
 import sys
 import Ice
@@ -200,6 +201,9 @@ class SessionsControl(UserGroupControl):
         logout = parser.add(
             sub, self.logout, "Logout and remove current session key")
         self._configure_login(login)
+        login.add_argument(
+            "--retry", nargs="?", type=int, default=0,
+            help="Number of seconds to retry login (default: no retry)")
 
         group = parser.add(
             sub, self.group,
@@ -531,7 +535,26 @@ class SessionsControl(UserGroupControl):
                             prompt = "Password:"
                         pasw = self.ctx.input(prompt, hidden=True,
                                               required=True)
-                    rv = store.create(name, pasw, props, sudo=args.sudo)
+
+                    ### Retry logic ############################################
+                    start = time.time()
+                    retries = 0
+                    while True:
+                        try:
+                            rv = store.create(name, pasw, props, sudo=args.sudo)
+                            break
+                        except Exception as e:
+                            elapsed = (time.time() - start)
+                            if not args.retry or (elapsed > args.retry):
+                                raise
+                            else:
+                                retries += 1
+                                msg = str(datetime.datetime.now().time())
+                                msg += ": Login retry #%d in 3s" % (retries)
+                                self.ctx.err(msg)
+                                time.sleep(3)
+                    ### End retry ##############################################
+
                     break
                 except PermissionDeniedException as pde:
                     tries -= 1


### PR DESCRIPTION
This should replace the wait.sh-stype scripts that exist in
multiple (especially docker) repositories.

Example output:

```
    $ omero sessions login -w omero root@localhost --retry=100
    Previous session expired for root on localhost:4064
    09:41:30.959913: Login retry #1 in 3s
    09:41:33.977181: Login retry #2 in 3s
    ...
    09:41:58.129038: Login retry #10 in 3s
    WARNING:omero.client:None - createSession retry: 1
    WARNING:omero.client:None - createSession retry: 2
    09:42:17.100098: Login retry #11 in 3s
    Created session for root@localhost:4064. Idle timeout: 10 min. Current group: system
````

see: https://github.com/ome/omero-server-docker/blob/master/test_login.sh