### PR TITLE
Ensure we are using pyopenssl (See ome/omero-py#240)

### DIFF
--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -15,6 +15,13 @@ import logging
 import requests
 standard_library.install_aliases()
 
+# Ensure we are using pyopenssl (ome/omero-py#240)
+try:
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3()
+except ImportError:
+    pass
+
 
 class UpgradeCheck(object):
 


### PR DESCRIPTION
As of (psf/requests#5443) released in requests 2.24.0 [1] the urllib3
monkeypatching in of pyopenssl now only happens if the SNI is
unavailable (mostly just Python 2).  The prevailing intent within
the requests project seems to be to avoid pyopenssl use where
possible.  Obviously, this is not what we need so we're going to
have to follow the requests and urllib3 advice to do it explictly.

I have chosen to only perform the explicit injection for the upgrade
check.  Other uses of requests which want to avoid the sort of weird
OpenSSL errors like those outlined in (ome/omero-py#240) will need to do
the same thing.

  1. https://github.com/psf/requests/blob/main/HISTORY.md#2240-2020-06-17