### PR TITLE
Remove Anonymous Diffie-Hellman default configuration

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -229,18 +229,6 @@ class BaseClient(object):
         self._optSetProp(id, "Ice.Default.PreferSecure", "1")
         self._optSetProp(id, "Ice.Plugin.IceSSL", "IceSSL:createIceSSL")
 
-        prop = "IceSSL.Ciphers"
-        try:
-            if sys.platform == "darwin":
-                self._optSetProp(id, prop, "(AES_256) (DH_anon.*AES)")
-            elif ssl.OPENSSL_VERSION_INFO >= (1, 1):
-                self._optSetProp(id, prop, "HIGH:ADH:@SECLEVEL=0")
-            else:
-                self._optSetProp(id, prop, "HIGH:ADH")
-        except Exception:
-            # OPENSSL_VERSION_INFO not available for 2.6, fall back to default
-            self._optSetProp(id, prop, "HIGH:ADH")
-
         self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1_0,tls1_1,tls1_2")


### PR DESCRIPTION
Since OMERO 5.6.2 (released in July, 2020) we have been recommending the use of `omero certificates` to ensure that all OMERO server installations have, at minimum, a self-signed certificate. Consequently, I think it's time we removed the Anonymous Diffie-Hellman (ADH) default configuration from omero-py.

We know that the detection is error prone and that ADH support is not present in newer OpenSSL versions.  So this change also helps us seamlessly support newer Linux distributions such as Ubuntu 22.04 as well as CentOS/RHEL/Rocky 9 and allows us to utilize manylinux wheels where OpenSSL version mismatches were making detection an ugly mess.

Cipher suites and minimum TLS version can still be enforced by server configuration.