### PR TITLE
getQueryString includes externalInfo

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -328,6 +328,7 @@ class BlitzObjectWrapper (object):
         """
         query = ("select obj from %s obj "
                  "join fetch obj.details.owner as owner "
+                 "join fetch obj.details.externalInfo "
                  "join fetch obj.details.creationEvent" % cls.OMERO_CLASS)
 
         params = omero.sys.ParametersI()

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -328,7 +328,7 @@ class BlitzObjectWrapper (object):
         """
         query = ("select obj from %s obj "
                  "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.externalInfo "
+                 "left outer join fetch obj.details.externalInfo "
                  "join fetch obj.details.creationEvent" % cls.OMERO_CLASS)
 
         params = omero.sys.ParametersI()


### PR DESCRIPTION
See https://github.com/ome/omero-web/pull/613.

This updates `getQueryString` (which builds queries for `conn.getObject()` and for JSON API) to include `externalInfo`.

So, all the "top level" objects will now include `externalInfo` if it exists.

E.g. going to `/api/v0/m/plates/51/wells/` we will see externalInfo on the Wells, but not on the child Images.

For that we'd have to also update various queries. E.g. BlitzGateway `Well._getQueryString()` would need:

```
             query += " left outer join fetch obj.wellSamples as wellSamples"\
                      " left outer join fetch wellSamples.image as image"\
+                     " left outer join fetch image.details.externalInfo "\
                      " left outer join fetch wellSamples.plateAcquisition"\
                      " as plateAcquisition"
```