### PR TITLE
Enforce numpy is lower than 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ setup(
         'urllib3<2',
         'appdirs',
         'future',
-        'numpy',
+        'numpy<2',
         'Pillow>=10.0.0',
         'PyYAML',
         'zeroc-ice>=3.6.5,<3.7',


### PR DESCRIPTION
Reported by @chris-allan

The backwards incompatibel changes associated with the latest major release of NumPy need to be assessed separately.

Proposing for an immediate 5.19.3 patch release