### PR TITLE
FilesetWrapper lazy loads Images and UsedFiles

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7552,15 +7552,41 @@ class _FilesetWrapper (BlitzObjectWrapper):
             "join fetch usedFile.originalFile"
         return query, [], omero.sys.ParametersI()
 
+    def _loadImages(self):
+        """ Load the Images linked to this Fileset """
+        params = omero.sys.ParametersI()
+        params.addId(self.getId())
+        query_svc = self._conn.getQueryService()
+        query = "select image from Image as image where image.fileset.id=:id"
+        self._obj._imagesSeq = query_svc.findAllByQuery(query, params,
+                                                        self._conn.SERVICE_OPTS)
+        self._obj._imagesLoaded = True
+
     def copyImages(self):
         """ Returns a list of :class:`ImageWrapper` linked to this Fileset """
+        if not self._obj._imagesLoaded:
+            self._loadImages()
+
         return [ImageWrapper(self._conn, i) for i in self._obj.copyImages()]
+
+    def _loadUsedFiles(self):
+        """ Load the UsedFiles linked to this Fileset """
+        params = omero.sys.ParametersI()
+        params.addId(self.getId())
+        query_svc = self._conn.getQueryService()
+        query = "select fse from FilesetEntry as fse join fetch fse.originalFile where fse.fileset.id=:id"
+        self._obj._usedFilesSeq = query_svc.findAllByQuery(query, params,
+                                                           self._conn.SERVICE_OPTS)
+        self._obj._usedFilesLoaded = True
 
     def listFiles(self):
         """
         Returns a list of :class:`OriginalFileWrapper` linked to this Fileset
         via Fileset Entries
         """
+        if not self._obj._usedFilesLoaded:
+            self._loadUsedFiles()
+
         return [OriginalFileWrapper(self._conn, f.originalFile)
                 for f in self._obj.copyUsedFiles()]
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7535,20 +7535,6 @@ class _FilesetWrapper (BlitzObjectWrapper):
 
     OMERO_CLASS = 'Fileset'
 
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("Fileset").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = "select obj from Fileset obj"
-        return query, [], omero.sys.ParametersI()
-
     def _loadImages(self):
         """ Load the Images linked to this Fileset """
         params = omero.sys.ParametersI()

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7546,10 +7546,7 @@ class _FilesetWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = "select obj from Fileset obj "\
-            "left outer join fetch obj.images as image "\
-            "left outer join fetch obj.usedFiles as usedFile " \
-            "join fetch usedFile.originalFile"
+        query = "select obj from Fileset obj"
         return query, [], omero.sys.ParametersI()
 
     def _loadImages(self):


### PR DESCRIPTION
Fixes #404.

When we do `conn.getObject('Fileset', fileset_id)` we don't try to load all Images and Files up front.
Instead, these are lazily loaded as required using the same pattern as for other Wrapper objects.

Test that `fileset.copyImages()` and `fileset.listFiles()` behaviour don't change:

E.g. test script should show no change:

`python test.py 123`

```
import argparse

from omero.cli import cli_login
from omero.gateway import BlitzGateway

def main(args):
    parser = argparse.ArgumentParser()
    parser.add_argument('fileset', type=int)
    args = parser.parse_args(args)
    fileset_id = args.fileset

    with cli_login() as cli:
        conn = BlitzGateway(client_obj=cli._client)

        fileset = conn.getObject('Fileset', fileset_id)

        for i in fileset.copyImages():
            print("Image", i.id, i.name)

        for f in fileset.listFiles():
            print("File", f.id, f.name)


if __name__ == '__main__':
    import sys
    main(sys.argv[1:])
```
