### PR TITLE
omero.util.populate_metadata: only log column types from HeaderResolver

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+  schedule:
+    - cron: '15 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: python
+          build-mode: none
+        - language: actions
+          build-mode: none
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/src/omero/util/populate_metadata.py
+++ b/src/omero/util/populate_metadata.py
@@ -824,7 +824,7 @@ class ParsingContext(object):
                                 % rows[header_index])
         if self.column_types is None and first_row_is_types:
             self.column_types = HeaderResolver.get_column_types(rows[0])
-        log.debug('Column types: %r' % self.column_types)
+            log.debug('Column types: %r' % self.column_types)
         self.header_resolver = HeaderResolver(
             self.target_object, rows[header_index],
             column_types=self.column_types)


### PR DESCRIPTION
This should address a code scanning alert about potential logging sensitive information