### PR TITLE
omero admin jvmcfg: remove MaxPermSize option

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,6 +36,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Download the latest OMERO.server
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          curl -L -o server.zip https://downloads.openmicroscopy.org/latest/omero/server.zip
+          unzip server.zip
+          ln -s OMERO.server* OMERO.current
+          echo "OMERODIR=${{ github.workspace }}/OMERO.current" >> $GITHUB_ENV
       - name: Install dependencies
         run: python -mpip install --upgrade wheel pytest tox virtualenv
       - name: Run tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Download the latest OMERO.server
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          curl -L -o server.zip https://downloads.openmicroscopy.org/latest/omero/server.zip
+          curl -L -o server.zip https://github.com/ome/openmicroscopy/releases/download/v5.6.15/OMERO.server-5.6.15-ice36.zip
           unzip server.zip
           ln -s OMERO.server* OMERO.current
           echo "OMERODIR=${{ github.workspace }}/OMERO.current" >> $GITHUB_ENV

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,9 +38,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Download the latest OMERO.server
         if: matrix.os == 'ubuntu-22.04'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl -L -o server.zip https://github.com/ome/openmicroscopy/releases/download/v5.6.15/OMERO.server-5.6.15-ice36.zip
-          unzip server.zip
+          gh release download -R ome/openmicroscopy --pattern "OMERO.server*zip"
+          unzip OMERO.server*.zip && rm OMERO.server*.zip
           ln -s OMERO.server* OMERO.current
           echo "OMERODIR=${{ github.workspace }}/OMERO.current" >> $GITHUB_ENV
       - name: Install dependencies

--- a/test/unit/clitest/test_admin.py
+++ b/test/unit/clitest/test_admin.py
@@ -248,10 +248,23 @@ class TestAdmin(object):
     def testDiagnostics(self, mocker):
         mock_out = mocker.patch.object(self.cli, "out")
         mock_err = mocker.patch.object(self.cli, "err")
-        
+        mock_popen = mocker.patch.object(self.cli, "popen")
+        mock_popen.return_value.wait.return_value = 0
+
         self.cli.invoke("admin diagnostics", strict=True)
         mock_out.assert_called()
-        mock_err.assert_not_called()
+        mock_err.assert_called()
+        mock_popen.assert_has_calls([
+            mocker.call(['java', '-version']),
+            mocker.call(['python', '-V']),
+            mocker.call(['icegridnode', '--version']),
+            mocker.call(['icegridadmin', '--version']),
+            mocker.call(['psql', '--version']),
+            mocker.call(['openssl', 'version']),
+            mocker.call([
+                "icegridadmin", f"--Ice.Config={self.cli.dir}/etc/internal.cfg",
+                "-e", "application list"])],
+            any_order=True)
 
     def testStatusNoConfig(self, mocker):
         mock_out = mocker.patch.object(self.cli, "out")

--- a/test/unit/test_jvmcfg.json
+++ b/test/unit/test_jvmcfg.json
@@ -8,8 +8,6 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions",
                 "foo",
                 "bar"
             ]
@@ -22,9 +20,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx512m",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx512m"
             ]
         }
     },
@@ -36,9 +32,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx1G",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx1G"
             ]
         }
     },
@@ -51,9 +45,7 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:+HeapDumpOnOutOfMemoryError",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-XX:+HeapDumpOnOutOfMemoryError"
             ]
         }
     },
@@ -65,9 +57,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx512m",
-                "-XX:MaxPermSize=1G",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx512m"
             ]
         }
     },
@@ -79,9 +69,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx512m",
-                "-XX:MaxPermSize=256m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx512m"
             ]
         }
     },
@@ -94,9 +82,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx150m",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx150m"
             ]
         }
     },
@@ -108,9 +94,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx600m",
-                "-XX:MaxPermSize=256m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx600m"
             ]
         }
     },
@@ -122,9 +106,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx1200m",
-                "-XX:MaxPermSize=512m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx1200m"
             ]
         }
     },
@@ -136,9 +118,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx3600m",
-                "-XX:MaxPermSize=1g",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx3600m"
             ]
         }
     },
