### PR TITLE
Fix reconnection issue

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -1970,9 +1970,9 @@ class _BlitzGateway (object):
             finally:
                 oldC.__del__()
                 oldC = None
-                self.c = None
                 self._session = None
                 self._sessionUuid = None
+                self._resetOmeroClient()
 
         self._proxies = NoProxies()
         logger.info("closed connection (uuid=%s)" % str(self._sessionUuid))


### PR DESCRIPTION
fix issue as described in #413 
I added a test for my problem to the tests from @sbesson in #400 
```
from omero.gateway import BlitzGateway
import omero

print("Connect with user/password, no secure argument")
with BlitzGateway(username=user, passwd=password, host=host) as conn:
    print("Connected: " + str(conn.connect()))
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    print("Creating encrypted client")
    conn.setSecure(True)
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")

print("\n")
print("Connect with user/password and secure=False")
with BlitzGateway(username=user, passwd=password, host=host, secure=False) as conn:
    print("Connected: " + str(conn.connect()))
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    print("Creating encrypted client")
    conn.setSecure(True)
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")

print("\n")
print("Connect with user/password and secure=True")
with BlitzGateway(username=user, passwd=password, host=host, secure=True) as conn:
    print("Connected: " + str(conn.connect()))
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    print("Creating unencrypted client")
    conn.setSecure(False)
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")

c = omero.client(host)
c.createSession(user, password)

print("\n")
print("Connect with encrypted client object")
with BlitzGateway(client_obj=c) as conn:
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    print("Creating unencrypted client")
    conn.setSecure(False)
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    c.closeSession()

c = omero.client(host)
c.createSession(user, password)
c2 = c.createClient(secure=False)
c.__del__()

print("\n")
print("Connect with unencrypted client object")
with BlitzGateway(client_obj=c2) as conn:
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    print("Creating encrypted client")
    conn.setSecure(True)
    print(f"conn.c.isSecure: {conn.c.isSecure()} "
          f"conn.isSecure: {conn.isSecure()} "
          f"conn.secure: {conn.secure}")
    c2.closeSession()

print("\n")
print("Connect with encrypted client object and secure=False")
c = omero.client(host)
c.createSession(user, password)
try:
    conn = BlitzGateway(client_obj=c, secure=False)
except Exception as e:
    print(str(e))
    c.closeSession()


c = omero.client(host)
c.createSession(user, password)
c2 = c.createClient(secure=False)
c.__del__()
print("Connect with unencrypted client object and secure=True")

try:
    conn = BlitzGateway(client_obj=c2, secure=True)
except Exception as e:
    print(str(e))
    c2.closeSession()

print("\n")
print("Connect then reconnect")
conn = BlitzGateway(username=user, passwd=password, host=host, secure=False)
print("Connected: " + str(conn.connect()))
conn.close()
print("Reconnected: " + str(conn.connect()))
```
which gives our desired outputs
```
Connect with user/password, no secure argument
Connected: True
conn.c.isSecure: False conn.isSecure: False conn.secure: False
Creating encrypted client
conn.c.isSecure: True conn.isSecure: True conn.secure: True


Connect with user/password and secure=False
Connected: True
conn.c.isSecure: False conn.isSecure: False conn.secure: False
Creating encrypted client
conn.c.isSecure: True conn.isSecure: True conn.secure: True


Connect with user/password and secure=True
Connected: True
conn.c.isSecure: True conn.isSecure: True conn.secure: True
Creating unencrypted client
conn.c.isSecure: False conn.isSecure: False conn.secure: False


Connect with encrypted client object
conn.c.isSecure: True conn.isSecure: True conn.secure: True
Creating unencrypted client
conn.c.isSecure: False conn.isSecure: False conn.secure: False


Connect with unencrypted client object
conn.c.isSecure: False conn.isSecure: False conn.secure: False
Creating encrypted client
conn.c.isSecure: True conn.isSecure: True conn.secure: True


Connect with encrypted client object and secure=False
Secure flag False and True do not match
Connect with unencrypted client object and secure=True
Secure flag True and False do not match


Connect then reconnect
Connected: True
Reconnected: True
```
the unit tests were passing on my fork.
instead of setting self.c to none I reset the client object.
Let me know if there's any test failures or considerations I should make. Thanks!