### PR TITLE
Fix image_to_html pixel unit

### DIFF
--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -225,9 +225,9 @@ def image_to_html(image):
         pixsizeX = '{:.3f}'.format(image.getPixelSizeX())
         pixsizeY = '{:.3f}'.format(image.getPixelSizeY())
         pixsizeZ = '{:.3f}'.format(image.getPixelSizeZ())
-        UnitX = image.getPixelSizeX().getUnit()
-        UnitY = image.getPixelSizeY().getUnit()
-        UnitZ = image.getPixelSizeZ().getUnit()
+        UnitX = image.getPixelSizeX(units=True).getUnit()
+        UnitY = image.getPixelSizeY(units=True).getUnit()
+        UnitZ = image.getPixelSizeZ(units=True).getUnit()
     except:
         pixsizeX, pixsizeY, pixsizeZ = 'na', 'na', 'na'
         UnitX, UnitY, UnitZ = 'na', 'na', 'na'


### PR DESCRIPTION
Fixes https://github.com/ome/omero-py/issues/436

The PR https://github.com/ome/omero-py/pull/394 introduced html representation of images, used for example when using jupyter notebooks.

An error slipped in with getting the pixelUnit of an image, this is simply the fix.

Before the fix

![image](https://github.com/user-attachments/assets/e31b5933-75f8-4f40-897a-8d9ba3c82c8d)


After the fix

![image](https://github.com/user-attachments/assets/f02ca4c4-daf6-409c-ab97-ac47f1295f83)
