### PR TITLE
Add changelog for 5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 5.12.0 (September 2022)
+
+## New features
+
+-   ParametersI now supports `addTime()` method [#327](https://github.com/ome/omero-py/pull/327)
+-   Pass `omero.db.properties` to reindex command [#329](https://github.com/ome/omero-py/pull/329)
+
+
+## Bug fixes
+
+-   Fix concurrency issues in pytest [#328](https://github.com/ome/omero-py/pull/328)
+-   Improve performance of channel renaming for Datasets [#331](https://github.com/ome/omero-py/pull/331)
+
 # 5.11.2 (May 2022)
 
 ## Bug fix


### PR DESCRIPTION
I'd like to get #331 merged and released, to see how much that fixes channel rename issues.

I notice there's a few PRs open that could be considered for this release, including 2 with `5.12.0` milestone.

cc @joshmoore @jburel any other PRs ready to add to this release?