### PR TITLE
use math module instead of numpy.math

### DIFF
--- a/src/omero/util/roi_handling_utils.py
+++ b/src/omero/util/roi_handling_utils.py
@@ -25,8 +25,9 @@ from __future__ import division
 
 from builtins import map
 from past.utils import old_div
-from numpy import asarray, int32, math, zeros, hstack, vstack
+from numpy import asarray, int32, zeros, hstack, vstack
 import omero.util.script_utils as script_utils
+import math
 
 
 def get_line_data(pixels, x1, y1, x2, y2, line_w=2, the_z=0, the_c=0, the_t=0):


### PR DESCRIPTION
This should fix the warning noticed in the updated CI
```
/home/omero/workspace/OMERO-test-integration/.venv3/lib64/python3.9/site-packages/omero/util/roi_handling_utils.py:28: DeprecationWarning: `np.math` is a deprecated alias for the standard library `math` module (Deprecated Numpy 1.25). Replace usages of `np.math` with `math`
23:16:31     from numpy import asarray, int32, math, zeros, hstack, vstack
```