### PR TITLE
Prevent hang on exit while omero.client keepalive is active

### DIFF
--- a/src/omero/util/__init__.py
+++ b/src/omero/util/__init__.py
@@ -674,7 +674,7 @@ class Resources(object):
 
                 ctx.logger.info("Halted")
 
-        self.thread = Task()
+        self.thread = Task(daemon=True)
         self.thread.ctx = self
         self.thread.start()
 


### PR DESCRIPTION
When using `omero.client` best practice appears to be to have everything in a `try` block and explicitly call `client.closeSession` to shut everything down nicely, however users don't always remember to do this.

If a user has called `client.enableKeepAlive(x)` then exiting without calling `closeSession` currently seems to cause Python to hang instead of exiting.

Minimal example:
```python
import omero
client = omero.client(host="my.omero.server")
session = client.createSession(username="user.name", password="my.pwd")
client.enableKeepAlive(5)
print("Session is active: ", client.getSessionId())
# A normal exit behaves similarly, but this is clearer in the console
raise Exception("A forced crash")
```
At least on my end, executing this script will throw the exception but fail to exit the interpreter.

Having investigated this, I believe that the task thread within the `omero.util.Resources` class fails to shut down when the main thread exits. The result is that, while the interpreter is waiting for all threads to close so that it can exit, the keepalive thread keeps spinning. It's currently set up to wait for an explicit close signal from the main thread, but this obviously never comes if that thread has stopped. You therefore get a hang.

As a quick fix, making these worker threads into daemon threads ensures that they die if the main thread exits, thus fixing the problem. I'm not sure how acceptable this is as the Resources class seems to be used for other repeating processes, but I couldn't find a scenario where these should also continue even in the absence of the main thread. If that's not the case then you could instead build some sort of "is the main thread alive?" check into the task.

It might actually be worth a broader review of omero-py's cleanup/shutdown routines. It looks like much of that code is rather old and so modern Python could have more effective ways to manage connections.