@@ -150,9 +130,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx7200m",
-                "-XX:MaxPermSize=1g",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx7200m"
             ]
         }
     },
@@ -164,9 +142,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx7200m",
-                "-XX:MaxPermSize=1g",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx7200m"
             ]
         }
     },
@@ -179,9 +155,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx9600m",
-                "-XX:MaxPermSize=1g",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx9600m"
             ]
         }
     },
@@ -194,8 +168,6 @@
         "output": {
             "blitz" : [
                 "-Xmx512m",
-                "-XX:MaxPermSize=128m",
-                "-XX:+IgnoreUnrecognizedVMOptions",
                 "foo"
             ]
         }
@@ -209,9 +181,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx4000m",
-                "-XX:MaxPermSize=512m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx4000m"
             ]
         }
     },
@@ -223,19 +193,13 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx1200m",
-                "-XX:MaxPermSize=512m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx1200m"
             ],
             "pixeldata" : [
-                "-Xmx1200m",
-                "-XX:MaxPermSize=512m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx1200m"
             ],
             "indexer" : [
-                "-Xmx800m",
-                "-XX:MaxPermSize=512m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx800m"
             ]
         }
     },
@@ -247,9 +211,7 @@
         },
         "output": {
             "blitz" : [
-                "-Xmx4g",
-                "-XX:MaxPermSize=256m",
-                "-XX:+IgnoreUnrecognizedVMOptions"
+                "-Xmx4g"
             ]
         }
     }

--- a/test/unit/test_jvmcfg.py
+++ b/test/unit/test_jvmcfg.py
@@ -153,9 +153,7 @@ class TestStrategy(object):
         strategy = ManualStrategy("blitz")
         settings = strategy.get_memory_settings()
         assert settings == [
-            "-Xmx512m",
-            "-XX:MaxPermSize=128m",
-            "-XX:+IgnoreUnrecognizedVMOptions",
+            "-Xmx512m"
         ]
 
     def test_percent_usage(self):

--- a/test/unit/test_jvmcfg.py
+++ b/test/unit/test_jvmcfg.py
@@ -209,7 +209,7 @@ for x in data:
 
 
 def template_xml():
-    templates = path(OMERODIR) / ".."
+    templates = path(OMERODIR)
     templates = templates / "etc" / "templates" / "grid" / "templates.xml"
     templates = templates.abspath()
     return XML(templates.text())

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ deps =
     # zeroc-ice installed automatically on other platforms (setup.py install_requires)
     pywin32; platform_system=="Windows"
     jinja2
+pass_env =
+    OMERODIR
 setenv =
     ICE_CONFIG = {toxinidir}/ice.config
 passenv =


### PR DESCRIPTION
Fixes #61. See also https://github.com/ome/openmicroscopy/pull/6428.

`-XX:MaxPermSize` has been ignored since Java 8. This PR updates the `omero admin` logic to remove this flag. The `-XX:+IgnoreUnrecognizedVMOptions` flag is also removed although this could be discussed as part of the review and the flag could be reintroduced conservatively.  The JVM configuration unit tests are adjusted to reflect these changes.

Additionally, the CI logic is updated to download the latest OMERO.server and  set `OMERODIR` on Ubuntu runners. The Tox configuration is also updated to pass `OMERODIR` through the tests. This should have the impact of restoring the execution of all unit tests requiring `OMERODIR` (primarily admin unit tests) on Ubuntu runners which is the primary environment where these commands would be executed. This  main downside to this coverage addition is a longer execution time for the Ubuntu jobs.

In terms of testing
- in GitHub CI, review the output of the unit tests especially on Ubuntu runners. The number of skipped tests (currently 129 in the latest execution against the HEAD) should decrease substantially and all the `test_jvmcfg.py` tests in particular should be executed and successful 
- in an environment with OMERO.server and OMERO.py including this PR, `omero admin jvmcfg` should only list the `-Xmx` option with a value depending on the configuration/system memory. The server should be able to restart with issue and all services should remain functional.