### PR TITLE
get objects by map annotations list

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4293,7 +4293,7 @@ class _BlitzGateway (object):
             query += "and ann.ns = " + ns
         query += """
             group by obj.id 
-            having count(*) = %s
+            having count(*) >= %s
         """ % key_vals_count
 
         # Return objects

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4290,7 +4290,7 @@ class _BlitzGateway (object):
         """ % (wrapper().OMERO_CLASS, keys_str, vals_str)
         # filter by namespace
         if ns is not None:
-            query += "and ann.ns = " + ns
+            query += "and ann.ns = '" + ns + "'"
         query += """
             group by obj.id 
             having count(*) >= %s

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4280,16 +4280,21 @@ class _BlitzGateway (object):
             params.page(offset, limit)
 
         # Query
-        query = f"""
-            select distinct obj.id from {obj_type}AnnotationLink oal
+        query = """
+            select distinct obj.id from %sAnnotationLink oal
             join oal.parent obj 
             join oal.child ann 
             join ann.mapValue mv
-            where mv.name in {keys_str}
-            and mv.value in {vals_str}
+            where mv.name in %s
+            and mv.value in %s
+        """ % (wrapper().OMERO_CLASS, keys_str, vals_str)
+        # filter by namespace
+        if ns is not None:
+            query += "and ann.ns = " + ns
+        query += """
             group by obj.id 
-            having count(*) = {key_vals_count}
-        """
+            having count(*) = %s
+        """ % key_vals_count
 
         # Return objects
         result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)


### PR DESCRIPTION
This pull request adds an additional gateway method, `getObjectsByMapAnnotationsList` to filter objects by a user provided list of map annotations, derived from the already provided `getObjectsByMapAnnotations`

```python
# List of key/value pairs to filter by
kv_pairs = [
    {
        'key': 'key1',
        'value': 'val1'
    },
    {
        'key': 'key2',
        'value': 'val2'
    },
    {
        'key': 'key3',
        'value': 'key3'
    }
]

# filter by object type and key/val filter
conn.getObjectsByMapAnnotationsList('Image', key_vals=kv_pairs)

#filter by object type, key/val filter, and namespace
conn.getObjectsByMapAnnotationsList('Image', key_vals=kv_pairs, ns='openmicroscopy.org/omero/client/mapAnnotation')
```