### PR TITLE
Bump code generated omero-blitz-python dependency to version 5.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ import configparser
 
 def get_blitz_location():
 
-    config_blitz_version = "5.5.5"
+    config_blitz_version = "5.8.1"
 
     # simplified strings
     defaultsect = configparser.DEFAULTSECT


### PR DESCRIPTION
Noticed while working with @jburel on https://github.com/ome/omero-blitz/pull/157. The current version of the code-generation OMERO.blitz Python classes (5.5.5) is quite behind the latest release (5.8.1). 

This PR simply updated the version of `omero-blitz-python` included in OMERO.py to the 5.8.1. There should be no impact on the CI builds as those are effectively testing the nightly SNAPSHOT of the code-generated sources.

Below is an attached text version of the diff between these two versions

[omero-blitz-python-5.5.3-5.8.1.diff.txt](https://github.com/user-attachments/files/19386642/omero-blitz-python-5.5.3-5.8.1.diff.txt)