### PR TITLE
Add more opts support for getObjects('Annotation')

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5162,10 +5162,42 @@ class AnnotationWrapper (BlitzObjectWrapper):
                             NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
+
+        query, clauses, params = super(
+            AnnotationWrapper, cls)._getQueryString(opts)
+        if opts is None:
+            opts = {}
+
         query = ("select obj from Annotation obj "
                  "join fetch obj.details.owner as owner "
                  "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+
+        ann_type = opts.get('ann_type', None)
+        if ann_type == "tag":
+            clauses.append("obj.class=TagAnnotation")
+        elif ann_type == "file":
+            clauses.append("obj.class=FileAnnotation")
+        elif ann_type == "comment":
+            clauses.append("obj.class=CommentAnnotation")
+        elif ann_type == "rating":
+            clauses.append("obj.class=LongAnnotation")
+            clauses.append("obj.ns='openmicroscopy.org/omero/insight/rating'")
+        elif ann_type == "map":
+            clauses.append("obj.class=MapAnnotation")
+
+        for obj_type in ['Project', 'Dataset', 'Image', 'Screen',
+                         'Plate', 'Well', 'Roi']:
+            plural = obj_type.lower() + "s"
+            if plural in opts:
+                ids = opts[plural]
+                if isinstance(ids, list) and len(ids) > 0:
+                    clauses.append(
+                        "exists (from %sAnnotationLink as link "
+                        "where link.child.id = obj.id "
+                        "and link.parent.id in (:%s_ids))" % (obj_type, plural))
+                    params.add("%s_ids" % plural, rlist([rlong(i) for i in ids]))
+        
+        return (query, clauses, params)
 
     @classmethod
     def _register(cls, regklass):

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5164,7 +5164,9 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Returns a tuple of (query, clauses, params).
 
         :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
+                            ann_type: "tag", "file", "comment", "rating", "map"
+                            parent_type: (optional) "project", "dataset", "image" etc
+                            parent_ids: (optional) list of IDs for the parent type
         :return:            Tuple of string, list, ParametersI
         """
 
@@ -5190,18 +5192,17 @@ class AnnotationWrapper (BlitzObjectWrapper):
         elif ann_type == "map":
             clauses.append("obj.class=MapAnnotation")
 
-        for obj_type in ['Project', 'Dataset', 'Image', 'Screen',
-                         'Plate', 'Well', 'Roi']:
-            plural = obj_type.lower() + "s"
-            if plural in opts:
-                ids = opts[plural]
-                if isinstance(ids, list) and len(ids) > 0:
-                    clauses.append(
-                        "exists (from %sAnnotationLink as link "
-                        "where link.child.id = obj.id "
-                        "and link.parent.id in (:%s_ids))" % (obj_type, plural))
-                    params.add("%s_ids" % plural, rlist([rlong(i) for i in ids]))
-        
+        if 'parent_type' in opts:
+            obj_type = opts['parent_type'].title().replace("Plateacquisition", "PlateAcquisition")
+            ids_clause = ""
+            if 'parent_ids' in opts:
+                ids_clause = f"and link.parent.id in (:parent_ids)"
+                params.add("parent_ids", rlist([rlong(i) for i in opts['parent_ids']]))
+
+            clause = f"""exists (from {obj_type}AnnotationLink as link
+                        where link.child.id = obj.id {ids_clause})"""
+            clauses.append(clause)
+
         return (query, clauses, params)
 
     @classmethod

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -10756,6 +10756,10 @@ class _LightSourceWrapper (BlitzObjectWrapper):
               '#type;lightSourceType',
               'version')
 
+    @classmethod
+    def ann_link_name(klass):
+        return "LightSourceAnnotationLink"
+
     def getLightSourceType(self):
         """
         Gets the Light Source type for this light source (enum value)
@@ -11053,7 +11057,6 @@ def refreshWrappers():
                            "filter": FilterWrapper,
                            "instrument": InstrumentWrapper,
                            "lightpath": LightPathWrapper,
-                           "lightsource": LightSourceWrapper,
                            "objective": ObjectiveWrapper,
                            "planeinfo": PlaneInfoWrapper,
                            # allows for getObjects("Annotation", ids)

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5165,7 +5165,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Returns a tuple of (query, clauses, params).
 
         :param opts:        Dictionary of optional parameters.
-                            parent_type: (optional) "project", "dataset", "image" etc
+                            parent_type: (optional) "Project", "Dataset", "Image" etc
                             parent_ids: (optional) list of IDs for the parent type
                             ns: (optional) namespace string to filter by
         :return:            Tuple of string, list, ParametersI
@@ -5185,8 +5185,15 @@ class AnnotationWrapper (BlitzObjectWrapper):
                  "join fetch obj.details.owner as owner "
                  "join fetch obj.details.creationEvent")
 
+        # We want to make parent_type case-insensitive...
         if 'parent_type' in opts:
