### PR TITLE
Don't ignore params limit if offset is None

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3386,11 +3386,10 @@ class _BlitzGateway (object):
             if lmt is not None:
                 limit = lmt.val
 
-        baseParams.theFilter = omero.sys.Filter()
         if limit is not None:
-            baseParams.theFilter.limit = rint(limit)
-        if offset is not None:
-            baseParams.theFilter.offset = rint(offset)
+            if offset is None:
+                offset = 0
+            baseParams.page(offset, limit)
 
         # getting object by ids
         if ids is not None:

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3381,13 +3381,16 @@ class _BlitzGateway (object):
             # pagination
             ofs = params.theFilter.offset
             lmt = params.theFilter.limit
-            if ofs is not None and lmt is not None:
+            if ofs is not None:
                 offset = ofs.val
+            if lmt is not None:
                 limit = lmt.val
-            # Other params args will be ignored unless we handle here
 
-        if limit is not None and offset is not None:
-            baseParams.page(offset, limit)
+        baseParams.theFilter = omero.sys.Filter()
+        if limit is not None:
+            baseParams.theFilter.limit = rint(limit)
+        if offset is not None:
+            baseParams.theFilter.offset = rint(offset)
 
         # getting object by ids
         if ids is not None:


### PR DESCRIPTION
Fixes #320 

To test:

The params `limit` should not be ignored:
```
params = omero.sys.ParametersI()
params.theFilter = omero.sys.Filter()
params.theFilter.limit = wrap(1)
images = list(conn.getObjects("Image", params=params))
assert len(images) == 1
```

I'll add an integration test...

cc @erickmartins @joshmoore 