### PR TITLE
omero admin cleanse: handle missing directories in the ManagedRepository

### DIFF
--- a/src/omero/util/cleanse.py
+++ b/src/omero/util/cleanse.py
@@ -324,7 +324,13 @@ def is_empty_dir(repo, directory, may_delete_dir, to_delete):
     empty_subdirs = []
     is_empty = True
 
-    for entry in repo.listFiles(directory):
+    try:
+        entries = repo.listFiles(directory)
+    except omero.ServerError as e:
+        print(f"   ERROR: {e.message}")
+        return False
+
+    for entry in entries:
         subdirectory = directory + entry.name.val + '/'
         may_delete_subdir = entry.details.permissions.canDelete()
         if entry.mimetype is not None and \


### PR DESCRIPTION
This commit tries to improve the handling a ManagedRepository directory registered in the database but missing from disk. Currently, `omero admin cleanse` fails with a `SecurityViolation` server error as per the contract of `repo.listFiles()`.

This change catches the server error, logs the message in the command output with an `ERROR` prefix and returns `False` to indicate no empty directory was found. This mechanism should allow the command to continue scanning the ManagedRepository, report other errors or empty directories and provide a more complete audit allowing the administrator to review and take the appropriate action.

To reproduce the issue:

- import a file via `omero import` to create a new `/OMERO/ManagedRepository/<user>_<id>/<YYYY>-<MM>/<DD>/<hh>-<mm>-<ss>-<SSS>` directory under the database
- delete the imported image using `omero delete`, this should delete the original file and the import log but keep empty directories
- delete `/OMERO/ManagedRepository/<user>_<id>/<YYYY>-<MM>/<DD>/<hh>-<mm>-<ss>-<SSS>` 
- delete `/OMERO/ManagedRepository/<user>_<id>/<YYYY>-<MM>/<DD>/` 

With OMERO.py 5.22.0, `omero admin cleanse --dry-run /OMERO` should fail with a `SecurityViolation` message similar `/<user>_<id>/<YYYY>-<MM>/<DD>/ does not exist` and abort.
With this PR included, the same command should log the error message indicating the folder does not exist but continue processing the binary repository.