-            obj_type = opts['parent_type'].title().replace("Plateacquisition", "PlateAcquisition")
+            # Title case works for most objects...
+            obj_type = opts['parent_type'].title()
+            # Handle special cases for certain annotatable object types
+            for otype in ["ExperimenterGroup", "LightPath", "LightSource",
+                          "OriginalFile", "PlaneInfo", "PlateAcquisition"]:
+                if obj_type == otype.title():
+                    obj_type = otype
             ids_clause = ""
             if 'parent_ids' in opts:
                 ids_clause = f"and link.parent.id in (:parent_ids)"

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -169,23 +169,7 @@ def getAnnotationLinkTableName(objecttype):
     Get the name of the AnnotationLink table
     for the given objecttype
     """
-    objecttype = objecttype.lower()
-
-    if objecttype == "project":
-        return "ProjectAnnotationLink"
-    if objecttype == "dataset":
-        return"DatasetAnnotationLink"
-    if objecttype == "image":
-        return"ImageAnnotationLink"
-    if objecttype == "screen":
-        return "ScreenAnnotationLink"
-    if objecttype == "plate":
-        return "PlateAnnotationLink"
-    if objecttype == "plateacquisition":
-        return "PlateAcquisitionAnnotationLink"
-    if objecttype == "well":
-        return "WellAnnotationLink"
-    return None
+    return ann_link_name(objecttype)
 
 
 def getPixelsQuery(imageName):

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5613,7 +5613,7 @@ from omero_model_TagAnnotationI import TagAnnotationI
 
 class TagAnnotationWrapper (AnnotationWrapper):
     """
-    omero_model_TagAnnotationI class wrapper extends AnnotationWrapper.
+    omero_model_BooleanAnnotationI class wrapper extends AnnotationWrapper.
     """
 
     OMERO_TYPE = TagAnnotationI

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -1062,7 +1062,11 @@ class BlitzObjectWrapper (object):
         :param ann:     The annotation object
         :type ann:      :class:`AnnotationWrapper`
         """
-        return self._linkObject(ann, "%sAnnotationLinkI" % self.OMERO_CLASS)
+        class_string = self.OMERO_CLASS
+        # e.g. "TagAnnotation" -> "AnnotationAnnotationLinkI"
+        if class_string.endswith("Annotation"):
+            class_string = "Annotation"
+        return self._linkObject(ann, "%sAnnotationLinkI" % class_string)
 
     def linkAnnotation(self, ann, sameOwner=False):
         """

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5164,9 +5164,10 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Returns a tuple of (query, clauses, params).
 
         :param opts:        Dictionary of optional parameters.
-                            ann_type: "tag", "file", "comment", "rating", "map"
+                            ann_type: (optional) "tag", "file", "comment", "rating", "map"
                             parent_type: (optional) "project", "dataset", "image" etc
                             parent_ids: (optional) list of IDs for the parent type
+                            ns: (optional) namespace string to filter by
         :return:            Tuple of string, list, ParametersI
         """
 
@@ -5202,6 +5203,10 @@ class AnnotationWrapper (BlitzObjectWrapper):
             clause = f"""exists (from {obj_type}AnnotationLink as link
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
+
+        if 'ns' in opts:
+            clauses.append("obj.ns=:ns")
+            params.add("ns", rstring(opts['ns']))
 
         return (query, clauses, params)
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -910,13 +910,13 @@ class BlitzObjectWrapper (object):
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.details.group.id.val)
         if not self._obj.isAnnotationLinksLoaded():
-            query = ("select l from %sAnnotationLink as l join "
+            query = ("select l from %s as l join "
                      "fetch l.details.owner join "
                      "fetch l.details.creationEvent "
                      "join fetch l.child as a join fetch a.details.owner "
                      "left outer join fetch a.file "
                      "join fetch a.details.creationEvent where l.parent.id=%i"
-                     % (self.OMERO_CLASS, self._oid))
+                     % (self.ann_link_name(), self._oid))
             links = self._conn.getQueryService().findAllByQuery(
                 query, None, ctx)
             self._obj._annotationLinksLoaded = True
@@ -1066,11 +1066,8 @@ class BlitzObjectWrapper (object):
         :param ann:     The annotation object
         :type ann:      :class:`AnnotationWrapper`
         """
