### PR TITLE
Fix HdfStorage.read() implementation to work with all column types

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -590,20 +590,6 @@ class HdfStorage(object):
 
         return self._as_data(cols, rowNumbers)
 
-    def _getrows(self, start, stop):
-        return self.__mea.read(start, stop)
-
-    def _rowstocols(self, rows, colNumbers, cols):
-        l = 0
-        rv = []
-        for i in colNumbers:
-            col = cols[i]
-            col.fromrows(rows)
-            rv.append(col)
-            if not l:
-                l = col.getsize()
-        return rv, l
-
     @stamped
     def slice(self, stamp, colNumbers, rowNumbers, current):
         self.__initcheck()

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -581,7 +581,14 @@ class HdfStorage(object):
 
         for col in cols:
             col.read(self.__mea, start, stop)
-        return self._as_data(cols, range(stop - start + 1))
+        if start is not None and stop is not None:
+            rowNumbers = list(range(start, stop))
+        elif start is not None and stop is None:
+            rowNumbers =  list(range(start, start + 1))
+        elif start is None and stop is None:
+            rowNumbers = list(range(self.__length()))
+
+        return self._as_data(cols, rowNumbers)
 
     def _getrows(self, start, stop):
         return self.__mea.read(start, stop)

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -576,11 +576,12 @@ class HdfStorage(object):
     def read(self, stamp, colNumbers, start, stop, current):
         self.__initcheck()
         self.__sizecheck(colNumbers, None)
-        cols = self.cols(None, current)
+        all_cols = self.cols(None, current)
+        cols = [all_cols[i] for i in colNumbers]
 
-        rows = self._getrows(start, stop)
-        rv, l = self._rowstocols(rows, colNumbers, cols)
-        return self._as_data(rv, list(range(start, start + l)))
+        for col in cols:
+            col.read(self.__mea, start, stop)
+        return self._as_data(cols, range(stop - start + 1))
 
     def _getrows(self, start, stop):
         return self.__mea.read(start, stop)

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -584,7 +584,7 @@ class HdfStorage(object):
         if start is not None and stop is not None:
             rowNumbers = list(range(start, stop))
         elif start is not None and stop is None:
-            rowNumbers =  list(range(start, start + 1))
+            rowNumbers =  list(range(start, self.__length()))
         elif start is None and stop is None:
             rowNumbers = list(range(self.__length()))
 

--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -593,7 +593,7 @@ class HdfStorage(object):
             col.fromrows(rows)
             rv.append(col)
             if not l:
-                l = len(col.values)
+                l = col.getsize()
         return rv, l
 
     @stamped

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -357,7 +357,7 @@ class TestHdfStorage(TestCase):
         assert 5 == test.y[1]
         assert 6 == test.w[1]
         assert 7 == test.h[1]
-        assert [0 == 1, 2, 3, 4], test.bytes[1]
+        assert [0, 1, 2, 3, 4] == test.bytes[1]
 
         data = hdf.read(hdf._stamp, [0], 0, 1, self.current)
         hdf.cleanup()

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -129,6 +129,7 @@ class TestHdfStorage(TestCase):
         self.append(hdf, {"a": 1, "b": 2, "c": 3})
         self.append(hdf, {"a": 5, "b": 6, "c": 7})
         data = hdf.readCoordinates(hdf._stamp, [0, 1], self.current)
+        assert len(data.columns) == 3
         assert 1 == data.columns[0].values[0]
         assert 5 == data.columns[0].values[1]
         assert 2 == data.columns[1].values[0]
@@ -142,6 +143,7 @@ class TestHdfStorage(TestCase):
         data.columns[1].values[1] = 400
         hdf.update(hdf._stamp, data)
         hdf.readCoordinates(hdf._stamp, [0, 1], self.current)
+        assert len(data.columns) == 3
         assert 100 == data.columns[0].values[0]
         assert 200 == data.columns[0].values[1]
         assert 300 == data.columns[1].values[0]
@@ -276,8 +278,17 @@ class TestHdfStorage(TestCase):
         # Unicode conditions don't work on Python 3
         # Fetching should still work though
         r1 = hdf.readCoordinates(time.time(), [1], self.current)
+        assert len(r1.columns) == 1
+        assert len(r1.columns[0].values) == 1
         assert r1.columns[0].size == bytesize
         assert r1.columns[0].values[0] == "მიკროსკოპის პონი"
+
+        r2 = hdf.read(time.time(), [0], 0, 2, self.current)
+        assert len(r2.columns) == 1
+        assert len(r2.columns[0].values) == 2
+        assert r2.columns[0].size == bytesize
+        assert r2.columns[0].values[0] == "foo"
+        assert r2.columns[0].values[1] == "მიკროსკოპის პონი"
 
         # Doesn't work yet.
         hdf.cleanup()
