### PR TITLE
Consume pre-build Ice Python wheel packages on Windows builds

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,11 +21,10 @@ jobs:
           - '3.12'
         os:
           - ubuntu-22.04
+          - windows-2019
         include:
           - python-version: '3.8'
             os: macos-latest
-          - python-version: '3.9'
-            os: windows-2019
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get tox target

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,11 @@ deps =
     https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp38-cp38-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.8"
     https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp39-cp39-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.9"
     https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp310-cp310-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.10"
+    https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp38-cp38-win_amd64.whl; platform_system=="Windows" and python_version=="3.8"
+    https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp39-cp39-win_amd64.whl; platform_system=="Windows" and python_version=="3.9"
+    https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp310-cp310-win_amd64.whl; platform_system=="Windows" and python_version=="3.10"
+    https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp311-cp311-win_amd64.whl; platform_system=="Windows" and python_version=="3.11"
+    https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/download/20240325/zeroc_ice-3.6.5-cp312-cp312-win_amd64.whl; platform_system=="Windows" and python_version=="3.12"
     # zeroc-ice installed automatically on other platforms (setup.py install_requires)
     pywin32; platform_system=="Windows"
     jinja2


### PR DESCRIPTION
Uses the newly pre-built Ice wheel packages for Windows x86_64 - see https://github.com/glencoesoftware/zeroc-ice-py-win-x86_64/releases/tag/20240325

Builds and unit test should now be running for Python 3.8 -> 3.12 on Windows 2019