### PR TITLE
Deprecate omero.install.python_warning module

### DIFF
--- a/src/omero/install/python_warning.py
+++ b/src/omero/install/python_warning.py
@@ -11,7 +11,10 @@ Python helper plugin
 
 import sys
 import platform
+import warnings
 
+warnings.warn(
+    "This module is deprecated as of OMERO.py 5.6.0", DeprecationWarning)
 
 PYTHON_WARNING = ("Python version %s is not "
                   "supported!" % platform.python_version())


### PR DESCRIPTION
Noticed while fixing a bug on the OMERO.web CLI plugin (see https://github.com/ome/omero-web/pull/436), this module is no longer relevant since OMERO.py 5.6.0 and the migration to Python 3.x
