### PR TITLE
OMERO.py 5.14.0: changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## Other updates
 
 - Add Python 3.10 to the testing matrix [#357](https://github.com/ome/omero-py/pull/357)
-- Readme updates [#358](https://github.com/ome/omero-py/pull/358) [#363](https://github.com/ome/omero-py/pull/363) [#369](https://github.com/ome/omero-py/pull/369)
+- Readme updates [#358](https://github.com/ome/omero-py/pull/358), [#363](https://github.com/ome/omero-py/pull/363), [#369](https://github.com/ome/omero-py/pull/369)
 - Update GitHub workflow actions [#365](https://github.com/ome/omero-py/pull/365)
 
 # 5.13.1 (November 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 5.14.0 (June 2023)
+
+## Bug fix
+
+- OMERO.cli: do not fail on the absence of --retry argument [#364](https://github.com/ome/omero-py/pull/364)
+
+## Deprecated
+
+- Deprecate omero.install.python_warning module [#362](https://github.com/ome/omero-py/pull/362)
+- Drop support for Python 3.7 [#368](https://github.com/ome/omero-py/pull/368)
+
+## Other updates
+
+- Add Python 3.10 to the testing matrix [#357](https://github.com/ome/omero-py/pull/357)
+- Readme updates [#358](https://github.com/ome/omero-py/pull/358) [#363](https://github.com/ome/omero-py/pull/363) [#369](https://github.com/ome/omero-py/pull/369)
+- Update GitHub workflow actions [#365](https://github.com/ome/omero-py/pull/365)
+
 # 5.13.1 (November 2022)
 
 ## Other updates


### PR DESCRIPTION
See https://github.com/ome/omero-py/pull/364#issuecomment-1600517295

Given the deprecation of a module as well as the update in Python support, proposing to increment the minor version number