@@ -340,26 +351,37 @@ class TestHdfStorage(TestCase):
         mask.bytes = [[0], [0, 1, 2, 3, 4]]
         hdf.append([mask])
         data = hdf.readCoordinates(hdf._stamp, [0, 1], self.current)
-        test = data.columns[0]
-        assert 1 == test.imageId[0]
-        assert 2 == test.theZ[0]
-        assert 3 == test.theT[0]
-        assert 4 == test.x[0]
-        assert 5 == test.y[0]
-        assert 6 == test.w[0]
-        assert 7 == test.h[0]
-        assert [0] == test.bytes[0]
+        assert len(data.columns) == 1
+        assert len(data.columns[0].imageId) == 2
+        assert 1 == data.columns[0].imageId[0]
+        assert 2 == data.columns[0].theZ[0]
+        assert 3 == data.columns[0].theT[0]
+        assert 4 == data.columns[0].x[0]
+        assert 5 == data.columns[0].y[0]
+        assert 6 == data.columns[0].w[0]
+        assert 7 == data.columns[0].h[0]
+        assert [0] == data.columns[0].bytes[0]
 
-        assert 2 == test.imageId[1]
-        assert 2 == test.theZ[1]
-        assert 3 == test.theT[1]
-        assert 4 == test.x[1]
-        assert 5 == test.y[1]
-        assert 6 == test.w[1]
-        assert 7 == test.h[1]
-        assert [0, 1, 2, 3, 4] == test.bytes[1]
+        assert 2 == data.columns[0].imageId[1]
+        assert 2 == data.columns[0].theZ[1]
+        assert 3 == data.columns[0].theT[1]
+        assert 4 == data.columns[0].x[1]
+        assert 5 == data.columns[0].y[1]
+        assert 6 == data.columns[0].w[1]
+        assert 7 == data.columns[0].h[1]
+        assert [0, 1, 2, 3, 4] == data.columns[0].bytes[1]
 
         data = hdf.read(hdf._stamp, [0], 0, 1, self.current)
+        assert len(data.columns) == 1
+        assert len(data.columns[0].imageId) == 1
+        assert 1 == data.columns[0].imageId[0]
+        assert 2 == data.columns[0].theZ[0]
+        assert 3 == data.columns[0].theT[0]
+        assert 4 == data.columns[0].x[0]
+        assert 5 == data.columns[0].y[0]
+        assert 6 == data.columns[0].w[0]
+        assert 7 == data.columns[0].h[0]
+        assert [0] == data.columns[0].bytes[0]
         hdf.cleanup()
 
 

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -375,9 +375,39 @@ class TestHdfStorage(TestCase):
         assert data.columns[0].name == 'b'
         assert data.columns[0].values[0] == 5
 
+        # (start=1, stop=1) should return no rows
         data = hdf.read(time.time(), [0, 1, 2], 1, 1, self.current)
         assert len(data.columns) == 3
         assert len(data.columns[0].values) == 0
+        hdf.cleanup()
+
+        # (start=None, stop=None) should return all rows
+        data = hdf.read(time.time(), [0, 1, 2], None, None, self.current)
+        assert len(data.columns) == 3
+        assert len(data.columns[0].values) == 3
+        assert data.columns[0].name == 'a'
+        assert data.columns[0].values[0] == 1
+        assert data.columns[0].values[1] == 2
+        assert data.columns[0].values[2] == 3
+        assert data.columns[1].name == 'b'
+        assert data.columns[1].values[0] == 4
+        assert data.columns[1].values[1] == 5
+        assert data.columns[1].values[2] == 6
+        assert data.columns[2].name == 'c'
+        assert data.columns[2].values[0] == 7
+        assert data.columns[2].values[1] == 8
+        assert data.columns[2].values[2] == 9
+
+        # (start=0, stop=None) should return one rows
+        data = hdf.read(time.time(), [0, 1, 2], 1, None, self.current)
+        assert len(data.columns) == 3
+        assert len(data.columns[0].values) == 1
+        assert data.columns[0].name == 'a'
+        assert data.columns[0].values[0] == 2
+        assert data.columns[1].name == 'b'
+        assert data.columns[1].values[0] == 5
+        assert data.columns[2].name == 'c'
+        assert data.columns[2].values[0] == 8
         hdf.cleanup()
 
     #

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -358,6 +358,7 @@ class TestHdfStorage(TestCase):
         assert data.columns[2].name == 'c'
         assert data.columns[2].values[0] == 7
         assert data.columns[2].values[1] == 8
+        assert data.rowNumbers == [0, 1]
 
         data = hdf.read(time.time(), [0, 2], 1, 3, self.current)
         assert len(data.columns) == 2
@@ -368,18 +369,20 @@ class TestHdfStorage(TestCase):
         assert data.columns[1].name == 'c'
         assert data.columns[1].values[0] == 8
         assert data.columns[1].values[1] == 9
