### PR TITLE
move `repr_html` to `_ImageWrapper`

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -245,13 +245,6 @@ class BlitzObjectWrapper (object):
                     self._conn.SERVICE_OPTS)
         self.__prepare__(**kwargs)
 
-    def _repr_html_(self):
-        """
-        Returns an HTML representation of the object. This is used by the
-        IPython notebook to display the object in a cell.
-        """
-        return image_to_html(self)
-
     def __eq__(self, a):
         """
         Returns true if the object is of the same type and has same id and name
@@ -8135,6 +8128,13 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 ctx.setOmeroGroup(-1)
             i = self._obj.instrument = meta_serv.loadInstrument(i.id.val, ctx)
         return InstrumentWrapper(self._conn, i)
+
+    def _repr_html_(self):
+        """
+        Returns an HTML representation of the object. This is used by the
+        IPython notebook to display the object in a cell.
+        """
+        return image_to_html(self)
 
     def _loadPixels(self):
         """


### PR DESCRIPTION
Fixes #428 

Dear OME-Team,

this PR fixes the issue that some classes that derive from `BlitzObjectWrapper` do not possess the necessary attributes to display the `repr_html` method correctly. `repr_html` mthods should be introduced specifically for each derived object. In this PR I simply move the `repr_html` to the derived class.

Since this is my last day at work before a longer parental leave, I unfortunately don't have the time to test this in detail but I hope that it's enough to get you started on the fix.