### PR TITLE
omero admin diagnostics: move OMERO.py version as part of the output

### DIFF
--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1081,9 +1081,9 @@ class DiagnosticsControl(BaseControl):
 
         self.ctx.out("""
 %s
-OMERO Diagnostics (%s) %s
+OMERO Diagnostics (%s)
 %s
-        """ % ("="*80, control_name, VERSION, "="*80))
+        """ % ("="*80, control_name, "="*80))
 
     def _sz_str(self, sz):
         if sz < 1000:

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -58,6 +58,11 @@ from omero_version import ice_compatibility
 
 from omero.util._process_defaultxml import _process_xml
 
+try:
+    from omero_version import omero_version
+    VERSION = omero_version
+except ImportError:
+    VERSION = "Unknown"  # Usually during testing
 
 try:
     import pywintypes
@@ -1111,6 +1116,16 @@ present, the user will enter a console""")
         return ['<property name="%s" value="%s"/>' % kv
                 for kv in list(glacier2_icessl.items())]
 
+    def get_omero_server_version(self):
+        """Returns the value of omero.version stored in omero.properties"""
+        omero_props_file = old_div(self._get_etc_dir(), "omero.properties")
+        with open(omero_props_file, 'r') as f:
+            for line in f.readlines():
+                if line.startswith("omero.version"):
+                    idx = line.index("=")
+                    return line[idx + 1:].rstrip()
+        return "unknown"
+
     @with_config
     def rewrite(self, args, config, force=False):
         """
@@ -1299,6 +1314,12 @@ present, the user will enter a console""")
         iga = version(["icegridadmin", "--version"])
         version(["psql",         "--version"])
         version(["openssl",      "version"])
+
+        self.ctx.out("")
+        self._item("Component", "OMERO.py")
+        self.ctx.out(VERSION)
+        self._item("Component", "OMERO.server")
+        self.ctx.out(self.get_omero_server_version())
 
         def get_ports(input):
             router_lines = [line for line in input.split("\n")

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1118,7 +1118,7 @@ present, the user will enter a console""")
 
     def get_omero_server_version(self):
         """Returns the value of omero.version stored in omero.properties"""
-        omero_props_file = old_div(self._get_etc_dir(), "omero.properties")
+        omero_props_file = os.path.join(self._get_etc_dir(), "omero.properties")
         with open(omero_props_file, 'r') as f:
             for line in f.readlines():
                 if line.startswith("omero.version"):


### PR DESCRIPTION
The historical behavior of the `omero admin diagnostics` is to output a title line of type `OMERO Diagnostics (plugin) version`. Since OMERO 5.6.0 and the decoupling of OMERO.py from OMERO.server, this leads to ambiguity as this will display the OMERO.py version but will typically be executed on a server environment.

This commit proposes to strip the version from the command title and instead report the versions of OMERO.py and OMERO.server as separate entries under the report.

To test this PR, run `omero admin diagnostics` on OMERO.server ideally with and without this change and compare the output