+        assert data.rowNumbers == [1, 2]
 
         data = hdf.read(time.time(), [1], 1, 2, self.current)
         assert len(data.columns) == 1
         assert len(data.columns[0].values) == 1
         assert data.columns[0].name == 'b'
         assert data.columns[0].values[0] == 5
+        assert data.rowNumbers == [1]
 
         # (start=1, stop=1) should return no rows
         data = hdf.read(time.time(), [0, 1, 2], 1, 1, self.current)
         assert len(data.columns) == 3
         assert len(data.columns[0].values) == 0
-        hdf.cleanup()
+        assert data.rowNumbers == []
 
         # (start=None, stop=None) should return all rows
         data = hdf.read(time.time(), [0, 1, 2], None, None, self.current)
@@ -397,6 +400,7 @@ class TestHdfStorage(TestCase):
         assert data.columns[2].values[0] == 7
         assert data.columns[2].values[1] == 8
         assert data.columns[2].values[2] == 9
+        assert data.rowNumbers == [1, 2, 3]
 
         # (start=0, stop=None) should return one rows
         data = hdf.read(time.time(), [0, 1, 2], 1, None, self.current)
@@ -408,6 +412,7 @@ class TestHdfStorage(TestCase):
         assert data.columns[1].values[0] == 5
         assert data.columns[2].name == 'c'
         assert data.columns[2].values[0] == 8
+        assert data.rowNumbers == [1]
         hdf.cleanup()
 
     #

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -334,6 +334,52 @@ class TestHdfStorage(TestCase):
         # Doesn't work yet.
         hdf.cleanup()
 
+    def testRead(self):
+        hdf = HdfStorage(self.hdfpath(), self.lock)
+        cols = [
+            omero.columns.LongColumnI('a'),
+            omero.columns.LongColumnI('b'),
+            omero.columns.LongColumnI('c')]
+        hdf.initialize(cols)
+        cols[0].values = [1, 2, 3]
+        cols[1].values = [4, 5, 6]
+        cols[2].values = [7, 8, 9]
+        hdf.append(cols)
+
+        data = hdf.read(time.time(), [0, 1, 2], 0, 2, self.current)
+        assert len(data.columns) == 3
+        assert len(data.columns[0].values) == 2
+        assert data.columns[0].name == 'a'
+        assert data.columns[0].values[0] == 1
+        assert data.columns[0].values[1] == 2
+        assert data.columns[1].name == 'b'
+        assert data.columns[1].values[0] == 4
+        assert data.columns[1].values[1] == 5
+        assert data.columns[2].name == 'c'
+        assert data.columns[2].values[0] == 7
+        assert data.columns[2].values[1] == 8
+
+        data = hdf.read(time.time(), [0, 2], 1, 3, self.current)
+        assert len(data.columns) == 2
+        assert len(data.columns[0].values) == 2
+        assert data.columns[0].name == 'a'
+        assert data.columns[0].values[0] == 2
+        assert data.columns[0].values[1] == 3
+        assert data.columns[1].name == 'c'
+        assert data.columns[1].values[0] == 8
+        assert data.columns[1].values[1] == 9
+
+        data = hdf.read(time.time(), [1], 1, 2, self.current)
+        assert len(data.columns) == 1
+        assert len(data.columns[0].values) == 1
+        assert data.columns[0].name == 'b'
+        assert data.columns[0].values[0] == 5
+
+        data = hdf.read(time.time(), [0, 1, 2], 1, 1, self.current)
+        assert len(data.columns) == 3
+        assert len(data.columns[0].values) == 0
+        hdf.cleanup()
+
     #
     # ROIs
     #

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -326,7 +326,6 @@ class TestHdfStorage(TestCase):
     #
     # ROIs
     #
-    @pytest.mark.broken
     def testMaskColumn(self):
         hdf = HdfStorage(self.hdfpath(), self.lock)
         mask = omero.columns.MaskColumnI('mask', 'desc', None)

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -358,6 +358,8 @@ class TestHdfStorage(TestCase):
         assert 6 == test.w[1]
         assert 7 == test.h[1]
         assert [0 == 1, 2, 3, 4], test.bytes[1]
+
+        data = hdf.read(hdf._stamp, [0], 0, 1, self.current)
         hdf.cleanup()
 
 

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -129,20 +129,39 @@ class TestHdfStorage(TestCase):
         self.append(hdf, {"a": 1, "b": 2, "c": 3})
         self.append(hdf, {"a": 5, "b": 6, "c": 7})
         data = hdf.readCoordinates(hdf._stamp, [0, 1], self.current)
