### PR TITLE
Let Ice choose the default SSL protocols that are available

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -231,7 +231,6 @@ class BaseClient(object):
 
         self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
-        self._optSetProp(id, "IceSSL.Protocols", "tls1_0,tls1_1,tls1_2")
 
         # Setting block size
         self._optSetProp(


### PR DESCRIPTION
This setting made sense when we were still supporting SSLv3 but that has been disabled by default since Ice 3.6:

 * https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.Protocols

Consequently, it's better to leave this setting as the default and let the server dictate what it expects since we do not have a complete overlap in TLS version support on the platforms we support (CentOS 7 does not support TLS 1.3).  This setting currently forbids clients from negotiating TLS 1.3 where it is available.  Ice will use sane defaults on these platforms.