### PR TITLE
getObject() and getExternalInfo() load externalInfo

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -328,6 +328,7 @@ class BlitzObjectWrapper (object):
         """
         query = ("select obj from %s obj "
                  "join fetch obj.details.owner as owner "
+                 "left outer join fetch obj.details.externalInfo "
                  "join fetch obj.details.creationEvent" % cls.OMERO_CLASS)
 
         params = omero.sys.ParametersI()
@@ -1332,6 +1333,26 @@ class BlitzObjectWrapper (object):
                 return self._obj.getName()
         else:
             return None
+
+    def getExternalInfo(self):
+        """
+        Gets the object's details.externalInfo
+
+        :return: omero.model.ExternalInfo object
+        """
+        extinfo = self.getDetails()._externalInfo
+        if extinfo is not None and not extinfo._loaded:
+            params = omero.sys.ParametersI()
+            params.addId(extinfo.id)
+            query = """
+                select e from ExternalInfo as e
+                where e.id = :id
+            """
+            queryService = self._conn.getQueryService()
+            extinfo = queryService.findByQuery(query, params, {"omero.group": "-1"})
+            # cache the result
+            self._obj._details._externalInfo = extinfo
+        return extinfo
 
     def getDescription(self):
         """

--- a/src/omero/plugins/obj.py
+++ b/src/omero/plugins/obj.py
@@ -326,7 +326,7 @@ class ExtInfoGetTxAction(NonFieldTxAction):
         if len(self.tx_cmd.arg_list) == 3:
             field = self.tx_cmd.arg_list[2]
             if field not in attr_list:
-                ctx.die(335, f"usage: ext-info-get OBJ [{"|".join(attr_list)}]")
+                ctx.die(335, f"usage: ext-info-get OBJ [{'|'.join(attr_list)}]")
             value = getattr(extinfo, field) or ""
             proxy += f"{unwrap(value)}"
         else:

--- a/src/omero/plugins/obj.py
+++ b/src/omero/plugins/obj.py
@@ -286,8 +286,18 @@ class ExtInfoSetTxAction(NonFieldTxAction):
         if argc not in [4, 5, 6]:
             ctx.die(345,
                     "usage: ext-info-set OBJ entityId entityType [lsid] [uuid]")
-        entity_id = int(self.tx_cmd.arg_list[2])
+        try:
+            entity_id = int(self.tx_cmd.arg_list[2])
+        except ValueError:
+            ctx.die(347, "entityId must be an integer, got: %s" %
+                    self.tx_cmd.arg_list[2])
         entity_type = self.tx_cmd.arg_list[3]
+
+        details = self.obj.getDetails()
+        extinfo_id = None
+        # if externalInfo exists, delete affer replacing below...
+        if details and details._externalInfo:
+            extinfo_id = details._externalInfo._id.val
 
         from omero.model import ExternalInfoI
         from omero.rtypes import rstring, rlong
@@ -306,6 +316,9 @@ class ExtInfoSetTxAction(NonFieldTxAction):
 
         self.obj.details.externalInfo = extinfo
         self.save_and_return(ctx)
+
+        if extinfo_id is not None:
+            self.update.deleteObject(ExternalInfoI(extinfo_id, False))
 
 
 class ExtInfoGetTxAction(NonFieldTxAction):

--- a/src/omero/plugins/obj.py
+++ b/src/omero/plugins/obj.py
@@ -283,31 +283,14 @@ class ExtInfoSetTxAction(NonFieldTxAction):
     def on_go(self, ctx, args):
         # ['ext-info-set', 'Project:302', 'lsid', 'entityType', 'entityId']
         argc = len(self.tx_cmd.arg_list)
-        if argc not in [3, 4, 5]:
+        if argc not in [4, 5]:
             ctx.die(345,
-                    "usage: ext-info-set OBJ lsid [entityType] [entityId]")
+                    "usage: ext-info-set OBJ lsid entityType [entityId]")
         lsid = self.tx_cmd.arg_list[2]
-
-        # lookup externalInfo for default values (NB: it is immutable)
-        extinfo = None
-        details = self.obj.getDetails()
-        if details and details._externalInfo:
-            extinfo = self.query.get("ExternalInfo",
-                details._externalInfo._id.val, {"omero.group": "-1"})
-
+        entity_type = self.tx_cmd.arg_list[3]
         entity_id = 3
         if argc == 5:
             entity_id = int(self.tx_cmd.arg_list[4])
-        elif extinfo is not None:
-            entity_id = extinfo.entityId.val
-
-        if argc > 3:
-            entity_type = self.tx_cmd.arg_list[3]
-        elif extinfo is not None:
-            entity_type = extinfo.entityType.val
-        else:
-            ctx.die(346, "usage: ext-info-set OBJ lsid entityType [entityId]"
-                    " No existing entityType found")
 
         from omero.model import ExternalInfoI
         from omero.rtypes import rstring, rlong


### PR DESCRIPTION
See https://github.com/ome/omero-web/pull/613.

This tweaks the base `BlitzObjectWrapper._getQueryString()` to include loading `externalInfo`.

It also adds `BlitzObjectWrapper.getExternalInfo()` to return the `externalInfo` and load it if necessary, e.g. for cases where `self._obj` is NOT the object loaded by `getObject()`.

E.g. for image:

```
def __loadedHotSwap__(self):
        ctx = self._conn.SERVICE_OPTS.copy()
        ctx.setOmeroGroup(self.getDetails().group.id.val)
        self._obj = self._conn.getContainerService().getImages(
            self.OMERO_CLASS, (self._oid,), None, ctx)[0]
```

To test:

Set some values for ExternalInfo:
Using this branch:

```
$ omero obj ext-info-set Image:12 myLsid myEntityType
```

Since the JSON API uses `_getQueryString()` to build queries, and omero-marshal already handles externalInfo, you can check the details at E.g. `/api/v0/m/images/ID/`: (NB: deployed on idr-testing, e.g. `/api/v0/m/images/15159664/`).

```
"externalInfo": {
    "@type": "TBD#ExternalInfo",
    "@id": 8,
    "omero:details": {},
    "EntityId": 3,
    "EntityType": "com.glencoesoftware.ngff:multiscales",
    "Lsid": "test_dataset_extinfo"
}
```