### PR TITLE
omero admin start: add warning for deprecated TLS protocols

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -800,20 +800,21 @@ present, the user will enter a console""")
                 "sysadmins/server-performance.html?highlight=poolsize\n"
                 "for more information.")
 
-        ssl_protocols = config.get("omero.glacier2.IceSSL.Protocols", "")
-        # TLS 1.0 and 1.1 were deprecated in https://datatracker.ietf.org/doc/html/rfc8996
+        # Warn if deprecated TLS 1.0 and 1.1 protocols are allowed
+        # See https://datatracker.ietf.org/doc/html/rfc8996
         # Both protocols are included in the default value of IceSSL.Protocols
         # https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.Protocols
-        has_deprecated_tls = (
-            ssl_protocols == "" or
-            "TLS1_0" in ssl_protocols or
-            "TLS1_1" in ssl_protocols
-        )
-        if has_deprecated_tls:
-            self.ctx.out(
-                "WARNING: Your server is configured to allow a deprecated TLS protocol.\n"
-                "\nPlease refer to https://omero.readthedocs.io/en/stable/sysadmins/server-upgrade.html"
-                " for instructions on how to upgrade the protocols.")
+        DEPRECATED_TLS_MESSAGE = (
+            "Your server is configured to allow a deprecated TLS protocol."
+            "\n\nPlease refer to https://omero.readthedocs.io/en/stable/"
+            "sysadmins/server-upgrade.html for instructions on how to "
+            "upgrade the protocols.")
+        try:
+            ssl_protocols = config["omero.glacier2.IceSSL.Protocols"]
+            if ("TLS1_0" in ssl_protocols or "TLS1_1" in ssl_protocols):
+                self.ctx.out("WARNING: " + DEPRECATED_TLS_MESSAGE)
+        except KeyError:
+            self.ctx.out("WARNING: " + DEPRECATED_TLS_MESSAGE)
 
         self._initDir()
         # Do a check to see if we've started before.

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -800,6 +800,21 @@ present, the user will enter a console""")
                 "sysadmins/server-performance.html?highlight=poolsize\n"
                 "for more information.")
 
+        ssl_protocols = config.get("omero.glacier2.IceSSL.Protocols", "")
+        # TLS 1.0 and 1.1 were deprecated in https://datatracker.ietf.org/doc/html/rfc8996
+        # Both protocols are included in the default value of IceSSL.Protocols
+        # https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.Protocols
+        has_deprecated_tls = (
+            ssl_protocols == "" or
+            "TLS1_0" in ssl_protocols or
+            "TLS1_1" in ssl_protocols
+        )
+        if has_deprecated_tls:
+            self.ctx.out(
+                "WARNING: Your server is configured to allow a deprecated TLS protocol.\n"
+                "\nPlease refer to https://omero.readthedocs.io/en/stable/sysadmins/server-upgrade.html"
+                " for instructions on how to upgrade the protocols.")
+
         self._initDir()
         # Do a check to see if we've started before.
         self._regdata()

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -807,8 +807,8 @@ present, the user will enter a console""")
         DEPRECATED_TLS_MESSAGE = (
             "Your server is configured to allow a deprecated TLS protocol."
             "\n\nPlease refer to https://omero.readthedocs.io/en/stable/"
-            "sysadmins/server-upgrade.html for instructions on how to "
-            "upgrade the protocols.")
+            "sysadmins/server-upgrade.html#server-certificates for "
+            "instructions on how to upgrade your configuration.")
         try:
             ssl_protocols = config["omero.glacier2.IceSSL.Protocols"]
             if ("TLS1_0" in ssl_protocols or "TLS1_1" in ssl_protocols):


### PR DESCRIPTION
The message should be raised either if omero.glacier2.IceSSL.Protocols is unset or if TLS 1.0 or 1.1 are found in the list of allowed protocols

Implements the suggestion in https://github.com/ome/omero-certificates/pull/36#issuecomment-1691376331.
The warning refers to the server upgrade page for the instructions but happy to use another reference page if needed.