### PR TITLE
Tmp files doc gen

### DIFF
--- a/src/omero/util/temp_files.py
+++ b/src/omero/util/temp_files.py
@@ -71,7 +71,7 @@ class TempFileManager(object):
                     break
             raise Exception(
                 "Failed to create temporary directory: %s" % self.userdir)
-        self.dir = old_div(self.userdir, self.pid())
+        self.dir = os.path.join(self.userdir, self.pid())
         """
         Directory under which all temporary files and folders will be created.
         An attempt to remove a path not in this directory will lead to an

--- a/src/omero/util/temp_files.py
+++ b/src/omero/util/temp_files.py
@@ -80,13 +80,13 @@ class TempFileManager(object):
 
         # Now create the directory. If a later step throws an
         # exception, we should try to rollback this change.
-        if not self.dir.exists():
-            self.dir.makedirs()
+        if not path(self.dir).exists():
+            os.makedirs(self.dir)
         self.logger.debug("Using temp dir: %s" % self.dir)
 
         self.lock = None
         try:
-            self.lock = open(str(old_div(self.dir, ".lock")), "a+")
+            self.lock = open(str(os.path.join(self.dir, ".lock")), "a+")
             """
             .lock file under self.dir which is used to prevent other
             TempFileManager instances (also in other languages) from
@@ -312,9 +312,9 @@ class TempFileManager(object):
         Deletes self.dir
         """
         dir = self.gettempdir()
-        if dir.exists():
+        if path(dir).exists():
             self.logger.debug("Removing tree: %s", dir)
-            dir.rmtree(onerror=self.on_rmtree)
+            path(dir).rmtree(onerror=self.on_rmtree)
 
     def clean_userdir(self):
         """

--- a/src/omero/util/temp_files.py
+++ b/src/omero/util/temp_files.py
@@ -201,7 +201,6 @@ class TempFileManager(object):
                             self.logger.debug("Failed os.remove(%s)", name)
 
             except Exception as e:
-                print(e)
                 if "Operation not permitted" in str(e) or \
                    "Operation not supported" in str(e):
 


### PR DESCRIPTION
Just to look at the changes

```
WARNING: autodoc: failed to import module 'temp_files' from module 'util'; the following exception was raised:
Traceback (most recent call last):
  File "/Users/jmarie/opt/anaconda3/envs/git/lib/python3.8/site-packages/sphinx/ext/autodoc/importer.py", line 70, in import_module
    return importlib.import_module(modname)
  File "/Users/jmarie/opt/anaconda3/envs/git/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/jmarie/Documents/git-repo/omero-py/docs/../src/omero/util/temp_files.py", line 349, in <module>
    manager = TempFileManager()
  File "/Users/jmarie/Documents/git-repo/omero-py/docs/../src/omero/util/temp_files.py", line 58, in __init__
    self.userdir = old_div(self.tmpdir(), ("%s_%s" %
  File "/Users/jmarie/Documents/git-repo/omero-py/docs/../src/omero/util/temp_files.py", line 159, in tmpdir
    targets.append(path(tempfile.gettempdir()) / "omero" / "tmp")
TypeError: unsupported operand type(s) for /: 'path' and 'str'

```