### PR TITLE
getGridSize() handles plates with no Wells

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -6656,7 +6656,10 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     "where plate.id = :id"
             res = q.projection(query, params, self._conn.SERVICE_OPTS)
             (row, col) = res[0]
-            self._gridSize = {'rows': row.val+1, 'columns': col.val+1}
+            if row is None or col is None:
+                self._gridSize = {'rows': 0, 'columns': 0}
+            else:
+                self._gridSize = {'rows': row.val+1, 'columns': col.val+1}
         return self._gridSize
 
     def getWellGrid(self, index=0):

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -6645,6 +6645,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         Iterates all wells on plate to retrieve grid size as {'rows': rSize,
         'columns':cSize} dict.
+        If the Plate has no Wells, it will return {'rows': 0, 'columns': 0}
 
         :rtype:     dict of {'rows': rSize, 'columns':cSize}
         """


### PR DESCRIPTION
Fixes error from QA: https://www.openmicroscopy.org/qa2/qa/feedback/41352/

```
{"message": "'NoneType' object has no attribute 'val'", "stacktrace": "Traceback (most recent call last):
File \"/opt/omero/web/venv3/lib64/python3.9/site-packages/omeroweb/webgateway/views.py\", line 1500, in wrap
 rv = f(request, *args, **kwargs)
 File \"/opt/omero/web/venv3/lib64/python3.9/site-packages/omeroweb/webgateway/views.py\", line 1708, in plateGrid_json
 rv = plateGrid.metadata
 File \"/opt/omero/web/venv3/lib64/python3.9/site-packages/omeroweb/webgateway/plategrid.py\", line 71, in metadata
self.plate.setGridSizeConstraints(8, 12)
 File \"/opt/omero/web/venv3/lib64/python3.9/site-packages/omero/gateway/__init__.py\", line 6637, in setGridSizeConstraints
 gs = self.getGridSize()\n File \"/opt/omero/web/venv3/lib64/python3.9/site-packages/omero/gateway/__init__.py\", line 6659, in getGridSize
 self._gridSize = {'rows': row.val+1, 'columns': col.val+1}
AttributeError: 'NoneType' object has no attribute 'val'
"}
```

To test, create a Plate with no Wells:

```
$ omero obj new Plate name=empty
```

Browse in webclient:

![Screenshot 2024-02-14 at 15 56 17](https://github.com/ome/omero-py/assets/900055/f983f166-2d6c-434c-8ca4-942f5ca297c5)


