### PR TITLE
Add logic to search OMERO.tables on non Pythonic named columns

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -543,7 +543,12 @@ class HdfStorage(object):
                      start, stop, step):
         self.__initcheck()
         try:
-            return self.__mea.get_where_list(condition, variables, None,
+            condvars = variables
+            if variables:
+                for key, value in condvars.items():
+                    if isinstance(value, str):
+                        condvars[key] = getattr(self.__mea.cols, value)
+            return self.__mea.get_where_list(condition, condvars, None,
                                              start, stop, step).tolist()
         except (NameError, SyntaxError, TypeError, ValueError) as err:
             aue = omero.ApiUsageException()

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -319,7 +319,7 @@ class TestHdfStorage(TestCase):
         hdf.append(cols)
         rows = hdf.getWhereList(
             time.time(), '(x=="bar")',
-            { 'x' : getattr(hdf._HdfStorage__mea.cols, name) },
+            { 'x' : name },
             'b', None, None, None)
         assert rows == [1]
         assert bytesize == hdf.readCoordinates(


### PR DESCRIPTION
See https://github.com/ome/omero-metadata/issues/57 for the reference issue.

OMERO.tables HDF storage uses PyTables [querying capabilities](https://www.pytables.org/usersguide/libref/structured_storage.html#table-methods-querying) in particular the `tables.get_where_list` API. This API takes as a primary input a condition which syntax is defined as in https://www.pytables.org/usersguide/condition_syntax.html.

Columns named in a Python compliant way (i.e. matching `^[a-zA-Z_][a-zA-Z0-9_]*$`), the column name can directly be used in the condition e.g. `foo>1`. Column names that do not match this patterns e.g. including spaces or brackets are supported but they need to be retrieved using `getattr` and they cannot directly used as an input condition. As it stands, this prevents the API from querying all the row based on a condition including such a column.

350dbc1 demonstrates how to use `condvars` and variable substitution to allow searching these non Pythonic named columns. ae5ca40 proposes to expand the semantics of the `variables` argument of `tables.get_where_list` to support these queries remotely.  Any string/string key value pair is expanded as a string/column key/pair and passed to the underlying `get_where_list` API allowing variable substitution. 

Using the OMERO API, this should allow the following types of queries

```
table.getWhereList("(count > 10) & (x =='pass')", variables={'x': rstring('Quality Control')}, start=0, stop=rowCount, step=0)
```