### PR TITLE
Add jstack command

### DIFF
--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -284,6 +284,24 @@ Examples:
                                           action="append",
                                           exclusive=False)
 
+        jstack = Action(
+            "jstack",
+            """Print active threads from the OMERO backend.
+
+If installed, the `jstack` tool will be invoked on
+the OMERO Java processes.
+
+Examples:
+
+  # By default, print the threads from the main Java process (Blitz-0)
+  omero admin jstack
+
+            """).parser
+        jstack.add_argument(
+            "--service",
+            default="Blitz-0",
+            help="Service name. '*' designates all services)")
+
         Action(
             "rewrite",
             """Regenerate the IceGrid configuration files
@@ -1663,6 +1681,38 @@ present, the user will enter a console""")
         finally:
             cb.close(True)
 
+
+    @with_config
+    def jstack(self, args, config):
+        """
+        """
+        if args.service == "*":
+            # TODO: get a list of services
+            services = ("Blitz-0", "Indexer-0", "PixelData-0")
+        else:
+            services = (args.service,)
+
+        unknown_services = 0
+        for service in services:
+            pid = self.check_service(service, return_pid=True)
+            if pid is None:
+                unknown_services += 1
+                self.ctx.err(f"service not running: {service}")
+            else:
+                self.ctx.err(f"Loading jstack for {service} ({pid})")
+                popen = self.ctx.popen(["jstack", str(pid)])
+                popen.wait()
+                jstack = popen.communicate()
+                jstack = [x.decode("utf-8") for x in jstack]
+                # TODO: offer to write to file
+                self.ctx.out("stdout:")
+                self.ctx.out(jstack[0])
+                self.ctx.err("stderr:")
+                self.ctx.err(jstack[1])
+
+        if unknown_services:
+                self.ctx.die(f"{unknown_services} unknown service(s)")
+
     def getdirsize(self, directory, strict=True):
         """
         Uses os.walk to calculate the deep size of the given
@@ -2009,12 +2059,19 @@ present, the user will enter a console""")
         self.ctx.controls["hql"].display(
             mapped, ("node", "session", "started", "owner", "agent", "notes"))
 
-    def check_service(self, name):
+    def check_service(self, name, return_pid=False):
         command = self._cmd()
         command.extend(["-e", "server pid %s" % name])
         p = self.ctx.popen(command)  # popen
         rc = p.wait()
-        return rc == 0
+        rv = rc == 0
+        if return_pid:
+            if rv:
+                return p.communicate()[0].decode("utf-8").strip()
+            else:
+                return None
+        else:
+            return rv
 
     def start_service(self, name):
         command = self._cmd()


### PR DESCRIPTION
Initial work on a jstack command which allows `omero admin jstack` to determine the pid of
the given process ("Blitz-0" by default) and pass that to the local `jstack` tool.

<details><summary>Example</summary>

```
omero admin jstack
Loading jstack for Blitz-0 (1160)
stdout:
2024-01-22 14:58:04
Full thread dump OpenJDK 64-Bit Server VM (11.0.21+9-LTS mixed mode, sharing):

Threads class SMR info:
_java_thread_list=0x00007fffac000c30, length=48, elements={
0x00007ffff8027800, 0x00007ffff840e000, 0x00007ffff8410800, 0x00007ffff841a000,
0x00007ffff841c000, 0x00007ffff841e000, 0x00007ffff8420000, 0x00007ffff8422000,
0x00007ffff846f000, 0x00007ffff8d4c800, 0x00007ffff8e99800, 0x00007ffff927c800,
0x00007ffff9285800, 0x00007ffff946d800, 0x00007ffff94ff800, 0x00007ffff959f800,
0x00007ffff9dc4000, 0x00007ffff9dc7000, 0x00007fff34007000, 0x00007fff34003800,
0x00007fff34005000, 0x00007fff3400b800, 0x00007ffff9390800, 0x00007ffff988b000,
0x00007ffff989d000, 0x00007fff3400d000, 0x00007ffffa205000, 0x00007ffed4001800,
0x00007ffef0059800, 0x00007fff8c002800, 0x00007ffed4002800, 0x00007fff8c003800,
0x00007fff50dd9800, 0x00007fff88a7b800, 0x00007ffed4004800, 0x00007ffec0001000,
0x00007fff50dda800, 0x00007ffec8001800, 0x00007ffed4005800, 0x00007ffefc01d000,
0x00007ffec0002800, 0x00007ffee40cb800, 0x00007fff50ddb000, 0x00007fff00007000,
0x00007ffec8002800, 0x00007ffef8029800, 0x00007fffac001000, 0x00007ffebc001000
}

"main" #1 prio=5 os_prio=0 cpu=11314.58ms elapsed=10209.15s tid=0x00007ffff8027800 nid=0x4a0 in Object.wait()  [0x00007ffffe961000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.21/Native Method)
	- waiting on <0x000000066437b428> (a IceInternal.ObjectAdapterFactory)
	at java.lang.Object.wait(java.base@11.0.21/Object.java:328)
	at IceInternal.ObjectAdapterFactory.waitForShutdown(ObjectAdapterFactory.java:63)
	- waiting to re-lock in wait() <0x000000066437b428> (a IceInternal.ObjectAdapterFactory)
	at Ice.CommunicatorI.waitForShutdown(CommunicatorI.java:32)
	at ome.services.blitz.Entry.start(Entry.java:202)
	at ome.services.blitz.Entry.main(Entry.java:146)

"Reference Handler" #2 daemon prio=10 os_prio=0 cpu=6.46ms elapsed=10209.04s tid=0x00007ffff840e000 nid=0x4be waiting on condition  [0x00007fffe024d000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.ref.Reference.waitForReferencePendingList(java.base@11.0.21/Native Method)
	at java.lang.ref.Reference.processPendingReferences(java.base@11.0.21/Reference.java:241)
	at java.lang.ref.Reference$ReferenceHandler.run(java.base@11.0.21/Reference.java:213)
```

</details>


Possible features:
- [ ] better handling of missing `jstack` command.
- [ ] write to a file
- [ ] use a patterned file name
- [ ] periodically repeat

cc: @pwalczysko 