### PR TITLE
Pytest warning fixes

### DIFF
--- a/test/unit/tablestest/test_hdfstorage.py
+++ b/test/unit/tablestest/test_hdfstorage.py
@@ -56,6 +56,9 @@ class TestHdfStorage(TestCase):
         for of in list(omero.columns.ObjectFactories.values()):
             of.register(self.ic)
 
+    def teardown_method(self, method):
+        self.ic.destroy()
+
     def cols(self):
         a = omero.columns.LongColumnI('a', 'first', None)
         b = omero.columns.LongColumnI('b', 'first', None)

--- a/test/unit/tablestest/test_servants.py
+++ b/test/unit/tablestest/test_servants.py
@@ -230,6 +230,7 @@ class TestTables(TestCase):
         """
         for t in self.__tables:
             t.__del__()
+        self.communicator.delegate.destroy()
 
     def tablesI(self, internal_repo=None):
         if internal_repo is None:

--- a/test/unit/tablestest/test_servants.py
+++ b/test/unit/tablestest/test_servants.py
@@ -263,6 +263,14 @@ class TestTables(TestCase):
         f = f / "repo_uuid"
         f.write_lines([repo_uuid])
 
+    def new_table(self):
+        self.repofile(self.sf.db_uuid)
+        f = omero.model.OriginalFileI(1, True)
+        f.details.group = omero.model.ExperimenterGroupI(1, False)
+        self.sf.return_values.append(f)
+        tables = self.tablesI()
+        return tables.getTable(f, self.sf, self.current)
+
     # Note: some of the following method were added as __init__ called
     # first _get_dir() and then _get_uuid(), so the naming is off
 
@@ -295,18 +303,11 @@ class TestTables(TestCase):
         self.sf.return_values.append(omero.model.OriginalFileI(1, False))
         self.tablesI()
 
-    def testTables(self, newfile=True):
-        if newfile:
-            self.repofile(self.sf.db_uuid)
-        f = omero.model.OriginalFileI(1, True)
-        f.details.group = omero.model.ExperimenterGroupI(1, False)
-        self.sf.return_values.append(f)
-        tables = self.tablesI()
-        table = tables.getTable(f, self.sf, self.current)
+    def testTables(self):
+        table = self.new_table()
         assert table
         assert table.table
         assert table.table.storage
-        return table
 
     def testTableOriginalFileLoaded(self):
         f1 = omero.model.OriginalFileI(1, False)
@@ -323,7 +324,7 @@ class TestTables(TestCase):
     def testTablePreInitialized(self):
         f = omero.model.OriginalFileI(1, True)
         f.details.group = omero.model.ExperimenterGroupI(1, False)
-        mocktable = self.testTables()
+        mocktable = self.new_table()
         table1 = mocktable.table
         storage = table1.storage
         storage.initialize([LongColumnI("a", None, [])])
@@ -333,7 +334,7 @@ class TestTables(TestCase):
         table1.cleanup()
 
     def testTableModifications(self):
-        mocktable = self.testTables()
+        mocktable = self.new_table()
         table = mocktable.table
         storage = table.storage
         storage.initialize([LongColumnI("a", None, [])])
@@ -342,8 +343,8 @@ class TestTables(TestCase):
         assert not storage.uptodate(table.stamp)
         table.cleanup()
 
-    def testTableAddData(self, newfile=True, cleanup=True):
-        mocktable = self.testTables(newfile)
+    def testTableAddData(self):
+        mocktable = self.new_table()
         table = mocktable.table
         storage = table.storage
         assert storage
@@ -354,12 +355,17 @@ class TestTables(TestCase):
         template[0].values = [1] * 5
         template[1].values = [2.0] * 5
         table.addData(template)
-        if cleanup:
-            table.cleanup()
-        return table
+        table.cleanup()
 
     def testTableSearch(self):
-        table = self.testTableAddData(True, False)
+        mocktable = self.new_table()
+        table = mocktable.table
+        table.initialize([LongColumnI("a", None, []),
+                          DoubleColumnI("b", None, [])])
+        template = table.getHeaders(self.current)
+        template[0].values = [1] * 5
+        template[1].values = [2.0] * 5
+        table.addData(template)
         rv = list(table.getWhereList('(a==1)', None, None, None, None, None))
         assert list(range(5)) == rv
         data = table.readCoordinates(rv, self.current)

--- a/test/unit/test_jvmcfg.py
+++ b/test/unit/test_jvmcfg.py
@@ -201,11 +201,11 @@ class AdjustFixture(object):
 
 
 import json
-f = open(__file__[:-3] + ".json", "r")
-data = json.load(f)
 AFS = []
-for x in data:
-    AFS.append(AdjustFixture(x["input"], x["output"], x["name"]))
+with open(__file__[:-3] + ".json", "r") as f:
+    data = json.load(f)
+    for x in data:
+        AFS.append(AdjustFixture(x["input"], x["output"], x["name"]))
 
 
 def template_xml():

--- a/test/unit/test_tempfiles.py
+++ b/test/unit/test_tempfiles.py
@@ -55,17 +55,18 @@ class TestTemps(object):
         p = t_f.create_path("close", ".dir", folder=True)
         assert p.exists()
         assert p.isdir()
-        return p
 
     def testFolderWrite(self):
-        p = self.testFolderSimple()
+        p = t_f.create_path("close", ".dir", folder=True)
         f = p / "file"
         f.write_text("hi")
-        return p
+        assert ["hi"] == f.lines()
 
     def testFolderDelete(self):
-        p = self.testFolderWrite()
+        p = t_f.create_path("close", ".dir", folder=True)
+        assert p.exists()
         p.rmtree()
+        assert not p.exists()
 
     #
     # Misc

--- a/tox.ini
+++ b/tox.ini
@@ -39,5 +39,5 @@ passenv =
 commands =
     rst-lint README.rst
     python setup.py install
-    pytest {posargs:-n4 -m "not broken" --reruns 5 -rf test -sv}
+    pytest {posargs:-n auto -m "not broken" --reruns 5 -rf test -v}
     omero version


### PR DESCRIPTION
Addresses a few warnings printed during the unit test execution:

- `PytestReturnNotNoneWarning`: the logic from some of the tests in `test_servants` and `test_tempfiles` was extracted so that tests do not depend on each other
- the communicators in `test_servants` and `test_hdfstorage` are destroyed on teardown 
- `ResourceWarning`: the JSON file containing the fixtures is opened using a context manager in `test_jvmcfg`

Additionally, the `pytest` command executed by Tox is updated to use `-n auto` and `-s` - see https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers.

These changes have no impact on the code itself and only affect unit tests. The output of the `pytest` command can be reviewed either locally or using the GitHub runs.