-        class_string = self.OMERO_CLASS
-        # e.g. "TagAnnotation" -> "AnnotationAnnotationLinkI"
-        if class_string.endswith("Annotation"):
-            class_string = "Annotation"
-        return self._linkObject(ann, "%sAnnotationLinkI" % class_string)
+        link_name = self.ann_link_name()
+        return self._linkObject(ann, "%sI" % link_name)
 
     def linkAnnotation(self, ann, sameOwner=False):
         """
@@ -3556,18 +3553,15 @@ class _BlitzGateway (object):
                        "Must be one of: %s" % (parent_type, wrapper_types))
             raise AttributeError(err_msg)
         wrapper = KNOWN_WRAPPERS.get(parent_type.lower(), None)
-        class_string = wrapper().OMERO_CLASS
-        # E.g. TagAnnotation -> Annotation for AnnotationAnnotationLink
-        if class_string.endswith("Annotation"):
-            class_string = "Annotation"
+        link_name = wrapper.ann_link_name()
 
-        query = ("select annLink from %sAnnotationLink as annLink "
+        query = ("select annLink from %s as annLink "
                  "join fetch annLink.details.owner as owner "
                  "join fetch annLink.details.creationEvent "
                  "join fetch annLink.child as ann "
                  "join fetch ann.details.owner "
                  "join fetch ann.details.creationEvent "
-                 "join fetch annLink.parent as parent" % class_string)
+                 "join fetch annLink.parent as parent" % link_name)
 
         q = self.getQueryService()
         if params is None:
@@ -3619,6 +3613,8 @@ class _BlitzGateway (object):
         if obj_type is None or not obj_ids:
             return counts
 
+        wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
+
         ctx = self.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(-1)
 
@@ -3637,12 +3633,12 @@ class _BlitzGateway (object):
                sum( case when an.class != LongAnnotation
                         then 1 else 0 end ), type(an.class)
                from Annotation an where an.id in
-                    (select distinct(ann.id) from %sAnnotationLink ial
+                    (select distinct(ann.id) from %s ial
                         join ial.child as ann
                         join ial.parent as i
                 where i.id in (:ids))
                     group by an.class
-            """ % obj_type
+            """ % wrapper.ann_link_name()
 
         queryResult = self.getQueryService().projection(q, params, ctx)
 
@@ -3703,22 +3699,23 @@ class _BlitzGateway (object):
 
         q = self.getQueryService()
         wheres = []
+        wrapper = KNOWN_WRAPPERS.get(parent_type.lower())
 
         if len(parent_ids) == 1:
             # We can use a single query to exclude links to a single parent
             p.map["oid"] = rlong(parent_ids[0])
             wheres.append(
-                "not exists ( select link from %sAnnotationLink as link "
+                "not exists ( select link from %s as link "
                 "where link.child=an.id and link.parent.id=:oid%s)"
-                % (parent_type, filterlink))
+                % (wrapper.ann_link_name(), filterlink))
         else:
             # for multiple parents, we first need to find annotations linked to
             # ALL of them, then exclude those from query
             p.map["oids"] = omero.rtypes.wrap([rlong(id) for id in parent_ids])
             query = ("select link.child.id, count(link.id) "
-                     "from %sAnnotationLink link where link.parent.id in "
+                     "from %s link where link.parent.id in "
                      "(:oids)%s group by link.child.id"
-                     % (parent_type, filterlink))
+                     % (wrapper.ann_link_name(), filterlink))
             # count annLinks and check if count == number of parents (all
             # parents linked to annotation)
             usedAnnIds = [e[0].getValue() for e in
@@ -4260,10 +4257,10 @@ class _BlitzGateway (object):
         # Using projection since can't seem to fetch objects AND filter by mapValue
         query = """
             select distinct obj.id from
-            %sAnnotationLink ial
+            %s ial
             join ial.child ann
             join ann.mapValue mv
-            join ial.parent obj""" % wrapper().OMERO_CLASS
+            join ial.parent obj""" % wrapper.ann_link_name()
         if len(clauses) > 0:
             query += " where " + " and ".join(clauses)
         result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)
@@ -5200,19 +5197,16 @@ class AnnotationWrapper (BlitzObjectWrapper):
 
         # We want to make parent_type case-insensitive...
         if 'parent_type' in opts:
-            # Title case works for most objects...
-            obj_type = opts['parent_type'].title()
-            # Handle special cases for certain annotatable object types
-            for otype in ["ExperimenterGroup", "LightPath", "LightSource",
-                          "OriginalFile", "PlaneInfo", "PlateAcquisition"]:
-                if obj_type == otype.title():
-                    obj_type = otype
+            wrapper = KNOWN_WRAPPERS.get(opts['parent_type'].lower(), None)
+            if wrapper is None:
+                raise AttributeError(
+                    f"parent_type '{opts['parent_type']}' not recognised")
             ids_clause = ""
             if 'parent_ids' in opts:
                 ids_clause = f"and link.parent.id in (:parent_ids)"
                 params.add("parent_ids", rlist([rlong(i) for i in opts['parent_ids']]))
 
