### PR TITLE
added `_repr_html_` method for `_ImageWrapper`

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -10474,10 +10474,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             {self.getSizeZ()},
             {self.getSizeY()},
             {self.getSizeX()})"""
-        physical_dims = f"""(
-            {self.getPixelSizeZ()},
-            {self.getPixelSizeY()},
-            {self.getPixelSizeX()})"""
+        physical_dims = """({:.3f}, {:.3f}, {:.3f})""".format(
+            self.getPixelSizeZ(),
+            self.getPixelSizeY(),
+            self.getPixelSizeX())
         physical_units = f"""(
             {self.getPixelSizeZ(units=True).getUnit()},
             {self.getPixelSizeY(units=True).getUnit()},

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -10426,6 +10426,107 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             return count[0][0].getValue()
         return len(self._get_rois(shapeType, filterByCurrentUser))
 
+    def _repr_html_(self):
+        import base64
+
+        html_style_header = """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Image Details</title>
+            <style>
+                img {
+                    min-width: 250px; /* Set the minimum width for all images */
+                    min-height: 250px; /* Set the minimum height for all images */
+                }
+                .align-top {
+                vertical-align: top;
+                }
+                .text-right {
+                text-align: right;
+                }
+            </style>
+        </head>
+        """
+
+        # create a sub-table for image information
+        table_imageinfo = f"""
+        <table>\n
+            <tr>\n
+                <td><b>Image name: </b></td> <td class=text-right>{self.getName()}</td>\n
+            </tr>\n
+            <tr>\n
+                <td><b>Image ID: </b></td>  <td class=text-right>{self.getId()}</td>\n
+            </tr>\n
+            <tr>\n
+                <td><b>Project ID: </b></td>   <td class=text-right>{self.getProject().getId()}</td>\n
+            </tr>\n
+        </table>
+        """
+
+        # get entries for thumbnail and dimensions
+        encoded_image = base64.b64encode(self.getThumbnail()).decode('utf-8')
+        dimensions = f"""(
+            {self.getSizeT()},
+            {self.getSizeC()},
+            {self.getSizeZ()},
+            {self.getSizeY()},
+            {self.getSizeX()})"""
+        physical_dims = f"""(
+            {self.getPixelSizeZ()},
+            {self.getPixelSizeY()},
+            {self.getPixelSizeX()})"""
+        physical_units = f"""(
+            {self.getPixelSizeZ(units=True).getUnit()},
+            {self.getPixelSizeY(units=True).getUnit()},
+            {self.getPixelSizeX(units=True).getUnit()})"""
+
+        table_dimensions = f"""
+        <table>\n
+            <tr>\n
+                <td><b>Dimensions (TCZYX): </b></td> <td class=text-right>{dimensions}</td>\n
+            </tr>\n
+            <tr>\n
+                <td><b>Voxel/Pixel dimensions (ZYX): </b></td> <td class=text-right>{physical_dims}</td>\n
+            </tr>\n
+            <tr>\n
+                <td><b>Physical units: </b></td> <td class=text-right>{physical_units}</td>\n
+            </tr>\n
+            <tr>\n
+                <td><b>Channel Names: </b></td> <td class=text-right>{self.getChannelLabels()}</td>\n
+            </tr>\n
+        </table>
+        """
+
+        table_assembly = f"""
+        <table>
+        <tr>
+            <td><div class="thumbnail">
+                <img src="data:image/jpeg;base64,{encoded_image}" alt="Thumbnail">
+            </div></td>
+            <td class="align-top"><h2>Image information </h2>
+            {table_imageinfo}
+            </td>
+        </tr>
+        </table>
+        <table>
+            <tr>
+                <td>{table_dimensions}</td>
+            </tr>
+        </table>
+        """
+
+        return '\n'.join([
+            html_style_header,
+            '<body>',
+            table_assembly,
+            '</body>',
+            '</html>'
+        ])
+
+
 ImageWrapper = _ImageWrapper
 
 # INSTRUMENT AND ACQUISITION #

--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -225,6 +225,17 @@ def propertiesToDict(m, prefix=None):
 def image_to_html(image):
     import base64
 
+    try:
+        pixsizeX = '{:.3f}'.format(image.getPixelSizeX())
+        pixsizeY = '{:.3f}'.format(image.getPixelSizeY())
+        pixsizeZ = '{:.3f}'.format(image.getPixelSizeZ())
+        UnitX = image.getPixelSizeX().getUnit()
+        UnitY = image.getPixelSizeY().getUnit()
+        UnitZ = image.getPixelSizeZ().getUnit()
+    except:
+        pixsizeX, pixsizeY, pixsizeZ = 'na', 'na', 'na'
+        UnitX, UnitY, UnitZ = 'na', 'na', 'na'
+
     html_style_header = """
     <!DOCTYPE html>
     <html lang="en">
@@ -273,14 +284,8 @@ def image_to_html(image):
         {image.getSizeZ()},
         {image.getSizeY()},
         {image.getSizeX()})"""
-    physical_dims = """({:.3f}, {:.3f}, {:.3f})""".format(
-        image.getPixelSizeZ(),
-        image.getPixelSizeY(),
-        image.getPixelSizeX())
-    physical_units = f"""(
-        {image.getPixelSizeZ(units=True).getUnit()},
-        {image.getPixelSizeY(units=True).getUnit()},
-        {image.getPixelSizeX(units=True).getUnit()})"""
+    physical_dims = f"""({pixsizeZ}, {pixsizeY}, {pixsizeX})""".format()
+    physical_units = f"""({UnitZ}, {UnitY}, {UnitX})"""
 
     table_dimensions = f"""
     <table>\n

--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -221,3 +221,106 @@ def propertiesToDict(m, prefix=None):
         except:
             d[items[-1]] = value
     return nested_dict
+
+def image_to_html(image):
+    import base64
+
+    html_style_header = """
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Image Details</title>
+        <style>
+            img {
+                min-width: 250px; /* Set the minimum width for all images */
+                min-height: 250px; /* Set the minimum height for all images */
+            }
+            .align-top {
+            vertical-align: top;
+            }
+            .text-right {
+            text-align: right;
+            }
+        </style>
+    </head>
+    """
+
+    def obj_html(obj, otype):
+        return f"""<tr>
+                <td><b>{otype}</b></td>
+                <td class=text-right>{obj.id if obj else ""}</td>
+                <td class=text-right>{obj.name if obj else ""}</td>
+                </tr>
+            """
+
+    # create a sub-table for image information
+    table_imageinfo = f"""
+    <table>
+        <tr><th></th><th>ID</th><th>Name</th></tr>
+        {obj_html(image, 'Image')}
+        {obj_html(image.getParent(), 'Dataset')}
+        {obj_html(image.getProject(), 'Project')}
+    </table>
+    """
+
+    # get entries for thumbnail and dimensions
+    encoded_image = base64.b64encode(image.getThumbnail()).decode('utf-8')
+    dimensions = f"""(
+        {image.getSizeT()},
+        {image.getSizeC()},
+        {image.getSizeZ()},
+        {image.getSizeY()},
+        {image.getSizeX()})"""
+    physical_dims = """({:.3f}, {:.3f}, {:.3f})""".format(
+        image.getPixelSizeZ(),
+        image.getPixelSizeY(),
+        image.getPixelSizeX())
+    physical_units = f"""(
+        {image.getPixelSizeZ(units=True).getUnit()},
+        {image.getPixelSizeY(units=True).getUnit()},
+        {image.getPixelSizeX(units=True).getUnit()})"""
+
+    table_dimensions = f"""
+    <table>\n
+        <tr>\n
+            <td><b>Dimensions (TCZYX): </b></td> <td class=text-right>{dimensions}</td>\n
+        </tr>\n
+        <tr>\n
+            <td><b>Voxel/Pixel dimensions (ZYX): </b></td> <td class=text-right>{physical_dims}</td>\n
+        </tr>\n
+        <tr>\n
+            <td><b>Physical units: </b></td> <td class=text-right>{physical_units}</td>\n
+        </tr>\n
+        <tr>\n
+            <td><b>Channel Names: </b></td> <td class=text-right>{image.getChannelLabels()}</td>\n
+        </tr>\n
+    </table>
+    """
+
+    table_assembly = f"""
+    <table>
+    <tr>
+        <td><div class="thumbnail">
+            <img src="data:image/jpeg;base64,{encoded_image}" alt="Thumbnail">
+        </div></td>
+        <td class="align-top"><h2>Image information </h2>
+        {table_imageinfo}
+        </td>
+    </tr>
+    </table>
+    <table>
+        <tr>
+            <td>{table_dimensions}</td>
+        </tr>
+    </table>
+    """
+
+    return '\n'.join([
+        html_style_header,
+        '<body>',
+        table_assembly,
+        '</body>',
+        '</html>'
+    ])


### PR DESCRIPTION
Fixes #393 

## Description

This PR overwrites the `repr_html` for the `_imageWrapper` class to show a html overview object in Jupyter Notebooks whenever an `ImageWrapper` object is sown in a cell. In essence, it creates an html object and fills it with some essential information about the image. Currently displayed:

- Image ID
- Project ID
- Description
- Image Name
- Image dimensions (TCZYX)
- Voxel dimensions (currently output with long names (e.g. `MICROMETER` - there is probably a way to add the units as µm or whatever it is set to).
- Channel names

Let me know what else you would consider relevant or added/changed in the displayed object. I am by no means an html expert, so there is certainly some room for improvement there :)