### PR TITLE
Method to add time to ParametersI

### DIFF
--- a/src/omero_sys_ParametersI.py
+++ b/src/omero_sys_ParametersI.py
@@ -359,4 +359,8 @@ class ParametersI(omero.sys.Parameters):
         self.add(name, rstring(stringValue))
         return self
 
+    def addTime(self, name, TimeValue):
+        self.add(name, rtime(TimeValue))
+        return self
+
 _omero_sys.ParametersI = ParametersI

--- a/test/unit/test_parameters.py
+++ b/test/unit/test_parameters.py
@@ -196,6 +196,16 @@ class TestParameters(object):
         p.addLong("long", rlong(1))
         assert rlong(1) == p.map["long"]
 
+    def testAddTimeRaw(self):
+        p = ParametersI()
+        p.addTime("time", 1)
+        assert rtime(1) == p.map["time"]
+
+    def testAddTimeRType(self):
+        p = ParametersI()
+        p.addTime("time", rtime(1))
+        assert rtime(1) == p.map["time"]
+
     def testAddIds(self):
         p = ParametersI()
         p.addIds([1, 2])


### PR DESCRIPTION
Added new addTime() method for `omero.sys.ParametersI` class. Added tests to test this method.

Without this PR, adding `rtime` type object required manual mapping:
```python
params = omero.sys.ParametersI()
date = datetime.datetime.fromtimestamp(1)
params.map["Date"] = omero.rtypes.rtime(date)
```
With this PR, it is possible to add the date directly:
```python
params = omero.sys.ParametersI()
date = datetime.datetime.fromtimestamp(1)
params.addTime("Date", date)
```