-            clause = f"""exists (from {obj_type}AnnotationLink as link
+            clause = f"""exists (from {wrapper.ann_link_name()} as link
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
 
@@ -5311,19 +5305,17 @@ class AnnotationWrapper (BlitzObjectWrapper):
         raise NotImplementedError
 
     def getParentLinks(self, ptype, pids=None):
-        ptype = ptype.title().replace("Plateacquisition", "PlateAcquisition")
-        objs = ('Project', 'Dataset', 'Image', 'Screen',
-                'Plate', 'Well', 'PlateAcquisition')
-        if ptype not in objs:
+        wrapper = KNOWN_WRAPPERS.get(ptype.lower(), None)
+        if wrapper is None:
             raise AttributeError(
                 "getParentLinks(): ptype '%s' not supported" % ptype)
         p = omero.sys.Parameters()
         p.map = {}
         p.map["aid"] = rlong(self.id)
-        sql = ("select oal from %sAnnotationLink as oal "
+        sql = ("select oal from %s as oal "
                "left outer join fetch oal.child as ch "
                "left outer join fetch oal.parent as pa "
-               "where ch.id=:aid " % (ptype))
+               "where ch.id=:aid " % (wrapper.ann_link_name()))
         if pids is not None:
             p.map["pids"] = rlist([rlong(ob) for ob in pids])
             sql += " and pa.id in (:pids)"

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5164,7 +5164,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Returns a tuple of (query, clauses, params).
 
         :param opts:        Dictionary of optional parameters.
-                            ann_type: (optional) "tag", "file", "comment", "rating", "map"
+                            ann_type: (optional) "tag", "file", "comment", "long", "map"
                             parent_type: (optional) "project", "dataset", "image" etc
                             parent_ids: (optional) list of IDs for the parent type
                             ns: (optional) namespace string to filter by

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5188,9 +5188,6 @@ class AnnotationWrapper (BlitzObjectWrapper):
             clauses.append("obj.class=FileAnnotation")
         elif ann_type == "comment":
             clauses.append("obj.class=CommentAnnotation")
-        elif ann_type == "rating":
-            clauses.append("obj.class=LongAnnotation")
-            clauses.append("obj.ns='openmicroscopy.org/omero/insight/rating'")
         elif ann_type == "long":
             clauses.append("obj.class=LongAnnotation")
         elif ann_type == "map":
@@ -5207,7 +5204,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
 
-        if 'ns' in opts and ann_type != "rating":
+        if 'ns' in opts:
             clauses.append("obj.ns=:ns")
             params.add("ns", rstring(opts['ns']))
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5192,6 +5192,10 @@ class AnnotationWrapper (BlitzObjectWrapper):
             clauses.append("obj.class=LongAnnotation")
         elif ann_type == "map":
             clauses.append("obj.class=MapAnnotation")
+        elif ann_type is not None:
+            msg = ("ann_type '%s' not recognised. Must be one of 'tag', 'file', "
+                   "'comment', 'long', 'map'" % ann_type)
+            raise AttributeError(msg)
 
         if 'parent_type' in opts:
             obj_type = opts['parent_type'].title().replace("Plateacquisition", "PlateAcquisition")

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -94,6 +94,26 @@ def omero_type(val):
         return val
 
 
+def ann_link_name(objecttype):
+    """
+    Returns AnnotationLink name, e.g. Image -> ImageAnnotationLink
+
+    Works with any case and handles annotations e.g:
+    plateacquisition -> PlateAcquisitionAnnotationLink
+    CommentAnnotation -> AnnotationAnnotationLink
+    annotation -> AnnotationAnnotationLink
+    """
+
+    # KNOWN_WRAPPERS['annotation'] is a function, so we can't use it here
+    if objecttype.lower() == "annotation":
+        return "AnnotationAnnotationLink"
+
+    wrapper = KNOWN_WRAPPERS.get(objecttype.lower())
+    if wrapper is None:
+        raise ValueError("Unknown object type: %s" % objecttype)
+    return wrapper.ann_link_name()
+
+
 def fileread(fin, fsize, bufsize):
     """
     Reads everything from fin, in chunks of bufsize.
@@ -3552,8 +3572,7 @@ class _BlitzGateway (object):
             err_msg = ("getAnnotationLinks() does not support type: '%s'. "
                        "Must be one of: %s" % (parent_type, wrapper_types))
             raise AttributeError(err_msg)
-        wrapper = KNOWN_WRAPPERS.get(parent_type.lower(), None)
-        link_name = wrapper.ann_link_name()
+        link_name = ann_link_name(parent_type)
 
         query = ("select annLink from %s as annLink "
                  "join fetch annLink.details.owner as owner "
@@ -3613,8 +3632,6 @@ class _BlitzGateway (object):
         if obj_type is None or not obj_ids:
             return counts
 
-        wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
-
         ctx = self.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(-1)
 
@@ -3638,7 +3655,7 @@ class _BlitzGateway (object):
                         join ial.parent as i
                 where i.id in (:ids))
                     group by an.class
-            """ % wrapper.ann_link_name()
+            """ % ann_link_name(obj_type)
 
         queryResult = self.getQueryService().projection(q, params, ctx)
 
@@ -3699,7 +3716,7 @@ class _BlitzGateway (object):
 
         q = self.getQueryService()
         wheres = []
-        wrapper = KNOWN_WRAPPERS.get(parent_type.lower())
+        ann_link_name = ann_link_name(parent_type)
 
         if len(parent_ids) == 1:
             # We can use a single query to exclude links to a single parent
@@ -3707,7 +3724,7 @@ class _BlitzGateway (object):
             wheres.append(
                 "not exists ( select link from %s as link "
                 "where link.child=an.id and link.parent.id=:oid%s)"
-                % (wrapper.ann_link_name(), filterlink))
+                % (ann_link_name, filterlink))
         else:
             # for multiple parents, we first need to find annotations linked to
             # ALL of them, then exclude those from query
@@ -3715,7 +3732,7 @@ class _BlitzGateway (object):
             query = ("select link.child.id, count(link.id) "
                      "from %s link where link.parent.id in "
                      "(:oids)%s group by link.child.id"
-                     % (wrapper.ann_link_name(), filterlink))
+                     % (ann_link_name, filterlink))
             # count annLinks and check if count == number of parents (all
             # parents linked to annotation)
             usedAnnIds = [e[0].getValue() for e in
@@ -4220,10 +4237,6 @@ class _BlitzGateway (object):
         :rtype:             :class:`BlitzObjectWrapper` generator
         """
 
-        wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
-        if not wrapper:
-            raise AttributeError("Don't know how to handle '%s'" % obj_type)
-
         params = omero.sys.ParametersI()
         clauses = []
 
@@ -4260,7 +4273,7 @@ class _BlitzGateway (object):
             %s ial
             join ial.child ann
             join ann.mapValue mv
-            join ial.parent obj""" % wrapper.ann_link_name()
+            join ial.parent obj""" % ann_link_name(obj_type)
         if len(clauses) > 0:
             query += " where " + " and ".join(clauses)
         result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)
