### PR TITLE
fix header from install package

### DIFF
--- a/src/omero/install/bzip2_tool.py
+++ b/src/omero/install/bzip2_tool.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
-
-   Function for enabling/disabling the bzip2.dll which
-   comes with PyTables.
-
-   Copyright 2009 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
+#
+# Copyright 2009 Glencoe Software, Inc. All rights reserved.
+# Use is subject to license terms supplied in LICENSE.txt
 
 """
+Function for enabling/disabling the bzip2.dll which
+comes with PyTables.
+"""
+
 from __future__ import print_function
 
 import os

--- a/src/omero/install/logs_library.py
+++ b/src/omero/install/logs_library.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# 
+# Copyright 2010 Glencoe Software, Inc. All rights reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+# 
+# Josh Moore <josh@glencoesoftware.com>
+
 """
-
-   Function for parsing OMERO log files.
-   The format expected is defined for Python in
-   omero.util.configure_logging.
-
-   Copyright 2010 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
-
-   :author: Josh Moore <josh@glencoesoftware.com>
-
+Function for parsing OMERO log files.
+The format expected is defined for Python in
+omero.util.configure_logging.
 """
 from __future__ import division
 from __future__ import print_function

--- a/src/omero/install/python_warning.py
+++ b/src/omero/install/python_warning.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-   python helper plugin
 
-   Copyright 2016 University of Dundee. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
+#
+# Copyright 2016 University of Dundee. All rights reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+
+"""
+Python helper plugin 
 """
 
 import sys

--- a/src/omero/install/versions.py
+++ b/src/omero/install/versions.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# $Id$
-#
 # Copyright 2009 Glencoe Software, Inc. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #

--- a/src/omero/install/win_set_path.py
+++ b/src/omero/install/win_set_path.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# 
+# Copyright 2009 Glencoe Software, Inc. All rights reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+# Josh Moore <josh@glencoesoftware.com>
+
 """
-
-   Function for setting the working directory for an
-   Omero installation on Windows, since relative paths
-   are not supported.
-
-   Copyright 2009 Glencoe Software, Inc. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
-
-   :author: Josh Moore <josh@glencoesoftware.com>
-
+Function for setting the working directory for an
+Omero installation on Windows, since relative paths
+are not supported.
 """
 from __future__ import print_function
 

--- a/src/omero/install/windows_warning.py
+++ b/src/omero/install/windows_warning.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
-   windows helper plugin
 
-   Copyright 2009-2016 University of Dundee. All rights reserved.
-   Use is subject to license terms supplied in LICENSE.txt
+#
+# Copyright 2009-2016 University of Dundee. All rights reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+
+"""
+windows helper plugin
+
 """
 
 from functools import wraps


### PR DESCRIPTION
This PR updates the header so it can be correctly displayed in the APi doc generation
for example see https://omero-py.readthedocs.io/en/latest/omero.install.bzip2_tool.html