### PR TITLE
Fix Windows regression in omero_ext.path

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - python-version: '3.8'
             os: macos-latest
+          - python-version: '3.9'
+            os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get tox target
@@ -33,7 +35,7 @@ jobs:
           echo "py=$py" >> $GITHUB_OUTPUT
         shell: bash
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -51,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Build package

--- a/src/omero_ext/path.py
+++ b/src/omero_ext/path.py
@@ -61,7 +61,11 @@ try:
 except ImportError:
     pass
 
-import pwd
+try:
+    import pwd
+except ImportError:
+    pass
+
 from functools import reduce
 
 getcwdu = os.getcwd


### PR DESCRIPTION
135a7128d8e304f52448f8ba2a0a465e741279b5 partly reverts commit efbb1a48338fe9c729cbd67776dc0886b5028fa5 which disabled the CI builds on Windows 2022 as Ice 3.6.5 requires additional patches for building and led to some regression in the Python 3.12 support work. This commit reintroduces Windows 2019 as a target operating system with a Python version (3.9) with > 1 year of support. It also upgrade the underlying GitHub actions for Node.js 20.

8f160161d7ef3ce8832eda388c9e0ef88266202e reintroduces the try/except block removed in f0548101b658d2030d01c31f35de28506efcd865 which led to regression on Windows systems where pwd is not installed.

Usin a Windows system using OMERO.py 5.19.0, any script or command e.g. `omero login` trying to import `omero_ext.path` should fail with a `ModuleNotFoundError`. With this PR, the same script or command should complete successfully.

Given it is a regression, proposing to schedule this for an emergency `5.19.1` patch release once testing is complete.

/cc @mabruce @erindiel 