### PR TITLE
Remove PyOpenSSL injection via urllib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,6 @@ setup(
     },
     python_requires='>=3.8',
     install_requires=[
-        'urllib3<2',
         'appdirs',
         'future',
         'numpy<2; python_version<"3.10"',

--- a/src/omero/util/upgrade_check.py
+++ b/src/omero/util/upgrade_check.py
@@ -11,13 +11,6 @@ import platform
 import logging
 import requests
 
-# Ensure we are using pyopenssl (ome/omero-py#240)
-try:
-    import urllib3.contrib.pyopenssl
-    urllib3.contrib.pyopenssl.inject_into_urllib3()
-except ImportError:
-    pass
-
 
 class UpgradeCheck(object):
 


### PR DESCRIPTION
Fixes #465

The `urllib3` workaround was primarily targeted for CentOS 7 systems which shipped OpenSSL 1.0.x - see https://github.com/ome/omero-py/pull/305 and https://github.com/ome/omero-py/pull/240 for more context. Following the sunset of the operating system and the removal of support in OMERO.py, it is reasonable to expect newer versions of Python/OpenSSL where this injection is no longer required.

This PR removes the usage and the declaration of `urllib3` (including the version capping) as a direct dependency of `omero-py`.

This proposal can be tested by creating a virtual environment on the various supported operating systems/Python versions, installing Ice, OMERO.py  and IPython and running a similar testing process as described in https://github.com/ome/omero-py/pull/305

```
$ venv/bin/omero shell --login
...
In [1]: client.closeSession()

In [2]: import requests

In [3]: r = requests.get('https://www.glencoesoftware.com/')

In [4]: r.status_code
```

I ran some testing on:

- CentOS 7 / Python 3.6 / OMERO.py 5.10.0: expected failure
- Rocky Linux 9 / Python 3.11 / OMERO.py with this change: success
- Ubntu 24.04 / Python 3.12 / OMERO.py with this change: success