### PR TITLE
RoiWrapper load_shapes includes externalInfo

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -5982,7 +5982,8 @@ class _RoiWrapper (BlitzObjectWrapper):
         if opts is None:
             opts = {}
         if opts.get('load_shapes'):
-            query += ' left outer join fetch obj.shapes'
+            query += """ left outer join fetch obj.shapes as shapes
+            left outer join fetch shapes.details.externalInfo"""
         if 'image' in opts:
             clauses.append('obj.image.id = :image_id')
             params.add('image_id', rlong(opts['image']))


### PR DESCRIPTION
Since it is useful to store data in the externalInfo of `shapes`, we want to be able to access that via the `/rois` endpoint.
Currently we have the option to `load_shapes` but this doesn't include `externalInfo` (added in this PR).

To test:

 - Draw or find a ROI ID and a Shape ID
 - These can be listed for an Image via `/api/v0/m/rois/?image=IMAGE_ID`
 - Set an externalInfo on the Shape, e.g. For a Rectangle:

```
$ omero obj ext-info-set Rectangle:331301 3 com.glencoesoftware.ngff:multiscales https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr/0/labels/0/
```
 - Refresh `/api/v0/m/rois/?image=IMAGE_ID` and you should now see this info on the Shape.