### PR TITLE
PyPA action: use release/v1 branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.20.0.dev0
+current_version = 5.19.8.dev0
 commit = True
 tag = True
 sign_tags = True

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,6 +59,6 @@ jobs:
           python -mpip install build
           python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/src/omero_version.py
+++ b/src/omero_version.py
@@ -1,3 +1,3 @@
-omero_version = "5.20.0.dev0"
+omero_version = "5.19.8.dev0"
 ice_compatibility = "3.6.5"
 build_year = "2023"


### PR DESCRIPTION
See https://github.com/ome/omero-py/actions/runs/14112413379/job/39534549288

Bumping the action to the `release/v1` branch should include the latest stable patches and fix the release to PyPI