### PR TITLE
Decode script stdout/stderr before printing

### DIFF
--- a/src/omero/plugins/script.py
+++ b/src/omero/plugins/script.py
@@ -436,7 +436,7 @@ class ScriptControl(BaseControl):
         def p(m):
             class handle(object):
                 def write(this, val):
-                    val = "\t* %s" % val
+                    val = "\t* %s" % val.decode()
                     val = val.replace("\n", "\n\t* ")
                     self.ctx.out(val, newline=False)
 


### PR DESCRIPTION
This change fixes a `bytes`-`str` concatenation issue in `omero script launch` output under Python 3 that caused the stdout/stderr lines to be printed as their `repr`. Output that previously looked like this:
```
	* b'Image:1 : Processing...\n--------------------\n'
```
Now looks correct:
```
	* Image:1 : Processing...
	* --------------------
	* 
```
(Tracebacks are now readable again too)