### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/src/omero/cli.py
+++ b/src/omero/cli.py
@@ -1120,7 +1120,7 @@ OMERO Diagnostics (%s)
                              r'error:?\s')
                 warn = 0
                 err = 0
-                for l in p.lines(errors="surrogateescape"):
+                for l in p.lines(encoding="utf-8", errors="surrogateescape"):
                     # ensure errors/warnings search is case-insensitive
                     lcl = l.lower()
                     if re.match(warn_regex, lcl):


### PR DESCRIPTION
Log files like e.g. the `Blitz-0.log` are containing references to files being uploaded by users, i.e. there is no reasonable assumption that can be made over what people will put into their file names.

Parsing the logs e.g. via "omero admin diagnostics" will fail with a UnicodeDecodeError when hitting lines referring to such file names.

Force-setting the encoding to "utf-8" here fixes this problem for us.