### PR TITLE
cap urllib3 to avoid openssl issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ setup(
     },
     python_requires='>=3',
     install_requires=[
+        'urllib3<2',
         'appdirs',
         'future',
         'numpy',


### PR DESCRIPTION
Problem noticed when running the omero-server job on CentOS 7 with SCL Python 3.8
cc @sbesson @khaledk2 