### PR TITLE
HdfStorage.read: fix rowNumbers for all start/end values

### DIFF
--- a/src/omero/hdfstorageV2.py
+++ b/src/omero/hdfstorageV2.py
@@ -587,13 +587,8 @@ class HdfStorage(object):
 
         for col in cols:
             col.read(self.__mea, start, stop)
-        if start is not None and stop is not None:
-            rowNumbers = list(range(start, stop))
-        elif start is not None and stop is None:
-            rowNumbers =  list(range(start, self.__length()))
-        elif start is None and stop is None:
-            rowNumbers = list(range(self.__length()))
-
+        allRows = list(range(self.__length()))
+        rowNumbers = allRows[start:stop]
         return self._as_data(cols, rowNumbers, current)
 
     @stamped


### PR DESCRIPTION
Under some conditions, the rowNumbers array returned as part of the data was inconsistent with the range of rows selected by the tables.Table.read() API. As the start/end parameters are expected to have the same meaning as the built-in Python slices, this modifies the current implementation to slice all row numbers using these values using start/end.

Discovered as part of the work on https://github.com/ome/openmicroscopy/pull/6412 to cover the different cases of the current table reading API.  With this change included, all the test cases in `testReadStartEnd` introduced in https://github.com/ome/openmicroscopy/pull/6412 should pass. Without it, several of the `rowNumbers` checks will fail.

This can also be tested manually e.g. by loading an existing table and calling `table.read()` with `start/end` values outside the `[0 getNumberOfRows() - 1]` range e.g.

```
>>> n = table.getNumberOfRows()
>>> table.read([0], -1, n)
>>> table.read([0], 0, n + 10)
>>> table.read([0], 0, -1)
>>> table.read([0], 0, -n + 1)
```

Without this change, the above should return incorrect values for `rowNumbers`. With this change, the `rowNumbers` should be consistent with the `[start:end]` slice and the `columns` value