### PR TITLE
bulk.yml depth is passed to xargs

### DIFF
--- a/src/omero/plugins/import.py
+++ b/src/omero/plugins/import.py
@@ -672,6 +672,8 @@ class ImportControl(BaseControl):
                         mode = "w"
                     else:
                         mode = "a"
+                    if command_args.depth:
+                        xargs.append("-Domero.import.depth=%s" % command_args.depth)
                     self.do_import(command_args, xargs, mode=mode)
                 if self.ctx.rv:
                     failed += 1


### PR DESCRIPTION
When performing bulk import, any `depth: 100` value added to the `bulk.yml` is currently ignored and you have to use `--depth=100` on the command line.

This attempts to fix that issue.

This fix works, BUT it now overrides any value passed on the command-line (which probably should take precedence)?
However, at this point in the code, I can't check `xarg` for the presence of any `-Domero.import.depth` command, since this is always there with the default of 4.

Not quite sure where the "right" place is to fix this?

cc @sbesson @joshmoore @dominikl 