### PR TITLE
omero.gateway: deprecate BlitzObjectWrapper.getExternalInfo()

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -1349,9 +1349,14 @@ class BlitzObjectWrapper (object):
     def getExternalInfo(self):
         """
         Gets the object's details.externalInfo
+        Deprecated in OMERO.py 5.22.0. Use getDetails().getExternalInfo().
 
         :return: omero.model.ExternalInfo object
         """
+        warnings.warn(
+            "Deprecated in OMERO.py 5.22.0. Use getDetails().getExternalInfo().",
+            DeprecationWarning)
+
         extinfo = self.getDetails()._externalInfo
         if extinfo is not None and not extinfo._loaded:
             params = omero.sys.ParametersI()


### PR DESCRIPTION
See https://github.com/ome/omero-py/issues/481 and the latest discussion

BlitzObjectWrapper.getDetails().getExternalInfo() should provide the same lazy-loading functionality and return a wrapped ExternalInfo

Consumers who might have adopted the OMERO.py gateway API introduced in https://github.com/ome/omero-py/pull/453 should update their code to use the existing `object.getDetails().getExternalInfo()` API which is separately being  fixed with #482.

This approach is consistent with similar metadata like `getDetails().getGroup()`, `getDetails().getOwner()` or `getDetails().getPermissions()`. Unlike `BlitzObjectWrapper.getExternalInfo()`, this API will return a wrapped `ExternalInfo` object allowing to use the convenience methods of the gateway e.g. `object.getDetails().getExternalInfo().getLsid()`