### PR TITLE
Remove all usage of sha library in favor of hashlib

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -809,8 +809,8 @@ class BaseClient(object):
         """
         Calculates the local sha1 for a file.
         """
-        from hashlib import sha1 as sha_new
-        digest = sha_new()
+        from hashlib import sha1
+        digest = sha1()
         file = open(filename, 'rb')
         try:
             while True:

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -4046,14 +4046,9 @@ class _BlitzGateway (object):
             originalFile.mimetype = rstring(mimetype)
         originalFile.setSize(rlong(fileSize))
         # set sha1
-        try:
-            import hashlib
-            hash_sha1 = hashlib.sha1
-        except:
-            import sha
-            hash_sha1 = sha.new
+        from hashlib import sha1
         fo.seek(0)
-        h = hash_sha1()
+        h = sha1()
         h.update(fo.read())
         shaHast = h.hexdigest()
         originalFile.setHash(rstring(shaHast))

--- a/src/omero/plugins/_upload_deprecated.py
+++ b/src/omero/plugins/_upload_deprecated.py
@@ -21,13 +21,6 @@ import mimetypes
 from omero.cli import BaseControl, CLI
 import omero_ext.path as path
 
-try:
-    import hashlib
-    hash_sha1 = hashlib.sha1
-except:
-    import sha
-    hash_sha1 = sha.new
-
 HELP = """Upload local files to the OMERO server"""
 RE = re.compile(r"\s*upload\s*")
 UNKNOWN = 'type/unknown'

--- a/src/omero/plugins/script.py
+++ b/src/omero/plugins/script.py
@@ -285,9 +285,9 @@ class ScriptControl(BaseControl):
         from omero.util.temp_files import create_path
         t = create_path("Demo_Script", ".py")
 
-        from hashlib import sha1 as sha_new
+        from hashlib import sha1
 
-        digest = sha_new()
+        digest = sha1()
         digest.update(DEMO_SCRIPT.encode('utf-8'))
         sha1 = digest.hexdigest()
 

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -36,12 +36,7 @@ from omero.model.enums import PixelsTypeint8, PixelsTypeuint8
 from omero.model.enums import PixelsTypefloat
 import omero.util.pixelstypetopython as pixelstypetopython
 
-try:
-    import hashlib
-    hash_sha1 = hashlib.sha1
-except:
-    import sha
-    hash_sha1 = sha.new
+from hashlib import sha1
 
 from PIL import Image
 
@@ -183,7 +178,7 @@ def calc_sha1(filename):
     """
 
     with open(filename, 'rb') as file_handle:
-        h = hash_sha1()
+        h = sha1()
         h.update(file_handle.read())
         hash = h.hexdigest()
     return hash
@@ -198,7 +193,7 @@ def calcSha1FromData(data):
     :param data The data array.
     :return The Hash
     """
-    h = hash_sha1()
+    h = sha1()
     h.update(data)
     hash = h.hexdigest()
     return hash


### PR DESCRIPTION
The `hashlib` module has been part of the Python standard library since Python 2.5. This PR cleans up several import fallbacks to its `sha` predecessor.

This is primarily a maintenance contribution, the dropped code paths should no longer be functional. All integration tests are expected to keep passing with this change included