### PR TITLE
get objects by map annotations

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4185,6 +4185,16 @@ class _BlitzGateway (object):
 
     def getObjectsByMapAnnotations(self, obj_type, key=None, value=None, ns=None,
                                    opts={}):
+        """
+        Retrieve objects linked to Map Annotations, filter by key and value.
+
+        :param obj_type:    'Dataset', 'Image' etc.
+        :param key:         Filter by key. Can start or end with * wild card
+        :param value:       Filter by value. Can start or end with * wild card
+        :param ns:          Filter by namespace
+        :return:            Generator yielding Objects
+        :rtype:             :class:`BlitzObjectWrapper` generator
+        """
 
         wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
         if not wrapper:

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4219,6 +4219,8 @@ class _BlitzGateway (object):
             query += " where " + " and ".join(clauses)
         result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)
         ids = [row[0].val for row in result]
+        if len(ids) == 0:
+            return []
         return self.getObjects(obj_type, ids)
 
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4222,7 +4222,7 @@ class _BlitzGateway (object):
 
         # Using projection since can't seem to fetch objects AND filter by mapValue
         query = """
-            select obj.id, obj.name from
+            select distinct obj.id from
             %sAnnotationLink ial
             join ial.child ann
             join ann.mapValue mv


### PR DESCRIPTION
See request for "How to query objects by map annotation?"
We don't have any examples at https://docs.openmicroscopy.org/omero/5.6.3/developers/Python.html
and need to look into Mapr source to find out how.
https://forum.image.sc/t/harmonization-of-image-metadata-for-different-file-formats-omero-mde/50827/10

This adds method  to gateway:

```
conn.getObjectsByMapAnnotations('Image', key='Primary Antibody')

conn.getObjectsByMapAnnotations('Image', value='ACA', ns="openmicroscopy.org/omero/client/mapAnnotation")

conn.getObjectsByMapAnnotations('Image', key='Primary Antibody', value='ACA')
```

To consider:

 - We could allow wild-card queries (as used for auto-complete in mapr)
 - One way to support this would be to allow the 'key' or 'value' to start/end with `*`: e.g. `key='Anti*' `
 - The BlitzGateway code could replace the `*` with `%%` and use `like` in the HQL query.

TODO: 
 - add tests... (Done - thanks Dom)
 - Add docstring