### PR TITLE
Add changelog for 5.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 5.19.0 (February 2024)
+
+- Removal of python-future compatibility code [#390](https://github.com/ome/omero-py/pull/390)
+
+This release adds preliminary support for running OMERO.py on Python 3.12 environments.
+
+The `future` dependency should be considered as deprecated and will be removed in the
+next minor release of OMERO.py. Downstream projects who are relying on this
+dependency should declare them explicitly in their configuration file.
+
 # 5.18.0 (January 2024)
 
 ## Other updates


### PR DESCRIPTION
Add blurb about preliminary Python 3.12 support and the roadmap for removing the `future` dependency