### PR TITLE
CLI sessions: handle case where retry is not passed as an argument

### DIFF
--- a/src/omero/plugins/sessions.py
+++ b/src/omero/plugins/sessions.py
@@ -545,7 +545,11 @@ class SessionsControl(UserGroupControl):
                             break
                         except Exception as e:
                             elapsed = (time.time() - start)
-                            if not args.retry or (elapsed > args.retry):
+                            cannot_retry = (
+                                'retry' not in vars(args) or
+                                not args.retry or
+                                elapsed > args.retry)
+                            if cannot_retry:
                                 raise
                             else:
                                 retries += 1


### PR DESCRIPTION
Some logic was introduced in https://github.com/ome/omero-py/pull/283 to allow auto-retries in the CLI sessions plugin. This new functionality is disabled by default. As can be seen in the original PR, most of the testing has been done using `omero sessions login` where the functionality was introduced.

Most CLI plugins can inherit the login mechanism: the addition of `add_login_arguments()` in the CLI plugin sub-parser means the `self.ctx.conn(args)` can then use `self.controls["sessions"].login(args)`.

As the `--retry` argument was only added to the sessions plugin, a misleading error message can be printed under some scenarios. The most typical ones and the easiest to reproduce is to enter an incorrect password.  The `login` command produces the expected behavior with 3 tries by defaut:

```
(venv3) [sbesson@prod114-omeroreadwrite ~]$ omero login public@localhost -C
Password:
Password check failed for 'public': [id=52]
Password:
Password check failed for 'public': [id=52]
Password:
3 incorrect password attempts
```

But any other command will fail immediately with a cryptic `InternalException`

```
(venv3) [sbesson@prod114-omeroreadwrite ~]$ omero hql 'select * from Image i' -u public -s localhost -C
Password:
InternalException: Failed to connect: 'Namespace' object has no attribute 'retry'
```

e5ac9c67d1e6b39913c840af05da6c7a73adcf1a proposes one way to fix this issue by adding an additional check for the existence of the `retry` in the `var(args)` dictionary and would make the two examples above behave identically.
An alternate strategy would be to add `--retry` to `Parser. add_login_arguments` and allow all sub-commands to set the value.