### PR TITLE
Add CHANGELOG for 5.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and structure.
 
 ## Bug Fix
 
-- CLI: point users at image.sc for reporting bugs
+- CLI: point users at [image.sc](https://forum.image.sc/) for reporting bugs
   [#297](https://github.com/ome/omero-py/pull/297)
 
 # 5.9.3 (July 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ renaming files. The command now specifies a directory path under which all
 files associated with the image are downloaded using the original file names
 and structure.
 
+## Bug Fix
+
+- CLI: point users at image.sc for reporting bugs
+  [#297](https://github.com/ome/omero-py/pull/297)
+
 # 5.9.3 (July 2021)
 
 ## Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 5.10.0 (September 2021)
+
+## New feature
+
+- omero.gateway: add new `getObjectsByMapAnnotations` API
+  [#285](https://github.com/ome/omero-py/pull/285)
+- CLI: Add support for downloading fileset and multi-file images [#298](https://github.com/ome/omero-py/pull/298)
+
+The CLI feature also introduces a backwards-incompatible layout change for
+the download of images to mitigate the risk of data corruption associated with
+renaming files. The command now specifies a directory path under which all
+files associated with the image are downloaded using the original file names
+and structure.
+
 # 5.9.3 (July 2021)
 
 ## Bug Fix


### PR DESCRIPTION
Release notes could also include https://github.com/ome/omero-py/pull/297 as a bug fix.

Apart from obvious typos, the main thing to review is the paragraph announcing the breaking layout change of `omero download Image:xxx` and the rationale. /cc @will-moore @joshmoore @pwalczysko 