### PR TITLE
Change ignoreExeptions default to empty tuple

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -7924,7 +7924,7 @@ class assert_re (object):
     call. Is configurable by various options.
     """
 
-    def __init__(self, onPrepareFailureReturnNone=True, ignoreExceptions=None):
+    def __init__(self, onPrepareFailureReturnNone=True, ignoreExceptions=()):
         """
         Initialises the decorator.
 


### PR DESCRIPTION
This is a Python 3 compatible way to specify that the except statement below should not catch anything, as intended by the previous default of None.

Fixes #446 #356 #308 