### PR TITLE
Always report pixeldata time in the output of fs importtime

### DIFF
--- a/src/omero/plugins/fs.py
+++ b/src/omero/plugins/fs.py
@@ -1263,6 +1263,7 @@ class ImportTime(object):
         self.metrics['UPLOAD'] = upload_end - upload_start
         self.metrics['SET_ID'] = set_id_end - upload_end
         self.metrics['METADATA'] = metadata_end - set_id_end
+        self.metrics['PIXELDATA'] = pixeldata_end - metadata_end
 
         if overlays_start:
             if settings_start:
@@ -1273,9 +1274,6 @@ class ImportTime(object):
                 self.metrics['OVERLAY'] = thumbnails_end - pixeldata_end
 
         if settings_start:
-            # If there are no rendering settings, pyramids must be built first.
-            self.metrics['PIXELDATA'] = pixeldata_end - metadata_end
-
             if thumbnails_start:
                 self.metrics['RDEF'] = thumbnails_start - settings_start
                 self.metrics['THUMBNAIL'] = thumbnails_end - thumbnails_start


### PR DESCRIPTION
While investigating, mismatches between the sum of the import times reported by the CLI command and the import logs, I realised the time for completing this step is being skipped if no rendering settings are assigned. In addition to pyramid generation, several actions are being performed including min/max calculation and pixel/series assignment.

## Testing

Without this PR, import a file e.g. a fake image/plate with and without setting the thumbnails

```
omero import "test&plateRows=4&plateCols=4.fake"
omero import "test&plateRows=4&plateCols=4.fake" --skip thumbnails
```

Then run `omero fs importtime Fileset:<id>` on both filesets. Without this PR the `pixeldata` step of the second command should be omitted from the output. With this PR included, it should be reported in both cases

