### PR TITLE
admin rewrite: make OMERO.tables module configurable

### DIFF
--- a/src/omero/install/config_parser.py
+++ b/src/omero/install/config_parser.py
@@ -48,6 +48,7 @@ MISC_HEADER = Header("Misc", reference="misc")
 PERFORMANCE_HEADER = Header("Performance", reference="performance")
 SCRIPTS_HEADER = Header("Scripts", reference="scripts")
 SECURITY_HEADER = Header("Security", reference="security")
+TABLES_HEADER = Header("Tables", reference="tables")
 
 HEADER_MAPPING = {
     "omero.data": FS_HEADER,
@@ -66,6 +67,7 @@ HEADER_MAPPING = {
     "omero.process": SCRIPTS_HEADER,
     "omero.scripts": SCRIPTS_HEADER,
     "omero.security": SECURITY_HEADER,
+    "omero.tables": TABLES_HEADER,
     "omero.resetpassword": SECURITY_HEADER,
     "omero.upgrades": MISC_HEADER,
     "Ice": ICE_HEADER,

--- a/src/omero/plugins/admin.py
+++ b/src/omero/plugins/admin.py
@@ -1198,7 +1198,9 @@ present, the user will enter a console""")
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
             '@omero.master.host@': config.get('omero.master.host', config.get(
-                'Ice.Default.Host', '127.0.0.1'))
+                'Ice.Default.Host', '127.0.0.1')),
+            "@omero.tables.module@": config.get(
+                "omero.tables.module", "runTables")
             }
 
         client_transports = config.get('omero.client.icetransports', 'ssl,tcp')


### PR DESCRIPTION
Add @omero.tables.module@ to the list of templates to be substituted in the server IceGrid XML templates and replaces it with the value. of `omero.tables.module` in the OMERO configuration, using `runTables` as the default.

This change should be a no-op when used with OMERO.server binaries up to 5.6.11 but will be mandatory once the templates are updated to use the new substitution field.