### PR TITLE
Replace to/fromstring by to/frombytes

### DIFF
--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -540,7 +540,7 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
                 # This occurs primarily in testing.
                 masks.append(numpy.array(x, dtype=tables.UInt8Atom()))
             else:
-                masks.append(numpy.fromstring(x, count=len(x),
+                masks.append(numpy.frombytes(x, count=len(x),
                                               dtype=tables.UInt8Atom()))
 
     def _getmasks(self, tbl):

--- a/src/omero/columns.py
+++ b/src/omero/columns.py
@@ -540,7 +540,7 @@ class MaskColumnI(AbstractColumn, omero.grid.MaskColumn):
                 # This occurs primarily in testing.
                 masks.append(numpy.array(x, dtype=tables.UInt8Atom()))
             else:
-                masks.append(numpy.frombytes(x, count=len(x),
+                masks.append(numpy.frombuffer(x, count=len(x),
                                               dtype=tables.UInt8Atom()))
 
     def _getmasks(self, tbl):

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3866,7 +3866,7 @@ class _BlitzGateway (object):
                 p += plane
                 plane = p
             byteSwappedPlane = plane.byteswap()
-            convertedPlane = byteSwappedPlane.tostring()
+            convertedPlane = byteSwappedPlane.tobytes()
             rawPixelsStore.setPlane(convertedPlane, z, c, t, self.SERVICE_OPTS)
 
         image = None

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -1503,7 +1503,7 @@ def numpy_to_image(plane, min_max, dtype):
 
     conv_array = convert_numpy_array(plane, min_max, dtype)
     if plane.dtype.name not in (PixelsTypeint8, PixelsTypeuint8):
-        return Image.fromstring('I', plane.shape, conv_array)
+        return Image.frombytes('I', plane.shape, conv_array)
     else:
         return Image.fromarray(conv_array)
 

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -27,7 +27,7 @@ import os
 import warnings
 
 from struct import unpack
-from numpy import add, array, asarray, fromstring, reshape, zeros
+from numpy import add, array, asarray, frombuffer, reshape, zeros
 from os.path import exists
 
 import omero.clients
@@ -591,7 +591,7 @@ def readFileAsArray(rawFileService, iQuery, fileId, row, col, separator=' '):
     warnings.warn(
         "This method is deprecated as of OMERO 5.3.0", DeprecationWarning)
     textBlock = readFromOriginalFile(rawFileService, iQuery, fileId)
-    arrayFromFile = fromstring(textBlock, sep=separator)
+    arrayFromFile = frombuffer(textBlock, sep=separator)
     return reshape(arrayFromFile, (row, col))
 
 
@@ -1503,7 +1503,7 @@ def numpy_to_image(plane, min_max, dtype):
 
     conv_array = convert_numpy_array(plane, min_max, dtype)
     if plane.dtype.name not in (PixelsTypeint8, PixelsTypeuint8):
-        return Image.frombuffer('I', plane.shape, conv_array)
+        return Image.fromstring('I', plane.shape, conv_array)
     else:
         return Image.fromarray(conv_array)
 

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -1085,7 +1085,7 @@ def upload_plane(raw_pixels_store, plane, z, c, t):
     :param t The T-Section of the plane.
     """
     byte_swapped_plane = plane.byteswap()
-    converted_plane = byte_swapped_plane.tostring()
+    converted_plane = byte_swapped_plane.tobytes()
     raw_pixels_store.setPlane(converted_plane, z, c, t)
 
 
@@ -1123,7 +1123,7 @@ def upload_plane_by_row(raw_pixels_store, plane, z, c, t):
     row_count, col_count = plane.shape
     for y in range(row_count):
         row = byte_swapped_plane[y:y+1, :]        # slice y axis into rows
-        converted_row = row.tostring()
+        converted_row = row.tobytes()
         raw_pixels_store.setRow(converted_row, y, z, c, t)
 
 

--- a/src/omero/util/script_utils.py
+++ b/src/omero/util/script_utils.py
@@ -1503,7 +1503,7 @@ def numpy_to_image(plane, min_max, dtype):
 
     conv_array = convert_numpy_array(plane, min_max, dtype)
     if plane.dtype.name not in (PixelsTypeint8, PixelsTypeuint8):
-        return Image.frombytes('I', plane.shape, conv_array)
+        return Image.frombuffer('I', plane.shape, conv_array)
     else:
         return Image.fromarray(conv_array)
 


### PR DESCRIPTION
In the recent release of [Numpy 2.30](see https://github.com/numpy/numpy/releases/tag/v2.3.0)
The deprecated methods ``tostring`` and ``fromstring``have now been removed.
This PR adjusts the code to make it compatible with Numpy 2.3.0

Replace ``tostring`` by ``tobytes`` and ``fromstring`` to ``frombytes``

For background see
See https://numpy.org/doc/stable/release/2.3.0-notes.html#expired-deprecations for background
especially

```
np.tostring has been removed, use tobytes instead (deprecated since 1.19)

([gh-28254](https://github.com/numpy/numpy/pull/28254))
```
```
The binary mode of fromstring now errors, use frombuffer instead (deprecated since 1.14)

([gh-28254](https://github.com/numpy/numpy/pull/28254))
```