### PR TITLE
import --fetch-jars: allow direct link

### DIFF
--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -576,7 +576,10 @@ class ImportControl(BaseControl):
             return None, omero_java_txt
 
     def download_omero_java(self, version):
-        omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
+        if version.startswith("http"):
+            omero_java_zip = version
+        else:
+            omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
         self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         jars_dir.makedirs_p()

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -36,6 +36,7 @@ import csv
 import sys
 import shlex
 import requests
+import re
 from zipfile import ZipFile
 
 
@@ -576,7 +577,7 @@ class ImportControl(BaseControl):
             return None, omero_java_txt
 
     def download_omero_java(self, version):
-        if version.startswith("http"):
+        if re.match("^\w+://", version):
             omero_java_zip = version
         else:
             omero_java_zip = OMERO_JAVA_ZIP.format(version=version)

--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -335,7 +335,7 @@ class ImportControl(BaseControl):
             " Default: etc/logback-cli.xml")
         add_python_argument(
             "--fetch-jars", type=str,
-            help="Download this version of OMERO.java jars and exit")
+            help="Download OMERO.java jars by version or URL, then exit")
 
         # The following arguments are strictly passed to Java
         name_group = parser.add_argument_group(
@@ -576,11 +576,11 @@ class ImportControl(BaseControl):
         else:
             return None, omero_java_txt
 
-    def download_omero_java(self, version):
-        if re.match("^\w+://", version):
-            omero_java_zip = version
+    def download_omero_java(self, version_or_uri):
+        if re.match("^\w+://", version_or_uri):
+            omero_java_zip = version_or_uri
         else:
-            omero_java_zip = OMERO_JAVA_ZIP.format(version=version)
+            omero_java_zip = OMERO_JAVA_ZIP.format(version=version_or_uri)
         self.ctx.err("Downloading %s" % omero_java_zip)
         jars_dir, omero_java_txt = self._userdir_jars(parentonly=True)
         jars_dir.makedirs_p()


### PR DESCRIPTION
see: https://github.com/ome/omero-py/pull/162/files#r494801779

allows usage such as:

```
omero import --fetch-jars https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastSuccessfulBuild/artifact/src/target/OMERO.java-5.6.3-150-65ec95d-ice36-b940.zip
```

Useful for testing:

```
omero import -f /tmp/a.ome.zarr/.zgroup
```

with https://github.com/ome/openmicroscopy/pull/6292