### PR TITLE
Config output exclude versions

### DIFF
--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -169,11 +169,9 @@ HEADER = \
 
 %(properties)s"""
 
-BLACK_LIST = ("##", "versions", "omero.upgrades")
+BLACK_LIST = ("##", "versions", "omero.upgrades", "omero.version")
 
 STOP = "### END"
-
-EXCLUDED_VERSION = ["omero.version"]
 
 import os
 import argparse
@@ -217,9 +215,8 @@ class Property(object):
     def detect(self, line):
         dbg("detect:" + line)
         idx = line.index("=")
-        if line[0:idx] not in EXCLUDED_VERSION:
-            self.key = line[0:idx]
-            self.val = line[idx + 1:]
+        self.key = line[0:idx]
+        self.val = line[idx + 1:]
 
     def cont(self, line):
         dbg("cont:  " + line)

--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -173,7 +173,7 @@ BLACK_LIST = ("##", "versions", "omero.upgrades")
 
 STOP = "### END"
 
-VERSION = "version"
+EXCLUDED_VERSION = ["omero.version"]
 
 import os
 import argparse
@@ -217,7 +217,7 @@ class Property(object):
     def detect(self, line):
         dbg("detect:" + line)
         idx = line.index("=")
-        if VERSION not in line[0:idx]:
+        if line[0:idx] not in EXCLUDED_VERSION:
             self.key = line[0:idx]
             self.val = line[idx + 1:]
 

--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -169,7 +169,7 @@ HEADER = \
 
 %(properties)s"""
 
-BLACK_LIST = ("##", "versions", "omero.upgrades", "omero.version")
+EXCLUDE_LIST = ("##", "versions", "omero.upgrades", "omero.version")
 
 STOP = "### END"
 
@@ -278,7 +278,7 @@ class PropertyParser(object):
         return self.properties
 
     def black_list(self, line):
-        for x in BLACK_LIST:
+        for x in EXCLUDE_LIST:
             if line.startswith(x):
                 return True
 

--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -173,6 +173,8 @@ BLACK_LIST = ("##", "versions", "omero.upgrades")
 
 STOP = "### END"
 
+VERSION = "version"
+
 import os
 import argparse
 import fileinput
@@ -215,8 +217,9 @@ class Property(object):
     def detect(self, line):
         dbg("detect:" + line)
         idx = line.index("=")
-        self.key = line[0:idx]
-        self.val = line[idx + 1:]
+        if VERSION not in line[0:idx]:
+            self.key = line[0:idx]
+            self.val = line[idx + 1:]
 
     def cont(self, line):
         dbg("cont:  " + line)

--- a/test/unit/clitest/test_prefs.py
+++ b/test/unit/clitest/test_prefs.py
@@ -519,3 +519,16 @@ class TestPrefs(object):
         assert props[2].val == 'line1line2'
         assert props[3].key == 'f.g'
         assert props[3].val == '\\n'
+
+    def testConfigNoVersionPropertyParser(self, tmpdir):
+        cfg = tmpdir.join("test-noversion.properties")
+        s = "omero.version=5.6.1\na.1=a"
+        cfg.write(s)
+        pp = PropertyParser()
+        props = pp.parse_file(str(cfg))
+
+        # Fails, the last two properties are parsed as one:
+        # 'd.e' = 'line1line2f.g=\\n'
+        assert len(props) == 1
+        assert props[0].key == 'a.1'
+        assert props[0].val == 'a'

--- a/test/unit/clitest/test_prefs.py
+++ b/test/unit/clitest/test_prefs.py
@@ -522,13 +522,15 @@ class TestPrefs(object):
 
     def testConfigNoVersionPropertyParser(self, tmpdir):
         cfg = tmpdir.join("test-noversion.properties")
-        s = "omero.version=5.6.1\na.1=a"
+        s = "omero.version=5.6.1\na.1=a\nomero.db.version=5.4.0"
         cfg.write(s)
         pp = PropertyParser()
         props = pp.parse_file(str(cfg))
 
         # Fails, the last two properties are parsed as one:
         # 'd.e' = 'line1line2f.g=\\n'
-        assert len(props) == 1
+        assert len(props) == 2
         assert props[0].key == 'a.1'
         assert props[0].val == 'a'
+        assert props[1].key == 'omero.db.version'
+        assert props[1].val == '5.4.0'


### PR DESCRIPTION
Exclude keys with ``version`` from the output of the ``config parse`` command

cc @sbesson @joshmoore 
