### PR TITLE
use gs wheel to match doc

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,9 @@ deps =
     pytest-xdist
     pytest-mock
     restructuredtext-lint
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
+    https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp38-cp38-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
+    https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+    https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp310-cp310-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.12"
     https://github.com/glencoesoftware/zeroc-ice-py-macos-x86_64/releases/download/20220722/zeroc_ice-3.6.5-cp38-cp38-macosx_10_15_x86_64.whl; platform_system!="Windows" and platform_system!="Linux" and python_version=="3.8"


### PR DESCRIPTION
This PR modifies the wheels used for testing when using Python 3.8, 3.9 and 3.10
This is to match the recommendation introduced in https://github.com/ome/omero-documentation/pull/2427