### PR TITLE
Remove Python 2 compat from gateway utilities and scripts tests

### DIFF
--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -26,12 +26,6 @@
 import logging
 import json
 
-try:
-    long
-except:
-    # Python 3
-    long = int
-
 logger = logging.getLogger(__name__)
 
 
@@ -172,7 +166,6 @@ class ServiceOptsDict(dict):
         if item is not None and not isinstance(item, bool) and \
             (isinstance(item, str) or
              isinstance(item, int) or
-             isinstance(item, long) or
              isinstance(item, float)):
             return True
         return False

--- a/test/unit/scriptstest/test_parse.py
+++ b/test/unit/scriptstest/test_parse.py
@@ -22,12 +22,6 @@ from omero.scripts import (
 from omero.scripts import client, parse_inputs, validate_inputs, parse_text
 from omero.scripts import group_params, rlist, rlong, rint, wrap, unwrap
 
-try:
-    long
-except:
-    # Python 3
-    long = int
-
 
 class TestParse(object):
 


### PR DESCRIPTION
Removes the Python 2 compatibility try block from the gateway utilities and scripts tests. There hasn't been Python 2 support for years.

Other modernisation was done in #390.