### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,12 +37,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,8 @@ jobs:
 
   test:
     name: Test
+    permissions:
+      contents: read
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -53,6 +55,8 @@ jobs:
   publish-pypi:
     name: Pypi
     if: startsWith(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     needs:
       # Only publish if other jobs passed
       - test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,8 +31,8 @@ jobs:
           py=$(echo ${{ matrix.python-version }} | tr -d .)
           echo "py=$py" >> $GITHUB_OUTPUT
         shell: bash
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download the latest OMERO.server
@@ -58,8 +58,8 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Build package

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.11'
           - '3.12'
         os:
-          - ubuntu-22.04
+          - ubuntu-latest
           - windows-latest
         include:
           - python-version: '3.10'
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download the latest OMERO.server
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
- apply a routine set of action upgrades in anticipation of the current deprecations - see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ and https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
- bumps the GitHub runner for the tests to ubuntu-latest
- sets some basic GitHub workflow permissions - see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

Testing should be limited to checking GitHub actions still runs and no longer warns about the deprecated actions