### PR TITLE
Use windows-latest

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
           - '3.12'
         os:
           - ubuntu-22.04
-          - windows-2019
+          - windows-latest
         include:
           - python-version: '3.10'
             os: macos-14


### PR DESCRIPTION
```
The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. 
Jobs using the windows-2019 YAML workflow label should be updated to windows-2022, windows-2025 or windows-latest. 
```