### PR TITLE
omero.testlib: rename test_dir utility as create_managed_dir

### DIFF
--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1240,9 +1240,9 @@ PFS = (
 class AbstractRepoTest(ITest):
 
     def setup_method(self, method):
-        self.unique_dir = self.test_dir()
+        self.unique_dir = self.create_test_dir()
 
-    def test_dir(self, client=None):
+    def create_test_dir(self, client=None):
         if client is None:
             client = self.client
         mrepo = self.get_managed_repo(client=client)

--- a/src/omero/testlib/__init__.py
+++ b/src/omero/testlib/__init__.py
@@ -1240,9 +1240,9 @@ PFS = (
 class AbstractRepoTest(ITest):
 
     def setup_method(self, method):
-        self.unique_dir = self.create_test_dir()
+        self.unique_dir = self.create_managed_dir()
 
-    def create_test_dir(self, client=None):
+    def create_managed_dir(self, client=None):
         if client is None:
             client = self.client
         mrepo = self.get_managed_repo(client=client)


### PR DESCRIPTION
See the failures of  https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/407/ for more context

With the release of pytest 8.4.0, tests that return a value other than None are now failing - see
https://github.com/pytest-dev/pytest/releases/tag/8.4.0. This behavior change affects all the subclasses of AbstractRepoTest. This commit renames the utility method as create_test_dir(). If this was flagged to be a backwards-compatibility concern during code review, we could keep `test_dir()` and simply `pass` or return None. Nevertheless, downstream tests consuming this method would still need to adjust their logic.


