### PR TITLE
setChannelNames performance

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3964,9 +3964,10 @@ class _BlitzGateway (object):
         if data_type == "Image":
             imageIds = [int(i) for i in ids]
         elif data_type == "Dataset":
-            images = self.getContainerService().getImages(
-                "Dataset", ids, None, self.SERVICE_OPTS)
-            imageIds = [i.getId().getValue() for i in images]
+            imageIds = []
+            for dataset_id in ids:
+                images = self.getObjects("Image", opts={'dataset': dataset_id})
+                imageIds.extend([i.id for i in images])
         elif data_type == "Plate":
             imageIds = []
             plates = self.getObjects("Plate", ids)


### PR DESCRIPTION
See https://forum.image.sc/t/apply-channel-names-to-all-images-in-an-omero-dataset-possible-bug/70521/12

It seems that `conn.setChannelNames()` is very slow in cross-group queries (which is the default behaviour for omero-web) and this is due to `containerService.getImages("Dataset", ids)`.
This PR should improve the speed by using a much faster alternative. See forum above for performance comparison.

Should also help fix other issues with setChannelNames: https://github.com/ome/omero-web/issues/304

To test:
 - Rename channels in a Dataset
 - Should work as before, but feel a bit faster