### PR TITLE
Fixed race condition bug in tables

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -118,6 +118,7 @@ class HdfList(object):
 
     @locked
     def addOrThrow(self, hdfpath, hdfstorage, read_only=False):
+
         if hdfpath in self.__paths:
             raise omero.LockTimeout(
                 None, None, "Path already in HdfList: %s" % hdfpath)
@@ -578,9 +579,9 @@ class HdfStorage(object):
     def read(self, stamp, colNumbers, start, stop, current):
         self.__initcheck()
         self.__sizecheck(colNumbers, None)
-
         all_cols = self.cols(None, current)
         cols = [all_cols[i] for i in colNumbers]
+
         for col in cols:
             col.read(self.__mea, start, stop)
         if start is not None and stop is not None:

--- a/src/omero/tables.py
+++ b/src/omero/tables.py
@@ -65,6 +65,8 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
 
         self._closed = False
 
+        self.storage = None
+
         if (not self.file_obj.isLoaded() or
                 self.file_obj.getDetails() is None or
                 self.file_obj.details.group is None):

--- a/src/omero/tables.py
+++ b/src/omero/tables.py
@@ -50,22 +50,22 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
     Spreadsheet implementation based on pytables.
     """
 
-    def __init__(self, ctx, file_obj, factory, uuid="unknown",
+    def __init__(self, ctx, file_obj, file_path, factory, storage_factory, read_only=False, uuid="unknown",
                  call_context=None, adapter=None):
         self.id = Ice.Identity()
         self.id.name = uuid
         self.uuid = uuid
         self.file_obj = file_obj
         self.factory = factory
+        self.storage = storage_factory.getOrCreate(file_path, self, read_only)
         self.call_context = call_context
         self.adapter = adapter
         self.can_write = factory.getAdminService().canUpdate(
             file_obj, call_context)
         omero.util.SimpleServant.__init__(self, ctx)
 
+        self.stamp = time.time()
         self._closed = False
-
-        self.storage = None
 
         if (not self.file_obj.isLoaded() or
                 self.file_obj.getDetails() is None or
@@ -73,10 +73,6 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
             self.file_obj = self.ctx.getSession().getQueryService().get(
                 'omero.model.OriginalFileI', unwrap(file_obj.id),
                 {"omero.group": "-1"})
-
-    def set_storage(self, storage):
-        self.storage = storage
-        self.stamp = self.storage._stamp
 
     def assert_write(self):
         """
@@ -533,14 +529,13 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
         if not p.exists():
             p.makedirs()
 
-        table = TableI(self.ctx, file_obj, factory,
+        table = TableI(self.ctx, file_obj,file_path,
+                       factory,
+                       self._storage_factory,
+                       read_only=self.read_only,
                        uuid=Ice.generateUUID(),
                        call_context=current.ctx,
                        adapter=current.adapter)
-        storage = self._storage_factory.getOrCreate(file_path, table, self.read_only)
-
-        table.set_storage(storage)
-
         self.resources.add(table)
         prx = current.adapter.add(table, table.id)
         return self._table_cast(prx)

--- a/test/unit/tablestest/test_servants.py
+++ b/test/unit/tablestest/test_servants.py
@@ -299,7 +299,7 @@ class TestTables(TestCase):
         assert table
         assert table.table
         assert table.table.storage
-        table.table.set_storage(storage)
+        table.table.set_storage(table.table.storage)
         return table
 
     def testTableOriginalFileLoaded(self):
@@ -320,6 +320,7 @@ class TestTables(TestCase):
         storage = table1.storage
         storage.initialize([LongColumnI("a", None, [])])
         table2 = omero.tables.TableI(self.ctx, f, self.sf)
+        storage.incr(table2)
         table2.set_storage(storage)
         table2.cleanup()
         table1.cleanup()
@@ -365,12 +366,12 @@ class TestTables(TestCase):
         self.repofile(self.sf.db_uuid)
         of = omero.model.OriginalFileI(1, False)
         self.sf.return_values.append(of)
+        self.sf.return_values.append(of)
 
         internal_repo = mock_internal_repo(self.tmp)
         f = open(internal_repo.path, "w")
         f.write("this file is not HDF")
         f.close()
-
         tables = self.tablesI(internal_repo)
         pytest.raises(omero.ValidationException, tables.getTable, of, self.sf,
                       self.current)

--- a/test/unit/tablestest/test_servants.py
+++ b/test/unit/tablestest/test_servants.py
@@ -299,6 +299,7 @@ class TestTables(TestCase):
         assert table
         assert table.table
         assert table.table.storage
+        table.table.set_storage(storage)
         return table
 
     def testTableOriginalFileLoaded(self):
@@ -308,17 +309,8 @@ class TestTables(TestCase):
         self.sf.return_values.append(f2)
         storage = mock_storage()
         self.ctx.newSession()
-        table = omero.tables.TableI(self.ctx, f1, self.sf, storage)
+        table = omero.tables.TableI(self.ctx, f1, self.sf)
         assert table.file_obj.details.group
-
-    def testTableIncrDecr(self):
-        f = omero.model.OriginalFileI(1, True)
-        f.details.group = omero.model.ExperimenterGroupI(1, False)
-        storage = mock_storage()
-        table = omero.tables.TableI(self.ctx, f, self.sf, storage)
-        assert storage.up
-        table.cleanup()
-        assert storage.down
 
     def testTablePreInitialized(self):
         f = omero.model.OriginalFileI(1, True)
@@ -327,7 +319,8 @@ class TestTables(TestCase):
         table1 = mocktable.table
         storage = table1.storage
         storage.initialize([LongColumnI("a", None, [])])
-        table2 = omero.tables.TableI(self.ctx, f, self.sf, storage)
+        table2 = omero.tables.TableI(self.ctx, f, self.sf)
+        table2.set_storage(storage)
         table2.cleanup()
         table1.cleanup()
 


### PR DESCRIPTION
There is a bug in omero tables where multiple simultaneous queries on the same table can result in failures. The crux of the issue is that there is a gap in the locking between the acquisition of the `HdfStorage`  in and the call to `incr`. E.g. if thread 1 makes a query against a table A, the locks is acquired, an `HdfStorage` is created and added to the `HdfList` ( in `getOrCreate`), and the lock is released. Then later when the `TableI` is created, the lock is acquired, `incr` is called (adding the table to the list of tables maintained by the `HdfStorage`), and the lock is released. Then the query is executed (a locked operation) and `decr` is called (locked). If thread 2 makes a query just after thread 1 though, it is possible that in between thread 2's call to `getOrCreate` and its call to `incr`, thread 1 will call `decr`, causing the `HdfStorage` to call `cleanup` on itself and making it unusable. This PR makes changes such that `incr` is called inside `getOrCreate` so there is no opportunity for `decr` and `cleanup` to be called in between storage acquisition and the call to `incr`.
To test this bug, I used siege (https://www.joedog.org/siege-home/) and ran the following on a server with omero and omero web running: `siege "http://localhost/webgateway/table/<table id>/query/?query=<query>&col_names=<col_name_1>&col_names=<col_name_2>" -H "Cookie:sessionid=<session_id>" -c20 -r2`
which will run 20 concurrent requests twice against the table query url. Usually at least 1 of these will fail with errors appearing in `OMEROweb.log`. 