### PR TITLE
omero.clients: initialize connection retry reason out of the while loop

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -627,8 +627,8 @@ class BaseClient(object):
             # Acquire router and get the proxy
             prx = None
             retries = 0
+            reason = None
             while retries < 3:
-                reason = None
                 if retries > 0:
                     self.__logger.warning(
                         "%s - createSession retry: %s" % (reason, retries))


### PR DESCRIPTION
Fixes #352 

The logic should be unchanged by the exception shouldn't be reset to `None` and displayed on each retry