### PR TITLE
Wrapper improvements for ROIs

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5593,7 +5593,7 @@ from omero_model_TagAnnotationI import TagAnnotationI
 
 class TagAnnotationWrapper (AnnotationWrapper):
     """
-    omero_model_BooleanAnnotationI class wrapper extends AnnotationWrapper.
+    omero_model_TagAnnotationWrapper class wrapper extends AnnotationWrapper.
     """
 
     OMERO_TYPE = TagAnnotationI

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5922,8 +5922,6 @@ class _RoiWrapper (BlitzObjectWrapper):
     omero_model_ExperimenterI class wrapper extends BlitzObjectWrapper.
     """
     OMERO_CLASS = 'Roi'
-    # TODO: test listChildren() to use ShapeWrapper? or remove?
-    CHILD_WRAPPER_CLASS = 'ShapeWrapper'
 
     @classmethod
     def _getQueryString(cls, opts=None):
@@ -5958,7 +5956,7 @@ class _RoiWrapper (BlitzObjectWrapper):
         if self._obj.image is not None:
             return ImageWrapper(self._conn, self._obj.image)
 
-    def getShapes(self):
+    def listChildren(self):
         """
         Gets shapes associated to an ROI.
         Shapes must be pre-loaded, use opts={"load_shapes":True}

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -154,9 +154,9 @@ def getAnnotationLinkTableName(objecttype):
     if objecttype == "project":
         return "ProjectAnnotationLink"
     if objecttype == "dataset":
-        return"DatasetAnnotationLink"
+        return "DatasetAnnotationLink"
     if objecttype == "image":
-        return"ImageAnnotationLink"
+        return "ImageAnnotationLink"
     if objecttype == "screen":
         return "ScreenAnnotationLink"
     if objecttype == "plate":
@@ -165,6 +165,8 @@ def getAnnotationLinkTableName(objecttype):
         return "PlateAcquisitionAnnotationLink"
     if objecttype == "well":
         return "WellAnnotationLink"
+    if objecttype == "roi":
+        return "RoiAnnotationLink"
     return None
 
 
@@ -5237,7 +5239,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
     def getParentLinks(self, ptype, pids=None):
         ptype = ptype.title().replace("Plateacquisition", "PlateAcquisition")
         objs = ('Project', 'Dataset', 'Image', 'Screen',
-                'Plate', 'Well', 'PlateAcquisition')
+                'Plate', 'Well', 'PlateAcquisition', 'Roi')
         if ptype not in objs:
             raise AttributeError(
                 "getParentLinks(): ptype '%s' not supported" % ptype)
@@ -9491,7 +9493,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             p1 = 0
             p2 = 1
             while (p2 <= len(tokens) and
-                   (font.getbbox(' '.join(tokens[p1:p2]))[2] - 
+                   (font.getbbox(' '.join(tokens[p1:p2]))[2] -
                     font.getbbox(' '.join(tokens[p1:p2]))[0]) < width):
                 p2 += 1
             rv.append(' '.join(tokens[p1:p2-1]))
@@ -10407,9 +10409,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                  filterByCurrentUser is True, otherwise the total rois
                  found.
         """
-        return [RoiWrapper(self._conn, roi) for roi in 
+        return [RoiWrapper(self._conn, roi) for roi in
                 self._get_rois(shapeType, filterByCurrentUser)]
-        
+
 
     def getROICount(self, shapeType=None, filterByCurrentUser=False):
         """

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5958,6 +5958,16 @@ class _RoiWrapper (BlitzObjectWrapper):
         if self._obj.image is not None:
             return ImageWrapper(self._conn, self._obj.image)
 
+    def getShapes(self):
+        """
+        Gets shapes associated to an ROI.
+        Shapes must be pre-loaded, use opts={"load_shapes":True}
+
+        :return: list of shapes in this ROI.
+        """
+        return [ShapeWrapper(self._conn, shape) for shape in
+                self._obj._shapesSeq]
+
 RoiWrapper = _RoiWrapper
 
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5919,7 +5919,7 @@ AnnotationWrapper._register(MapAnnotationWrapper)
 
 class _RoiWrapper (BlitzObjectWrapper):
     """
-    omero_model_ExperimenterI class wrapper extends BlitzObjectWrapper.
+    omero_model_RoiI class wrapper extends BlitzObjectWrapper.
     """
     OMERO_CLASS = 'Roi'
 
@@ -5956,15 +5956,38 @@ class _RoiWrapper (BlitzObjectWrapper):
         if self._obj.image is not None:
             return ImageWrapper(self._conn, self._obj.image)
 
-    def listChildren(self):
-        """
-        Gets shapes associated to an ROI.
-        Shapes must be pre-loaded, use opts={"load_shapes":True}
+    def listChildren(self, ns=None, val=None, params=None):
+            """
+            Lists available child objects.
 
-        :return: list of shapes in this ROI.
+            :rtype: generator of :class:`BlitzObjectWrapper` objs
+            :return: child objects.
+            """
+            for child in self._listChildren(ns=ns, val=val, params=params):
+                yield ShapeWrapper(self._conn, child, self._cache)
+
+    def _listChildren(self, ns=None, val=None, params=None):
         """
-        return [ShapeWrapper(self._conn, shape) for shape in
-                self._obj._shapesSeq]
+        Lists Shapes in this ROI, not sorted
+
+        :rtype: list of :class:`omero.model.ShapeI` objects
+        :return: child objects.
+        """
+        q = self._conn.getQueryService()
+        params = omero.sys.Parameters()
+        params.map = {}
+        params.map["oid"] = rlong(self.getId())
+        query = ("select shape from Shape as shape "
+                "join fetch shape.details.creationEvent "
+                "join fetch shape.details.owner "
+                "join fetch shape.details.group "
+                "left outer join fetch shape.roi as roi "
+                "where roi.id = :oid")
+
+        self._childcache = {}
+        for shape in q.findAllByQuery(
+                query, params, self._conn.SERVICE_OPTS):
+            yield shape
 
 RoiWrapper = _RoiWrapper
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5237,7 +5237,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
     def getParentLinks(self, ptype, pids=None):
         ptype = ptype.title().replace("Plateacquisition", "PlateAcquisition")
         objs = ('Project', 'Dataset', 'Image', 'Screen',
-                'Plate', 'Well', 'PlateAcquisition', 'Roi')
+                'Plate', 'Well', 'PlateAcquisition')
         if ptype not in objs:
             raise AttributeError(
                 "getParentLinks(): ptype '%s' not supported" % ptype)

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -154,9 +154,9 @@ def getAnnotationLinkTableName(objecttype):
     if objecttype == "project":
         return "ProjectAnnotationLink"
     if objecttype == "dataset":
-        return "DatasetAnnotationLink"
+        return"DatasetAnnotationLink"
     if objecttype == "image":
-        return "ImageAnnotationLink"
+        return"ImageAnnotationLink"
     if objecttype == "screen":
         return "ScreenAnnotationLink"
     if objecttype == "plate":
@@ -165,8 +165,6 @@ def getAnnotationLinkTableName(objecttype):
         return "PlateAcquisitionAnnotationLink"
     if objecttype == "well":
         return "WellAnnotationLink"
-    if objecttype == "roi":
-        return "RoiAnnotationLink"
     return None
 
 


### PR DESCRIPTION
Changes in this PR are to increase the support of functionalities around ROIs:
* support annotations on ROIs (could be used to organize ROIs with tags, add properties with KV pairs, ...)
* `getShapes` for an ROI now retrieves wrapped shapes instead of `ShapeI`