### PR TITLE
Tables Out of Memory Issues

### DIFF
--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -518,8 +518,7 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
         for idx in rowNumbers:
             self.bytes.append(masks[idx].tolist())
 
-    def fromrows(self, all_rows):
-        rows = all_rows[self.name]
+    def fromrows(self, rows):
         # WORKAROUND:
         # http://www.zeroc.com/forums/bug-reports/4165-icepy-can-not-handle-buffers-longs-i64.html#post20468
         self.imageId = rows["i"].tolist()

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -102,7 +102,7 @@ class AbstractColumn(object):
                 rows = tbl.read_coordinates(rowNumbers, field=self.name)
             else:
                 rows = tbl.readCoordinates(rowNumbers, field=self.name)
-            self.fromrows(rows)
+        self.fromrows(rows)
 
     def read(self, tbl, start, stop):
         rows = tbl.read(start, stop, field=self.name)

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -150,7 +150,7 @@ class AbstractColumn(object):
         """
 
         if not field_only:
-            rows = all_rows[self.name]
+            rows = rows[self.name]
 
         self.values = rows
 

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -157,6 +157,7 @@ class AbstractColumn(object):
         # if isinstance(d, str):
         #     d = numpy.dtype(d)
         # if d.kind == "S" or (d.kind == "i" and d.itemsize == "8"):
+        self.values = self.values.tolist()
 
 
 class FileColumnI(AbstractColumn, omero.grid.FileColumn):

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -99,13 +99,13 @@ class AbstractColumn(object):
             rows = tbl.read()
         else:
             if has_pytables3:
-                rows = tbl.read_coordinates(rowNumbers)
+                rows = tbl.read_coordinates(rowNumbers, field=self.name)
             else:
-                rows = tbl.readCoordinates(rowNumbers)
-        self.fromrows(rows)
+                rows = tbl.readCoordinates(rowNumbers, field=self.name)
+            self.fromrows(rows)
 
     def read(self, tbl, start, stop):
-        rows = tbl.read(start, stop)
+        rows = tbl.read(start, stop, field=self.name)
         self.fromrows(rows)
 
     def getsize(self):
@@ -148,7 +148,7 @@ class AbstractColumn(object):
         Any method which does not use the "values" field
         will need to override this method.
         """
-        self.values = rows[self.name]
+        self.values = rows
         # WORKAROUND:
         # http://www.zeroc.com/forums/bug-reports/4165-icepy-can-not-handle-buffers-longs-i64.html#post20468
         # see ticket:1951 and #2160
@@ -157,7 +157,6 @@ class AbstractColumn(object):
         # if isinstance(d, str):
         #     d = numpy.dtype(d)
         # if d.kind == "S" or (d.kind == "i" and d.itemsize == "8"):
-        self.values = self.values.tolist()
 
 
 class FileColumnI(AbstractColumn, omero.grid.FileColumn):


### PR DESCRIPTION
We found that when retrieving a large number of rows from certain Omero tables, we were having memory issues even when only one small column was selected. Upon investigation, we found that whenever `column::read` is called, the entire table is retrieved for the requested number of rows (see https://github.com/ome/omero-py/blob/2b9d1b43f69e02d8784bfef50dd07415eb193f34/src/omero/columns.py#L108). Then the requested columns are subsequently filtered for (see https://github.com/ome/omero-py/blob/2b9d1b43f69e02d8784bfef50dd07415eb193f34/src/omero/columns.py#L151).
The PyTables API allows for the passing of a "field" argument into it's `read` and `readCoordinates` functions which will filter for the specified column by name (see https://github.com/PyTables/PyTables/blob/a51c549c1555050d72e0aeb2ff5e04d48a71b1b4/tables/table.py#L1747). In this PR, we use this argument to prevent retrieval of the entire table for each column. 