### PR TITLE
Support omero download Fileset:ID

### DIFF
--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -80,7 +80,10 @@ class DownloadControl(BaseControl):
             self.download_fileset(conn, fileset, args.filename)
         elif dtype == "Image":
             image = self.get_object(conn, dtype, obj.id.val)
-            self.download_fileset(conn, image.getFileset(), args.filename)
+            fileset = image.getFileset()
+            if fileset is None:
+                self.ctx.die(602, 'Input image has no associated Fileset')
+            self.download_fileset(conn, fileset, args.filename)
         else:
             orig_file = self.get_file(client.sf, dtype, obj.id.val)
             target_file = str(args.filename)

--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -105,16 +105,17 @@ class DownloadControl(BaseControl):
             self.ctx.die(66, ("Download of OriginalFile:"
                               "%s is restricted") % orig_file.id.val)
 
-        self.ctx.out(f"Downloading file ID: {orig_file.id.val} to {target_file}")
-        if os.path.exists(target_file):
-            self.ctx.out(f"File exists! Skipping...")
-
         try:
             if target_file == "-":
                 client.download(orig_file, filehandle=StdOutHandle())
                 sys.stdout.flush()
             else:
-                client.download(orig_file, target_file)
+                self.ctx.out(
+                    f"Downloading file ID: {orig_file.id.val} to {target_file}")
+                if os.path.exists(target_file):
+                    self.ctx.out(f"File exists! Skipping...")
+                else:
+                    client.download(orig_file, target_file)
         except omero.ClientError as ce:
             self.ctx.die(67, "ClientError: %s" % ce)
         except omero.ValidationException as ve:

--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -6,7 +6,7 @@
    Plugin read by omero.cli.Cli during initialization. The method(s)
    defined here will be added to the Cli class for later use.
 
-   Copyright 2007 - 2014 Glencoe Software, Inc. All rights reserved.
+   Copyright 2007 - 2021 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
 
 """
@@ -20,8 +20,8 @@ from omero.cli import BaseControl, CLI, ProxyStringType
 from omero.rtypes import unwrap
 from omero.gateway import BlitzGateway
 
-HELP = """Download the given file with a specified ID to a target file with
-a specified filename.
+HELP = """Download a File, Image or Fileset with a specified ID to a target file
+or directory.
 
 Examples:
 
@@ -33,9 +33,11 @@ Examples:
     # Download the OriginalFile linked to FileAnnotation 20 to local_file
     omero download FileAnnotation:20 local_file
 
-    # Download the OriginalFile linked to Image 5
-    # Works only with single files imported with OMERO 5.0.0 and above
-    omero download Image:5 original_image
+    # Download the OriginalFiles linked to Image 5 into a directory
+    # The Files will be named as they are in OMERO's Managed repository
+    omero download Image:5 output_dir
+    # Download the OriginalFiles linked to Fileset 6 into a directory
+    omero download Fileset:6 output_dir
 """
 
 

--- a/src/omero/plugins/download.py
+++ b/src/omero/plugins/download.py
@@ -70,14 +70,15 @@ class DownloadControl(BaseControl):
     def __call__(self, args):
         client = self.ctx.conn(args)
         obj = args.object
-        dtype = obj.__class__.name
+        # e.g. "ImageI" -> "Image"
+        dtype = obj.__class__.__name__[:-1]
         conn = BlitzGateway(client_obj=client)
         conn.SERVICE_OPTS.setOmeroGroup(-1)
 
-        if dtype == "FilesetI":
+        if dtype == "Fileset":
             fileset = self.get_object(conn, dtype, obj.id.val)
             self.download_fileset(conn, fileset, args.filename)
-        elif dtype == "ImageI":
+        elif dtype == "Image":
             image = self.get_object(conn, dtype, obj.id.val)
             self.download_fileset(conn, image.getFileset(), args.filename)
         else:
@@ -87,6 +88,7 @@ class DownloadControl(BaseControl):
             self.download_file(client, orig_file, target_file)
 
     def download_fileset(self, conn, fileset, dir_path):
+        self.ctx.out(f"Fileset: {fileset.id}")
         template_prefix = fileset.getTemplatePrefix()
         for orig_file in fileset.listFiles():
             file_path = orig_file.path.replace(template_prefix, "")


### PR DESCRIPTION
See https://forum.image.sc/t/download-full-projects-with-their-datasets/56434/

This adds support for:

```
$ omero download Fileset:ID download_dir
```
Files are downloaded to the named directory. If original files have a path that is longer than the fileset template prefix,
that path will be used to create additional directories inside the named directory.

The same behaviour is used for Images (this fixes the previous limitation of only a single-file for an Image):
```
$ omero download Image:ID download_dir
```

Other functionality to test for regressions:
```
$ omero download OriginalFile:ID download_filename
# assumes OriginalFile:
$ omero download ID download_filename
$ omero download FileAnnotation:ID download_filename
```