@@ -5197,16 +5210,13 @@ class AnnotationWrapper (BlitzObjectWrapper):
 
         # We want to make parent_type case-insensitive...
         if 'parent_type' in opts:
-            wrapper = KNOWN_WRAPPERS.get(opts['parent_type'].lower(), None)
-            if wrapper is None:
-                raise AttributeError(
-                    f"parent_type '{opts['parent_type']}' not recognised")
+            ann_link_name = ann_link_name(opts['parent_type'])
             ids_clause = ""
             if 'parent_ids' in opts:
                 ids_clause = f"and link.parent.id in (:parent_ids)"
                 params.add("parent_ids", rlist([rlong(i) for i in opts['parent_ids']]))
 
-            clause = f"""exists (from {wrapper.ann_link_name()} as link
+            clause = f"""exists (from {ann_link_name} as link
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
 
@@ -5305,17 +5315,13 @@ class AnnotationWrapper (BlitzObjectWrapper):
         raise NotImplementedError
 
     def getParentLinks(self, ptype, pids=None):
-        wrapper = KNOWN_WRAPPERS.get(ptype.lower(), None)
-        if wrapper is None:
-            raise AttributeError(
-                "getParentLinks(): ptype '%s' not supported" % ptype)
         p = omero.sys.Parameters()
         p.map = {}
         p.map["aid"] = rlong(self.id)
         sql = ("select oal from %s as oal "
                "left outer join fetch oal.child as ch "
                "left outer join fetch oal.parent as pa "
-               "where ch.id=:aid " % (wrapper.ann_link_name()))
+               "where ch.id=:aid " % (ann_link_name(ptype)))
         if pids is not None:
             p.map["pids"] = rlist([rlong(ob) for ob in pids])
             sql += " and pa.id in (:pids)"

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3553,8 +3553,8 @@ class _BlitzGateway (object):
             raise AttributeError(err_msg)
         wrapper = KNOWN_WRAPPERS.get(parent_type.lower(), None)
         class_string = wrapper().OMERO_CLASS
-        # E.g. AnnotationWrappers have no OMERO_CLASS
-        if class_string is None and "annotation" in parent_type.lower():
+        # E.g. TagAnnotation -> Annotation for AnnotationAnnotationLink
+        if class_string.endswith("Annotation"):
             class_string = "Annotation"
 
         query = ("select annLink from %sAnnotationLink as annLink "

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -229,6 +229,10 @@ class BlitzObjectWrapper (object):
     def LINK_PARENT(x):
         return x.parent
 
+    @classmethod
+    def ann_link_name(klass):
+        return klass.OMERO_CLASS + "AnnotationLink"
+
     def __init__(self, conn=None, obj=None, cache=None, **kwargs):
         """
         Initialises the wrapper object, setting the various class variables etc
@@ -5139,6 +5143,11 @@ class AnnotationWrapper (BlitzObjectWrapper):
     registry = {}
     OMERO_TYPE = None
     OMERO_CLASS = "Annotation"
+
+    @classmethod
+    def ann_link_name(cls):
+        # avoid TagAnnotationAnnotationLink etc.
+        return "AnnotationAnnotationLink"
 
     def __init__(self, *args, **kwargs):
         """

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5210,13 +5210,12 @@ class AnnotationWrapper (BlitzObjectWrapper):
 
         # We want to make parent_type case-insensitive...
         if 'parent_type' in opts:
-            ann_link_name = ann_link_name(opts['parent_type'])
             ids_clause = ""
             if 'parent_ids' in opts:
                 ids_clause = f"and link.parent.id in (:parent_ids)"
                 params.add("parent_ids", rlist([rlong(i) for i in opts['parent_ids']]))
 
-            clause = f"""exists (from {ann_link_name} as link
+            clause = f"""exists (from {ann_link_name(opts['parent_type'])} as link
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -11047,6 +11047,15 @@ def refreshWrappers():
                            "timestampannotation": TimestampAnnotationWrapper,
                            "mapannotation": MapAnnotationWrapper,
                            "xmlannotation": XmlAnnotationWrapper,
+                           "channel": ChannelWrapper,
+                           "detector": DetectorWrapper,
+                           "dichroic": DichroicWrapper,
+                           "filter": FilterWrapper,
+                           "instrument": InstrumentWrapper,
+                           "lightpath": LightPathWrapper,
+                           "lightsource": LightSourceWrapper,
+                           "objective": ObjectiveWrapper,
+                           "planeinfo": PlaneInfoWrapper,
                            # allows for getObjects("Annotation", ids)
                            "annotation": AnnotationWrapper._wrap})
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5134,6 +5134,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
     # E.g. DoubleAnnotationI : DoubleAnnotationWrapper
     registry = {}
     OMERO_TYPE = None
