### PR TITLE
Use Image.LANCZOS alias rather than Image.ANTIALIAS

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -9308,7 +9308,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             else:
                 size = (int(width * ratio), int(size))
             jpeg_data = Image.open(BytesIO(jpeg_data))
-            jpeg_data.thumbnail(size, Image.ANTIALIAS)
+            jpeg_data.thumbnail(size, Image.LANCZOS)
             ImageDraw.Draw(jpeg_data)
             f = BytesIO()
             jpeg_data.save(f, "JPEG")


### PR DESCRIPTION
These aliases are strictly equivalent but the latter has been deprecated in Pillow 9.1 and dropped in Pillow 10 - see https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html