### PR TITLE
Switch result logging to DEBUG level

### DIFF
--- a/src/omero/util/decorators.py
+++ b/src/omero/util/decorators.py
@@ -71,6 +71,8 @@ def remoted(func):
             rv = func(*args, **kwargs)
             if log.isEnabledFor(logging.DEBUG):
                 log.debug(__RESULT, rv)
+            else:
+                log.info(__RESULT, type(rv))
             return rv
         except Exception as e:
             log.info(__EXCEPT, e)

--- a/src/omero/util/decorators.py
+++ b/src/omero/util/decorators.py
@@ -69,7 +69,8 @@ def remoted(func):
             self = args[0]
             log.info(" Meth: %s.%s", self.__class__.__name__, func.__name__)
             rv = func(*args, **kwargs)
-            log.info(__RESULT, rv)
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug(__RESULT, rv)
             return rv
         except Exception as e:
             log.info(__EXCEPT, e)


### PR DESCRIPTION
Converting every remoted result value to a string can be an incredibly expensive operation. This is especially true if hundreds of thousands of table cells, along with their row indices are passing through the OMERO.tables API. In such a scenario the `omero.grid.Data` object will be fully converted to a string and then the first 120 characters logged which can take longer than the query, slice or read operation itself.

Rather than remove the functionality entirely, which might be justified (the first 120 characters is rarely that useful), I've opted to raise the level to debug. This impacts OMERO.tables and the script Processor logging.

The change improves performance and memory usage when retrieving even moderate amounts of data quite substantially. We could look to adjusting OMERO.web's `MAX_TABLE_DOWNLOAD_ROWS` up accordingly.

/cc @erindiel, @kkoz, @DavidStirling, @emilroz 