### PR TITLE
Add inherited-members option to the gateway automodule configuration

### DIFF
--- a/docs/omero.gateway.rst
+++ b/docs/omero.gateway.rst
@@ -24,5 +24,6 @@ Module contents
 .. automodule:: gateway
    :members:
    :inherited-members:
+   :private-members:
    :undoc-members:
    :show-inheritance:

--- a/docs/omero.gateway.rst
+++ b/docs/omero.gateway.rst
@@ -23,5 +23,6 @@ Module contents
 
 .. automodule:: gateway
    :members:
+   :inherited-members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
As most of these classes are effectively aliases/inherited, the current generated API documentation is pretty bare for the omero.gateway package as most methods are inherited from private base classes. This commit investigates using the inherited-members option to expose the docstrings