### PR TITLE
Config property for passing environment variables (see #395)

### DIFF
--- a/src/omero/processor.py
+++ b/src/omero/processor.py
@@ -147,23 +147,37 @@ class ProcessI(omero.grid.Process, omero.util.SimpleServant):
     #
 
     def make_env(self):
-        self.env = omero.util.Environment(
-            "CLASSPATH",
-            "DISPLAY",
-            "DYLD_LIBRARY_PATH",
-            "HOME",
-            "JYTHON_HOME",
-            "LC_ALL",
-            "LANG",
-            "LANGUAGE",
-            "LD_LIBRARY_PATH",
-            "MLABRAW_CMD_STR",
-            "OMERODIR",
-            "OMERO_TEMPDIR",
-            "OMERO_TMPDIR",
-            "PATH",
-            "PYTHONPATH",
-        )
+        variables = self.ctx.get("omero.process.env_vars", None)
+        if variables is None:
+            variables = (
+                # For backwards compatibility
+                "CLASSPATH",
+                "DISPLAY",
+                "DYLD_LIBRARY_PATH",
+                "HOME",
+                "JYTHON_HOME",
+                "LC_ALL",
+                "LANG",
+                "LANGUAGE",
+                "LD_LIBRARY_PATH",
+                "MLABRAW_CMD_STR",
+                "OMERODIR",
+                "OMERO_TEMPDIR",
+                "OMERO_TMPDIR",
+                "PATH",
+                "PYTHONPATH",
+                # issue:395
+                "http_proxy",
+                "HTTP_PROXY",
+                "https_proxy",
+                "HTTPS_PROXY",
+                "no_proxy",
+                "NO_PROXY",
+            )
+        else:
+            variables = variables.split(",")
+
+        self.env = omero.util.Environment(*variables)
 
         # Since we know the location of our OMERO, we're going to
         # force the value for OMERO_HOME. This is useful in scripts


### PR DESCRIPTION
Rather than needing to update omero-py each time a new env variable needs passing to a script, this adds the

```
omero.processor.env_vars
```

property which can be updated. Likely needs more discussion since possibly this should be an "additional" list.