+    OMERO_CLASS = "Annotation"
 
     def __init__(self, *args, **kwargs):
         """
@@ -5164,7 +5165,6 @@ class AnnotationWrapper (BlitzObjectWrapper):
         Returns a tuple of (query, clauses, params).
 
         :param opts:        Dictionary of optional parameters.
-                            ann_type: (optional) "tag", "file", "comment", "long", "map"
                             parent_type: (optional) "project", "dataset", "image" etc
                             parent_ids: (optional) list of IDs for the parent type
                             ns: (optional) namespace string to filter by
@@ -5176,26 +5176,14 @@ class AnnotationWrapper (BlitzObjectWrapper):
         if opts is None:
             opts = {}
 
-        query = ("select obj from Annotation obj "
-                 "left outer join fetch obj.file as file "
+        fetch_file = ""
+        if cls.OMERO_CLASS in ("Annotation", "FileAnnotation"):
+            fetch_file = "left outer join fetch obj.file as file"
+
+        query = (f"select obj from {cls.OMERO_CLASS} obj "
+                 f"{fetch_file} "
                  "join fetch obj.details.owner as owner "
                  "join fetch obj.details.creationEvent")
-
-        ann_type = opts.get('ann_type', None)
-        if ann_type == "tag":
-            clauses.append("obj.class=TagAnnotation")
-        elif ann_type == "file":
-            clauses.append("obj.class=FileAnnotation")
-        elif ann_type == "comment":
-            clauses.append("obj.class=CommentAnnotation")
-        elif ann_type == "long":
-            clauses.append("obj.class=LongAnnotation")
-        elif ann_type == "map":
-            clauses.append("obj.class=MapAnnotation")
-        elif ann_type is not None:
-            msg = ("ann_type '%s' not recognised. Must be one of 'tag', 'file', "
-                   "'comment', 'long', 'map'" % ann_type)
-            raise AttributeError(msg)
 
         if 'parent_type' in opts:
             obj_type = opts['parent_type'].title().replace("Plateacquisition", "PlateAcquisition")
@@ -5357,28 +5345,13 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
     """
 
     OMERO_TYPE = FileAnnotationI
+    OMERO_CLASS = "FileAnnotation"
 
     def __init__(self, *args, **kwargs):
         super(FileAnnotationWrapper, self).__init__(*args, **kwargs)
         self._file = None
 
     _attrs = ('file|OriginalFileWrapper',)
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("FileAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from FileAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent join fetch obj.file")
-        return query, [], omero.sys.ParametersI()
 
     def getValue(self):
         """ Not implemented """
@@ -5561,22 +5534,7 @@ class TimestampAnnotationWrapper (AnnotationWrapper):
     """
 
     OMERO_TYPE = TimestampAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("TimestampAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from TimestampAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "TimestampAnnotation"
 
     def getValue(self):
         """
@@ -5616,22 +5574,7 @@ class BooleanAnnotationWrapper (AnnotationWrapper):
     """
 
     OMERO_TYPE = BooleanAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("BooleanAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from BooleanAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "BooleanAnnotation"
 
     def getValue(self):
         """
@@ -5659,10 +5602,11 @@ from omero_model_TagAnnotationI import TagAnnotationI
 
 class TagAnnotationWrapper (AnnotationWrapper):
     """
-    omero_model_BooleanAnnotationI class wrapper extends AnnotationWrapper.
+    omero_model_TagAnnotationI class wrapper extends AnnotationWrapper.
     """
 
     OMERO_TYPE = TagAnnotationI
+    OMERO_CLASS = "TagAnnotation"
 
     def countTagsInTagset(self):
         # temp solution waiting for #5785