+        assert 1 == data.columns[0].values[0]
+        assert 5 == data.columns[0].values[1]
+        assert 2 == data.columns[1].values[0]
+        assert 6 == data.columns[1].values[1]
+        assert 3 == data.columns[2].values[0]
+        assert 7 == data.columns[2].values[1]
+
         data.columns[0].values[0] = 100
         data.columns[0].values[1] = 200
         data.columns[1].values[0] = 300
         data.columns[1].values[1] = 400
         hdf.update(hdf._stamp, data)
         hdf.readCoordinates(hdf._stamp, [0, 1], self.current)
+        assert 100 == data.columns[0].values[0]
+        assert 200 == data.columns[0].values[1]
+        assert 300 == data.columns[1].values[0]
+        assert 400 == data.columns[1].values[1]
+        assert 3 == data.columns[2].values[0]
+        assert 7 == data.columns[2].values[1]
         hdf.cleanup()
 
     def testReadTicket1951(self):
         hdf = HdfStorage(self.hdfpath(), self.lock)
         self.init(hdf, True)
         self.append(hdf, {"a": 1, "b": 2, "c": 3})
-        hdf.readCoordinates(hdf._stamp, [0], self.current)
-        hdf.read(hdf._stamp, [0, 1, 2], 0, 1, self.current)
+        data = hdf.readCoordinates(hdf._stamp, [0], self.current)
+        assert 1 == data.columns[0].values[0]
+        assert 2 == data.columns[1].values[0]
+        assert 3 == data.columns[2].values[0]
+        data = hdf.read(hdf._stamp, [0, 1, 2], 0, 1, self.current)
+        assert 1 == data.columns[0].values[0]
+        assert 2 == data.columns[1].values[0]
+        assert 3 == data.columns[2].values[0]
         hdf.cleanup()
 
     def testSorting(self):  # Probably shouldn't work

--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -371,6 +371,7 @@ class TestHdfStorage(TestCase):
         assert data.columns[1].values[1] == 9
         assert data.rowNumbers == [1, 2]
 
+        # Reads row 1
         data = hdf.read(time.time(), [1], 1, 2, self.current)
         assert len(data.columns) == 1
         assert len(data.columns[0].values) == 1
@@ -378,13 +379,13 @@ class TestHdfStorage(TestCase):
         assert data.columns[0].values[0] == 5
         assert data.rowNumbers == [1]
 
-        # (start=1, stop=1) should return no rows
+       # Reads no row
         data = hdf.read(time.time(), [0, 1, 2], 1, 1, self.current)
         assert len(data.columns) == 3
         assert len(data.columns[0].values) == 0
         assert data.rowNumbers == []
 
-        # (start=None, stop=None) should return all rows
+        # Read all rows
         data = hdf.read(time.time(), [0, 1, 2], None, None, self.current)
         assert len(data.columns) == 3
         assert len(data.columns[0].values) == 3
@@ -400,19 +401,19 @@ class TestHdfStorage(TestCase):
         assert data.columns[2].values[0] == 7
         assert data.columns[2].values[1] == 8
         assert data.columns[2].values[2] == 9
-        assert data.rowNumbers == [1, 2, 3]
+        assert data.rowNumbers == [0, 1, 2]
 
-        # (start=0, stop=None) should return one rows
-        data = hdf.read(time.time(), [0, 1, 2], 1, None, self.current)
-        assert len(data.columns) == 3
-        assert len(data.columns[0].values) == 1
+        # Read from row 1 until the end of the table
+        data = hdf.read(time.time(), [0, 2], 1, None, self.current)
+        assert len(data.columns) == 2
+        assert len(data.columns[0].values) == 2
         assert data.columns[0].name == 'a'
         assert data.columns[0].values[0] == 2
-        assert data.columns[1].name == 'b'
-        assert data.columns[1].values[0] == 5
-        assert data.columns[2].name == 'c'
-        assert data.columns[2].values[0] == 8
-        assert data.rowNumbers == [1]
+        assert data.columns[0].values[1] == 3
+        assert data.columns[1].name == 'c'
+        assert data.columns[1].values[0] == 8
+        assert data.columns[1].values[1] == 9
+        assert data.rowNumbers == [1, 2]
         hdf.cleanup()
 
     #


### PR DESCRIPTION
Reported by @jburel, the tables.read() method internally uses `col.values` (via `_getrows`). For any column type with overrides the default methods of `AbstractColumn` like `MaskColumnI`, this will fail.

fe8b863 tried to address the problem by using the `getsize()` API which should be independent of the column implementation details. However, `testMaskColumn` is still failing as the logic does not populate the `.bytes` attributes.

 6c27eae is a more robust fix to the underlying issue which uses the fact that the column API effectively has a `read` method and effectively delegates to this API like `readCoordinates`.

All the other commits expand the unit tests to cover both `readCoordinates` and `read` scenarios for the different column types (long, string, mask) as well as a test for various arguments of `table.read`

Proposing for a patch release of `omero-py`