### PR TITLE
Also pass omero.db.properties to reindex

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1817,7 +1817,7 @@ present, the user will enter a console""")
         cfg = config.as_map()
         omero_data_dir = self._get_data_dir(config)
         config.close()  # Early close. See #9800
-        for x in ("name", "user", "host", "port"):
+        for x in ("name", "user", "host", "port", "properties"):
             # NOT passing password on command-line
             k = "omero.db.%s" % x
             if k in cfg:


### PR DESCRIPTION
Under certain conditions, in particular those where a specific `sslmode` [^1] is required, `omero.db.properties` is an essential property that must be provided for the reindexing code to be able to communicate with the database.

[^1]: https://jdbc.postgresql.org/documentation/head/ssl-client.html