@@ -5709,22 +5653,6 @@ class TagAnnotationWrapper (AnnotationWrapper):
                         self._conn, l.parent, l))
         return rv
 
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("TagAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from TagAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
-
     def getValue(self):
         """
         Gets the value of the Tag
@@ -5756,22 +5684,7 @@ class CommentAnnotationWrapper (AnnotationWrapper):
     """
 
     OMERO_TYPE = CommentAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("CommentAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from CommentAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "CommentAnnotation"
 
     def getValue(self):
         """
@@ -5802,22 +5715,7 @@ class LongAnnotationWrapper (AnnotationWrapper):
     omero_model_LongAnnotationI class wrapper extends AnnotationWrapper.
     """
     OMERO_TYPE = LongAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("LongAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from LongAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "LongAnnotation"
 
     def getValue(self):
         """
@@ -5849,22 +5747,7 @@ class DoubleAnnotationWrapper (AnnotationWrapper):
     omero_model_DoubleAnnotationI class wrapper extends AnnotationWrapper.
     """
     OMERO_TYPE = DoubleAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("DoubleAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from DoubleAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "DoubleAnnotation"
 
     def getValue(self):
         """
@@ -5897,22 +5780,7 @@ class TermAnnotationWrapper (AnnotationWrapper):
     only in 4.2+
     """
     OMERO_TYPE = TermAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("TermAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-        query = ("select obj from TermAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "TermAnnotation"
 
     def getValue(self):
         """
@@ -5944,6 +5812,7 @@ class XmlAnnotationWrapper (CommentAnnotationWrapper):
     omero_model_XmlAnnotationI class wrapper extends CommentAnnotationWrapper.
     """
     OMERO_TYPE = XmlAnnotationI
+    OMERO_CLASS = "XmlAnnotation"
 
 AnnotationWrapper._register(XmlAnnotationWrapper)
 
@@ -5956,23 +5825,7 @@ class MapAnnotationWrapper (AnnotationWrapper):
     omero_model_MapAnnotationI class wrapper.
     """
     OMERO_TYPE = MapAnnotationI
-
-    @classmethod
-    def _getQueryString(cls, opts=None):
-        """
-        Used for building queries in generic methods such as
-        getObjects("MapAnnotation").
-        Returns a tuple of (query, clauses, params).
-
-        :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
-        :return:            Tuple of string, list, ParametersI
-        """
-
-        query = ("select obj from MapAnnotation obj "
-                 "join fetch obj.details.owner as owner "
-                 "join fetch obj.details.creationEvent")
-        return query, [], omero.sys.ParametersI()
+    OMERO_CLASS = "MapAnnotation"
 
     def getValue(self):
         """

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5185,11 +5185,14 @@ class AnnotationWrapper (BlitzObjectWrapper):
             clauses.append("obj.class=TagAnnotation")
         elif ann_type == "file":
             clauses.append("obj.class=FileAnnotation")
+            query += " join fetch obj.file as file"
         elif ann_type == "comment":
             clauses.append("obj.class=CommentAnnotation")
         elif ann_type == "rating":
             clauses.append("obj.class=LongAnnotation")
             clauses.append("obj.ns='openmicroscopy.org/omero/insight/rating'")
+        elif ann_type == "long":
+            clauses.append("obj.class=LongAnnotation")
         elif ann_type == "map":
             clauses.append("obj.class=MapAnnotation")
 
@@ -5204,7 +5207,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
                         where link.child.id = obj.id {ids_clause})"""
             clauses.append(clause)
 
-        if 'ns' in opts:
+        if 'ns' in opts and ann_type != "rating":
             clauses.append("obj.ns=:ns")
             params.add("ns", rstring(opts['ns']))
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -3377,7 +3377,7 @@ class _BlitzGateway (object):
             wrapper = KNOWN_WRAPPERS.get(obj_type.lower(), None)
             if wrapper is None:
                 raise KeyError(
-                    "obj_type of %s not supported by getOjbects(). "
+                    "obj_type of %s not supported by getObjects(). "
                     "E.g. use 'Image' etc" % obj_type)
         else:
             raise AttributeError(
@@ -11034,6 +11034,7 @@ def refreshWrappers():
                            "termannotation": TermAnnotationWrapper,
                            "timestampannotation": TimestampAnnotationWrapper,
                            "mapannotation": MapAnnotationWrapper,
+                           "xmlannotation": XmlAnnotationWrapper,
                            # allows for getObjects("Annotation", ids)
                            "annotation": AnnotationWrapper._wrap})
 

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -1063,7 +1063,10 @@ class BlitzObjectWrapper (object):
         :type obj:      :class:`BlitzObjectWrapper`
         """
         ctx = self._conn.SERVICE_OPTS.copy()
-        ctx.setOmeroGroup(self.details.group.id.val)
+        if isinstance(self, ExperimenterGroupWrapper):
+            ctx.setOmeroGroup(self.id)
+        else:
+            ctx.setOmeroGroup(self.details.group.id.val)
         if not obj.getId():
             # Not yet in db, save it
             obj = obj.__class__(

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5177,6 +5177,7 @@ class AnnotationWrapper (BlitzObjectWrapper):
             opts = {}
 
         query = ("select obj from Annotation obj "
+                 "left outer join fetch obj.file as file "
                  "join fetch obj.details.owner as owner "
                  "join fetch obj.details.creationEvent")
 
@@ -5185,7 +5186,6 @@ class AnnotationWrapper (BlitzObjectWrapper):
             clauses.append("obj.class=TagAnnotation")
         elif ann_type == "file":
             clauses.append("obj.class=FileAnnotation")
-            query += " join fetch obj.file as file"
         elif ann_type == "comment":
             clauses.append("obj.class=CommentAnnotation")
         elif ann_type == "rating":

--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -928,7 +928,10 @@ class BlitzObjectWrapper (object):
         # Need to set group context. If '-1' then canDelete() etc on
         # annotations will be False
         ctx = self._conn.SERVICE_OPTS.copy()
-        ctx.setOmeroGroup(self.details.group.id.val)
+        if isinstance(self, ExperimenterGroupWrapper):
+            ctx.setOmeroGroup(self.id)
+        else:
+            ctx.setOmeroGroup(self.details.group.id.val)
         if not self._obj.isAnnotationLinksLoaded():
             query = ("select l from %s as l join "
                      "fetch l.details.owner join "
@@ -1033,7 +1036,11 @@ class BlitzObjectWrapper (object):
         :rtype:     :class:`AnnotationWrapper` generator
         """
         for ann in self._getAnnotationLinks(ns):
-            yield AnnotationWrapper._wrap(self._conn, ann.child, link=ann)
+            if isinstance(ann, omero.model.AnnotationAnnotationLink):
+                child = ann._child
+            else:
+                child = ann.child
+            yield AnnotationWrapper._wrap(self._conn, child, link=ann)
 
     def listOrphanedAnnotations(self, eid=None, ns=None, anntype=None,
                                 addedByMe=True):


### PR DESCRIPTION
# conn.getObjects("Annotation")

This adds support for various options for `conn.getObjects("Annotation", opts)`, in preparation for JSON api:
The `OMERO_CLASS` is now set on `AnnotationWrapper` objects.
Also Fixes #433.

This is used by https://github.com/ome/omero-web/pull/682

Tests added in https://github.com/ome/openmicroscopy/pull/6458

Supported opts - All are optional (but parent_ids needs parent_type)

 - `"parent_type": "dataset"`
 - `"parent_ids": [1, 2]`
 - `"ns": "my.namespace"`

E.g. `/api/tagannotations/?project=1&project=2` would be backed by:

```
conn.getObjects("TagAnnotation", opts={
  "parent_type": "project",
  "parent_ids": [1,2]
})
```

# %sAnnotationLink

This also improves the formulation of `%sAnnotationLink` (E.g. `ImageAnnotationLink`, `ExperimenterGroupAnnotationLink`, `AnnotationAnnotationLink`) in multiple places:

 - `conn.getObjectsByMapAnnotations("Dataset", key="foo")`
 - `obj._loadAnnotationLinks() / _getAnnotationLinks()`
   - `unlinkAnnotations()`
   - `removeAnnotations()`
   - `getAnnotation()`
   - `listAnnotations()`
 - `obj._linkAnnotation() / _linkObject` unused?
 - `conn.getAnnotationLinks()`
 - `conn.countAnnotations()`
 - `conn.listOrphanedAnnotations()`
 - `AnnotationWrapper._getQueryString()` 

We can now do `getObject()` and `listAnnotations()` etc with many more object types:

E.g:

```
tag = omero.gateway.TagAnnotationWrapper(conn)
tag.setValue("Test Tag on Group")

group = conn.getGroupFromContext()
group.linkAnnotation(tag)

group.listAnnotations()
```

# Known issue: Loading Parents

For webclient/api/annotations/ we get the annotations along with links to the parents and the parent objects too. 
E.g. 

```
  "link": {
    "id": 39752336,
    "owner": {
      "id": 2
    },
    "parent": {
      "id": 3414011,
      "class": "ImageI",
      "name": "10percent-Wt1-GFP-spheroid-MV.czi [0]"
    },
    "date": "2017-11-27T14:13:19+00:00",
    "permissions": {
      "canDelete": false,
      "canAnnotate": false,
      "canLink": false,
      "canEdit": false
    }
  }
```

This is useful to have permissions, timestamp, owner etc on the link but it is particularly essential when we are loading annotations on multiple objects. E.g. `/api/annotations/?type=tag&project=1&project=2` would load annotations for 2 projects, BUT we without links, we don't know which Annotations are linked to which Project.

But, it doesn't appear possible to achieve this with `omero_marshal`, since for Annotations, there is no handling of links to Parent objects. Annotations are "Annotatable", so we check for annotations ON the object https://github.com/ome/omero-marshal/blob/f8ff1c2e439f0599d96423b7f64898864548ba9f/omero_marshal/encode/encoders/annotation.py#L68
but not whether the Object (annotation) is annotating a Parent.
In fact, I don't see that it's possible for e.g. an Annotation to have links loaded (in the same way that a Project or Dataset can have `obj.copyAnnotationLinks()`, since the possible links for an Annotation object are stored in a different Table for each parent, e.g. `ProjectAnnotationLinks, DatasetAnnotationLinks` etc.