### PR TITLE
Parse omero.logging properties under new Logging heading

### DIFF
--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -44,6 +44,7 @@ GRID_HEADER = Header("Grid", reference="grid")
 ICE_HEADER = Header("Ice", reference="ice")
 LDAP_HEADER = Header("LDAP", reference="ldap")
 JVM_HEADER = Header("JVM", reference="jvm")
+LOGGING_HEADER = Header("Logging", reference="log")
 MISC_HEADER = Header("Misc", reference="misc")
 PERFORMANCE_HEADER = Header("Performance", reference="performance")
 SCRIPTS_HEADER = Header("Scripts", reference="scripts")
@@ -59,6 +60,7 @@ HEADER_MAPPING = {
     "omero.managed": FS_HEADER,
     "omero.ldap": LDAP_HEADER,
     "omero.jvmcfg": JVM_HEADER,
+    "omero.logging": LOGGING_HEADER,
     "omero.sessions": PERFORMANCE_HEADER,
     "omero.threads": PERFORMANCE_HEADER,
     "omero.throttling": PERFORMANCE_HEADER,


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/pull/6393, this adds the corresponding changes to the `omero config parse [--rst]` command so that the properties gets properly parsed and included in a new section under https://omero.readthedocs.io/en/stable/sysadmins/config.html

To test these changes, a server binary needs to be built with the changes from https://github.com/ome/openmicroscopy/pull/6393. Running `OMERODIR=path_to_server omero config parse --rst` should now include a Logging section with all `omero.logging` properties descriptions and their default values.

I expect that with the current 5.6.11 release of OMERO.server which does not includes these properties under `etc/omero.properties`, these additions should be a no-op and not impact the generated documentation.